### PR TITLE
Fixing missing netCDF lib from periodic_hex Makefile

### DIFF
--- a/grid_gen/periodic_hex/Makefile
+++ b/grid_gen/periodic_hex/Makefile
@@ -38,7 +38,10 @@ CPP = cpp -C -P -traditional
 CPPFLAGS = 
 CPPINCLUDES = 
 INCLUDES = -I$(NETCDF)/include
+
+# Specify NetCDF libraries, checking if netcdff is required (it will be present in v4 of netCDF)
 LIBS = -L$(NETCDF)/lib
+NCLIB = -lnetcdf
 NCLIBF = -lnetcdff
 ifneq ($(wildcard $(NETCDF)/lib/libnetcdff.*), ) # CHECK FOR NETCDF4
         LIBS += $(NCLIBF)


### PR DESCRIPTION
Logic I added in 50a6d6108 to determine which netCDF libraries are
needed to build periodic_hex was missing the line that specifies '-lnetcdf'
This pull request fixes #12.
