### PR TITLE
PYTHON SCRIPT: Updating the parsing script for namelist options.

### DIFF
--- a/python_scripts/namelist_generation/parse_xml_registry.py
+++ b/python_scripts/namelist_generation/parse_xml_registry.py
@@ -41,7 +41,10 @@ namelist = open('namelist.input.generated', 'w+')
 for nml_rec in registry.iter("nml_record"):
 	namelist.write('&%s\n'%nml_rec.attrib['name'])
 	for nml_opt in nml_rec.iter("nml_option"):
-		namelist.write('\t%s = %s\n'%(nml_opt.attrib['name'], nml_opt.attrib['default_value']))
+		if nml_opt.attrib['type'] == "character":
+			namelist.write('\t%s = "%s"\n'%(nml_opt.attrib['name'], nml_opt.attrib['default_value']))
+		else:
+			namelist.write('\t%s = %s\n'%(nml_opt.attrib['name'], nml_opt.attrib['default_value']))
 
 	namelist.write('/\n')
 


### PR DESCRIPTION
It now adds quotes around namelist options that are of type character.
This is only done when writing namelist.input.generated, to ensure the
namelist is formatted properly.
