### PR TITLE
Updating version number script to handle README.

### DIFF
--- a/python_scripts/update_version_numbers/update_versions.py
+++ b/python_scripts/update_version_numbers/update_versions.py
@@ -10,6 +10,9 @@ parser.add_option("--minor", action="store_true", dest="minor", help="Increment 
 
 options, args = parser.parse_args()
 
+if not options.major and not options.minor:
+    parser.error('Either major or minor version is required.')
+
 for r, d, f in os.walk("."):
     for files in f:
         if files.endswith(".xml"):
@@ -25,6 +28,7 @@ for r, d, f in os.walk("."):
                 new_major_ver = major_ver + 1
                 new_minor_ver = 0
             elif options.minor:
+                new_major_ver = major_ver
                 new_minor_ver = minor_ver + 1
 
             print "%s version: %d.%d"%(path, new_major_ver, new_minor_ver)
@@ -36,8 +40,38 @@ for r, d, f in os.walk("."):
             registry_file.truncate()
             for line in lines:
                 if 'version="%d.%d"'%(major_ver,minor_ver) in line:
-                    new_line = line.replace('%d.%d'%(major_ver, minor_ver), '%d.%d'%(new_major_ver, new_minor_ver))
+					if 'xml' in line:
+						new_line = line
+					else:
+						new_line = line.replace('%d.%d'%(major_ver, minor_ver), '%d.%d'%(new_major_ver, new_minor_ver))
                 else:
                     new_line = line
                 registry_file.write(new_line)
+        elif files == "README.md":
+            path = os.path.join(r, files)
+            readme_file = open(path, 'r+')
+
+            lines = readme_file.readlines()
+            readme_file.seek(0)
+            readme_file.truncate()
+
+            for line in lines:
+                if line.find('MPAS-v') >= 0:
+                    version_num = line.replace('MPAS-v', '')
+                    version_array = version_num.split('.')
+                    major_ver = int(version_array[0])
+                    minor_ver = int(version_array[1])
+
+                    if options.major:
+                        new_major_ver = major_ver + 1
+                        new_minor_ver = 0
+                    elif options.minor:
+                        new_major_ver = major_ver
+                        new_minor_ver = minor_ver + 1
+
+                    print "%s version: %d.%d"%(path, new_major_ver, new_minor_ver)
+
+                    readme_file.write(line.replace('v%d.%d'%(major_ver, minor_ver), 'v%d.%d'%(new_major_ver, new_minor_ver)))
+                else:
+                    readme_file.write(line)
 


### PR DESCRIPTION
If the readme file contains the string "MPAS-v#.#" where # and # are
replaced with the major and minor version numbers respectively, the
version update script now updates the version numbers in the README.md
file as well as all Registry.xml files in the repository.

The script needs to be run from the same directory as the README.md file
in order to properly update all version numbers.

This pull request assumes https://github.com/MPAS-Dev/MPAS/pull/52 will be sufficient. Assuming we change the way the version number is added to the README.md file, we will need to modify this script as well.
