### PR TITLE
Remove line that sets surfaceWindStress to zero for realistic WOCE.

### DIFF
--- a/grid_gen/basin/src/basin.F
+++ b/grid_gen/basin/src/basin.F
@@ -915,7 +915,7 @@ do iEdge=1,nEdgesNew
 !   endif
 !   enddo
 ! else
-    surfaceWindStressNew(:) = 0.0
+!    surfaceWindStressNew(:) = 0.0
 ! end if
 
 enddo


### PR DESCRIPTION
@toddringler please check this.  surfaceWindStress was always zero.  Was something else intended?
