### PR TITLE
Addition of two tools.

### DIFF
--- a/grid_gen/mesh_conversion_tools/Makefile
+++ b/grid_gen/mesh_conversion_tools/Makefile
@@ -1,0 +1,23 @@
+#Assumes ${NETCDF} is defined to the root of the netcdf library
+
+CC=g++
+CFLAGS= -O3 -std=c++11
+CONV_EXECUTABLE= MpasMeshConverter.x
+CULL_EXECUTABLE= MpasCellCuller.x
+
+NCINCDIR=${NETCDF}/include
+NCLIBDIR=${NETCDF}/lib
+
+all:
+	${CC} mpas_mesh_converter.cpp netcdf_utils.cpp ${CFLAGS} -o ${CONV_EXECUTABLE} -I${NCINCDIR} -L${NCLIBDIR} -lnetcdf_c++ -lnetcdf -lstdc++
+	${CC} mpas_cell_culler.cpp netcdf_utils.cpp ${CFLAGS} -o ${CULL_EXECUTABLE} -I${NCINCDIR} -L${NCLIBDIR} -lnetcdf_c++ -lnetcdf -lstdc++
+
+debug:
+	${CC} mpas_mesh_converter.cpp netcdf_utils.cpp -D_DEBUG -g -o ${CONV_EXECUTABLE} -I${NCINCDIR} -L${NCLIBDIR} -lnetcdf_c++ -lnetcdf -lstdc++
+	${CC} mpas_cell_culler.cpp netcdf_utils.cpp -D_DEBUG -g -o ${CULL_EXECUTABLE} -I${NCINCDIR} -L${NCLIBDIR} -lnetcdf_c++ -lnetcdf -lstdc++
+
+clean:
+	rm -f grid.nc
+	rm -f graph.info
+	rm -f ${CONV_EXECUTABLE} ${CULL_EXECUTABLE}
+

--- a/grid_gen/mesh_conversion_tools/README
+++ b/grid_gen/mesh_conversion_tools/README
@@ -1,0 +1,82 @@
+Readme for mpas_mesh_converter.cpp and mpas_cell_culler.cpp
+
+Author: Doug Jacobsen <douglasj@lanl.gov>
+
+Purpose:
+	mpas_mesh_converter.cpp is a piece of software designed create an MPAS mesh.
+	As input, this software takes the locations of MPAS cell centers, and cell
+	vertices, along with the connectivity array cellsOnVertex. If provided, it
+	will also migrate data from the meshDensity field, if it's not present it
+	will write 1.0 for every cell.
+
+	mpas_cell_culler.cpp is a piece of software designed remove
+	cells/edge/vertices from an MPAS mesh.  As input, this software takes a
+	valid MPAS mesh with one additional field "cellMask". This new field should
+	be nCells integers. A 1 means the cell should be kept, and a 0 means the
+	cell should be removed.
+	
+Requirements:
+	mpas_mesh_converter.cpp requires the c++ netcdf libraries to be able to read/write a NetCDF files.
+	It also requires the tr1 headers for c++, specifically unordered_set.
+	It has been tested using g++ version 4.8.1
+
+	mpas_cell_culler.cpp requires the c++ netcdf libraries to be able to read/write a NetCDF files.
+	It has been tested using g++ version 4.8.1
+
+Usage of mpas_mesh_converter.cpp:
+	./MpasMeshConverter.x [input_name] [output_name]
+
+	input_name:
+		The input_name should be the name of a NetCDF file containing the following information.
+			Dimensions:
+				nCells - The number of cells described in the file.
+				nVertices - The number of vertices described in the file.
+				vertexDegree - The maximum number of cells that surround each vertex.
+			Variables:
+				xCell -- The x location of every cell center.
+				yCell -- The y location of every cell center.
+				zCell -- The z location of every cell center.
+				xVertex -- The x location of every vertex (cell corner).
+				yVertex -- The y location of every vertex (cell corner).
+				zVertex -- The z location of every vertex (cell corner).
+				cellsOnVertex -- A list of cell indices that border each vertex (Dimensioned vertexDegree * nVertices).
+								 This list can contain -1 values if the dual cell is not complete (e.g. a line rather than a triangle).
+				meshDensity -- (Optional) The value of the generating density function at each cell center.
+							   If this variable is ommitted, it is filled with 1.0 on output.
+			Global Attributes:
+				on_a_sphere -- Should be "YES" if the cells/vertices are defined on a sphere and "NO" if they are defined in a plane.
+				history -- (Optional) Should be defined to a string describing how the input file was generated.
+				mesh_id -- (Optional) Should be a 40 character string (Alpha-Numeric) that can be used to identify the mesh.
+						   If ommitted, a random string will be placed in the output file.
+	output_name:
+		The output_name should be the name of the NetCDF file that will be generated. It will be a valid MPAS mesh.
+		No initial conditions are placed in this file.
+
+
+Usage of mpas_cell_culler.cpp:
+	./MpasCellCuller.x [input_name] [output_name]
+
+	input_name:
+		The input name should be the name of a NetCDF file that is a fully valid MPAS file.
+		It is required to have all of the fields an output file from MpasMeshConverter.x contains.
+		There is one additional field:
+		cellMask -- (Optional) Should be dimensioned nCells. Should contain a 0 for all cells that should be removed
+					and a 1 for all cells that should be kept.
+
+	output_name:
+		The output_name should be the name of the NetCDF file that will be generated. It will be the same as the input file,
+		with cells, edges, and vertices removed where appropriate. Also, the cellMask field will be removed.
+
+
+Notes for mpas_mesh_converter.cpp:
+	- The output mesh should have an attribute "mesh_spec" which defined which
+		version of the MPAS Mesh Specification this mesh conforms to.
+	- Cells that are not complete (e.g. are not surrounded by vertices) will be
+		given a negative area.
+	- Negative area cells can be removed at a later state to remove non-complete
+		cells.
+	
+
+Notes for mpas_cell_culler.cpp:
+	- Cells that contain negative area will be removed in addition to all cells that have
+		a cellMask value of 0.

--- a/grid_gen/mesh_conversion_tools/edge.h
+++ b/grid_gen/mesh_conversion_tools/edge.h
@@ -1,0 +1,32 @@
+
+class edge {/*{{{*/
+	public:
+		int cell1, cell2;
+		int vertex1, vertex2;
+		int idx;
+
+	edge() 
+		: cell1(-1), cell2(-1), vertex1(-1), vertex2(-1), idx(-1) { }
+
+	struct edge_hasher {/*{{{*/
+		size_t operator()(const edge &edge_) const {
+			uint32_t hash; 
+			size_t i, key[2] = { (size_t)edge_.vertex1, (size_t)edge_.vertex2 };
+			for(hash = i = 0; i < sizeof(key); ++i) {
+				hash += ((uint8_t *)key)[i];
+				hash += (hash << 10);
+				hash ^= (hash >> 6);
+			}
+			hash += (hash << 3);
+			hash ^= (hash >> 11);
+			hash += (hash << 15);
+			return hash;
+		}
+	};/*}}}*/
+
+	bool operator==(const edge &e) const {/*{{{*/
+		return (vertex1 == e.vertex1) && (vertex2 == e.vertex2);
+	}/*}}}*/
+};/*}}}*/
+
+

--- a/grid_gen/mesh_conversion_tools/mpas_cell_culler.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_cell_culler.cpp
@@ -1,0 +1,1256 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <utility>
+#include <math.h>
+#include <assert.h>
+#include <time.h>
+
+#include "netcdf_utils.h"
+
+#define ID_LEN 40
+
+using namespace std;
+
+int nCells, nVertices, nEdges, vertexDegree, maxEdges;
+bool spherical;
+string in_history = "";
+string in_mesh_id = "";
+string in_parent_id = "";
+double in_mesh_spec = 1.0;
+
+// Connectivity and location information {{{
+
+vector<int> cellMask;
+vector<int> cellMap;
+vector<int> vertexMap;
+vector<int> edgeMap;
+vector< vector<int> > verticesOnEdge;
+vector< vector<int> > cellsOnEdge;
+vector< vector<int> > cellsOnVertex;
+vector<double> areaCell;
+
+// }}}
+
+/* Input/Marking Functions {{{ */
+int readGridInput(const string inputFilename);
+int markCells();
+int markVertices();
+int markEdges();
+/*}}}*/
+
+/* Mapping/Output functions {{{*/
+int outputGridDimensions(const string outputFilename);
+int outputGridAttributes(const string inputFilename, const string outputFilename);
+int mapAndOutputGridCoordinates(const string inputFilename, const string outputFilename);
+int mapAndOutputCellFields(const string inputFilename, const string outputFilename);
+int mapAndOutputEdgeFields(const string inputFilename, const string outputFilename);
+int mapAndOutputVertexFields(const string inputFilename, const string outputFilename);
+/*}}}*/
+
+string gen_random(const int len);
+
+int main ( int argc, char *argv[] ) {
+	int error;
+	string out_name = "culled.nc";
+	string in_name = "grid.nc";
+
+	cout << endl << endl;
+	cout << "************************************************************" << endl;
+	cout << "MPAS_CELL_CULLER:\n";
+	cout << "  C++ version\n";
+	cout << "  Remove cells/edges/vertices from a NetCDF MPAS Mesh file. \n";
+	cout << endl << endl;
+	cout << "  Compiled on " << __DATE__ << " at " << __TIME__ << ".\n";
+	cout << "************************************************************" << endl;
+	cout << endl << endl;
+	//
+	//  If the input file was not specified, get it now.
+	//
+	if ( argc <= 1 )
+	{
+		cout << "\n";
+		cout << "MPAS_CELL_CULLER:\n";
+		cout << "  Please enter the NetCDF input filename.\n";
+
+		cin >> in_name;
+
+		cout << "\n";
+		cout << "MPAS_CELL_CULLER:\n";
+		cout << "  Please enter the output NetCDF MPAS Mesh filename.\n";
+
+		cin >> out_name;
+	}
+	else if (argc == 2)
+	{
+		in_name = argv[1];
+
+		cout << "\n";
+		cout << "MPAS_CELL_CULLER:\n";
+		cout << "  Output name not specified. Using default of culled.nc\n";
+	}
+	else if (argc == 3)
+	{
+		in_name = argv[1];
+		out_name = argv[2];
+	}
+
+	if(out_name == in_name){
+		cout << "   ERROR: Input and Output names are the same." << endl;
+		return 1;
+	}
+
+
+	srand(time(NULL));
+
+	cout << "Reading input grid." << endl;
+	error = readGridInput(in_name);
+	if(error) return 1;
+
+	cout << "Marking cells for removal." << endl;
+	error = markCells();
+	if(error) return 1;
+
+	cout << "Marking vertices for removal." << endl;
+	error = markVertices();
+	if(error) return 1;
+
+	cout << "Marking edges for removal." << endl;
+	error = markEdges();
+	if(error) return 1;
+
+	cout << "Writing grid dimensions" << endl;
+	if(error = outputGridDimensions(out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+
+	cout << "Writing grid attributes" << endl;
+	if(error = outputGridAttributes(in_name, out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+
+	cout << "Writing grid coordinates" << endl;
+	if(error = mapAndOutputGridCoordinates(in_name, out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+
+	cout << "Mapping and writing cell fields" << endl;
+	if(error = mapAndOutputCellFields(in_name, out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+
+	cout << "Mapping and writing edge fields" << endl;
+	if(error = mapAndOutputEdgeFields(in_name, out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+
+	cout << "Mapping and writing vertex fields" << endl;
+	if(error = mapAndOutputVertexFields(in_name, out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+
+	return 0;
+}
+
+/* Input/Marking Functions {{{ */
+int readGridInput(const string inputFilename){/*{{{*/
+	double *xcell, *ycell,*zcell;
+	double *xvertex, *yvertex,*zvertex;
+	int *cellsonvertex_list, *verticesonedge_list, *cellsonedge_list;
+
+#ifdef _DEBUG
+	cout << endl << endl << "Begin function: readGridInput" << endl << endl;
+#endif
+
+	nCells = netcdf_mpas_read_dim(inputFilename, "nCells");
+	nVertices = netcdf_mpas_read_dim(inputFilename, "nVertices");
+	nEdges = netcdf_mpas_read_dim(inputFilename, "nEdges");
+	vertexDegree = netcdf_mpas_read_dim(inputFilename, "vertexDegree");
+	maxEdges = netcdf_mpas_read_dim(inputFilename, "maxEdges");
+#ifdef _DEBUG
+	cout << "   Reading on_a_sphere" << endl;
+#endif
+	spherical = netcdf_mpas_read_onsphere(inputFilename);
+#ifdef _DEBUG
+	cout << "   Reading history" << endl;
+#endif
+	in_history = netcdf_mpas_read_history(inputFilename);
+#ifdef _DEBUG
+	cout << "   Reading mesh_id" << endl;
+#endif
+	in_mesh_id = netcdf_mpas_read_meshid(inputFilename);
+#ifdef _DEBUG
+	cout << "   Reading parent_id" << endl;
+#endif
+	in_parent_id = netcdf_mpas_read_parentid(inputFilename);
+#ifdef _DEBUG
+	cout << "   Reading mesh_spec" << endl;
+#endif
+	in_mesh_spec = netcdf_mpas_read_meshspec(inputFilename);
+
+
+	cout << "Read dimensions:" << endl;
+	cout << "    nCells = " << nCells << endl;
+	cout << "    nVertices = " << nVertices << endl;
+	cout << "    nEdges = " << nEdges << endl;
+	cout << "    vertexDegree = " << vertexDegree << endl;
+	cout << "    maxEdges = " << maxEdges << endl;
+	cout << "    Spherical? = " << spherical << endl;
+
+#ifdef _DEBUG
+	cout << " Read areaCell" << endl;
+#endif
+	areaCell.clear();
+	areaCell.resize(nCells);
+	netcdf_mpas_read_areacell ( inputFilename, nCells, &areaCell[0] );
+
+#ifdef _DEBUG
+	cout << " Read cellMask" << endl;
+#endif
+	cellMask.clear();
+	cellMask.resize(nCells);
+	netcdf_mpas_read_cellmask ( inputFilename, nCells, &cellMask[0] );
+
+	// Build cellsOnVertex information
+	cellsonvertex_list = new int[nVertices * vertexDegree];
+
+#ifdef _DEBUG
+	cout << " Read cellsOnVertex" << endl;
+#endif
+	netcdf_mpas_read_cellsonvertex ( inputFilename, nVertices, vertexDegree, cellsonvertex_list );
+	cellsOnVertex.resize(nVertices);
+
+	for(int i = 0; i < nVertices; i++){
+		for(int j = 0; j < vertexDegree; j++){
+			// Subtract 1 to convert into base 0 (c index space).
+			cellsOnVertex.at(i).push_back(cellsonvertex_list[i*vertexDegree + j] - 1);
+		}
+	}
+
+	delete[] cellsonvertex_list;
+
+	// Build verticesOnEdge information
+	verticesonedge_list = new int[nEdges * 2];
+	verticesOnEdge.clear();
+	verticesOnEdge.resize(nEdges);
+
+#ifdef _DEBUG
+	cout << " Read verticesOnEdge" << endl;
+#endif
+	netcdf_mpas_read_verticesonedge ( inputFilename, nEdges, verticesonedge_list );
+	for(int i = 0; i < nEdges; i++){
+		// Subtract 1 to convert into base 0 (c index space).
+		verticesOnEdge.at(i).push_back(verticesonedge_list[i*2] - 1);
+		verticesOnEdge.at(i).push_back(verticesonedge_list[i*2+1] - 1);
+	}
+
+	delete[] verticesonedge_list;
+
+	// Build cellsOnEdge information
+	cellsonedge_list = new int[nEdges * 2];
+	cellsOnEdge.clear();
+	cellsOnEdge.resize(nEdges);
+
+#ifdef _DEBUG
+	cout << " Read cellsOnEdge" << endl;
+#endif
+	netcdf_mpas_read_cellsonedge ( inputFilename, nEdges, cellsonedge_list );
+	for(int i = 0; i < nEdges; i++){
+		// Subtract 1 to convert into base 0 (c index space).
+		cellsOnEdge.at(i).push_back(cellsonedge_list[i*2] - 1);
+		cellsOnEdge.at(i).push_back(cellsonedge_list[i*2+1] - 1);
+	}
+
+	delete[] cellsonedge_list;
+
+	return 0;
+}/*}}}*/
+int markCells(){/*{{{*/
+	int new_idx;
+	int cells_removed;
+	cellMap.clear();
+	cellMap.resize(nCells);
+
+	new_idx = 0;
+	cells_removed = 0;
+	for(int iCell = 0; iCell < nCells; iCell++){
+		// Remove all cells with negative area, and cells that shouldn't be in the grid.
+		if(areaCell.at(iCell) < 0 || cellMask.at(iCell) == 0){
+			cellMap.at(iCell) = -1;
+			cells_removed++;
+		} else {
+			cellMap.at(iCell) = new_idx;
+			new_idx++;
+		}
+	}
+
+	cout << "Removing " << cells_removed << " cells." << endl;
+
+	return 0;
+}/*}}}*/
+int markVertices(){/*{{{*/
+	bool keep_vertex;
+	int iCell, new_idx;
+	int vertices_removed;
+
+	vertexMap.clear();
+	vertexMap.resize(nVertices);
+
+	new_idx = 0;
+	vertices_removed = 0;
+	for(int iVertex = 0; iVertex < nVertices; iVertex++){
+
+		// Only keep vertices that have at least one cell connected to them
+		// after cell removal.
+		keep_vertex = false;
+		for(int j = 0; j < cellsOnVertex.at(iVertex).size(); j++){
+			iCell = cellsOnVertex.at(iVertex).at(j);
+			keep_vertex = keep_vertex || (cellMap.at(iCell) != -1);
+		}
+
+		if(keep_vertex){
+			vertexMap.at(iVertex) = new_idx;
+			new_idx++;
+		} else {
+			vertexMap.at(iVertex) = -1;
+			vertices_removed++;
+		}
+	}
+
+	cout << "Removing " << vertices_removed << " vertices." << endl;
+
+	return 0;
+}/*}}}*/
+int markEdges(){/*{{{*/
+	bool keep_edge;
+	int vertex1, vertex2;
+	int cell1, cell2;
+	int new_idx;
+	int edges_removed;
+
+	edgeMap.clear();
+	edgeMap.resize(nEdges);
+
+	new_idx = 0;
+	edges_removed = 0;
+	for(int iEdge = 0; iEdge < nEdges; iEdge++){
+		vertex1 = verticesOnEdge.at(iEdge).at(0);
+		vertex2 = verticesOnEdge.at(iEdge).at(1);
+		cell1 = cellsOnEdge.at(iEdge).at(0);
+		cell2 = cellsOnEdge.at(iEdge).at(1);
+
+		// Only keep an edge if it has two vertices
+		// after vertex removal and at least one cell
+		// after cell removal.
+		keep_edge = cellMap.at(cell1) != -1;
+		if(cell2 != -1){
+			keep_edge = keep_edge || cellMap.at(cell2) != -1;
+		}
+		keep_edge = keep_edge && (vertexMap.at(vertex1) != -1) && (vertexMap.at(vertex2) != -1);
+
+		if(keep_edge){
+			edgeMap.at(iEdge) = new_idx;
+			new_idx++;
+		} else {
+			edgeMap.at(iEdge) = -1;
+			edges_removed++;
+		}
+	}
+
+	cout << "Removing " << edges_removed << " edges." << endl;
+
+	return 0;
+}/*}}}*/
+/*}}}*/
+
+/* Mapping/Output functions {{{*/
+int outputGridDimensions( const string outputFilename ){/*{{{*/
+	/************************************************************************
+	 *
+	 * This function writes the grid dimensions to the netcdf file named
+	 * outputFilename
+	 *
+	 * **********************************************************************/
+
+	int nCellsNew, nEdgesNew, nVerticesNew;
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Replace, NULL, 0, NcFile::Offset64Bits);
+
+	/*
+	for(vec_int_itr = edgesOnCell.begin(); vec_int_itr != edgesOnCell.end(); ++vec_int_itr){
+		maxEdges = std::max(maxEdges, (int)(*vec_int_itr).size());	
+	}*/
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// define dimensions
+	NcDim *nCellsDim;
+	NcDim *nEdgesDim;
+	NcDim *nVerticesDim;
+	NcDim *TWODim;
+	NcDim *THREEDim;
+	NcDim *vertexDegreeDim;
+	NcDim *timeDim;
+
+	nCellsNew = 0;
+	for(int iCell = 0; iCell < nCells; iCell++){
+		nCellsNew += (cellMap.at(iCell) != -1);
+	}
+
+	nVerticesNew = 0;
+	for(int iVertex = 0; iVertex < nVertices; iVertex++){
+		nVerticesNew += (vertexMap.at(iVertex) != -1);
+	}
+
+	nEdgesNew = 0;
+	for(int iEdge = 0; iEdge < nEdges; iEdge++){
+		nEdgesNew += (edgeMap.at(iEdge) != -1);
+	}
+	
+	// write dimensions
+	if (!(nCellsDim =		grid.add_dim(	"nCells",		nCellsNew)		)) return NC_ERR;
+	if (!(nEdgesDim =		grid.add_dim(	"nEdges",		nEdgesNew)		)) return NC_ERR;
+	if (!(nVerticesDim =	grid.add_dim(	"nVertices",	nVerticesNew)	)) return NC_ERR;
+	if (!(TWODim =			grid.add_dim(	"TWO",			2)					)) return NC_ERR;
+	if (!(vertexDegreeDim = grid.add_dim(   "vertexDegree", vertexDegree)		)) return NC_ERR;
+	if (!(timeDim = 		grid.add_dim(   "Time")								)) return NC_ERR;
+
+	grid.close();
+	
+	// file closed when file obj goes out of scope
+	return 0;
+}/*}}}*/
+int outputGridAttributes( const string inputFilename, const string outputFilename ){/*{{{*/
+	/************************************************************************
+	 *
+	 * This function writes the grid dimensions to the netcdf file named
+	 * outputFilename
+	 *
+	 * **********************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	NcBool sphereAtt, radiusAtt;
+	NcBool history, id, spec, conventions, source, parent_id;
+	string history_str = "";
+	string id_str = "";
+	string parent_str = "";
+	
+	// write attributes
+	if(!spherical){
+		if (!(sphereAtt = grid.add_att(   "on_a_sphere", "NO\0"))) return NC_ERR;
+		if (!(radiusAtt = grid.add_att(   "sphere_radius", 0.0))) return NC_ERR;
+	} else {
+		if (!(sphereAtt = grid.add_att(   "on_a_sphere", "YES\0"))) return NC_ERR;
+		if (!(radiusAtt = grid.add_att(   "sphere_radius", 1.0))) return NC_ERR;
+	}
+
+	history_str += "MpasCellCuller.x ";
+	history_str += inputFilename;
+	history_str += " ";
+	history_str += outputFilename;
+	if(in_history != ""){
+		history_str += "\n";
+		history_str += in_history;
+	}
+
+	if(in_mesh_id != "" ){
+		parent_str = in_mesh_id;
+		if(in_parent_id != ""){
+			parent_str += "\n";
+			parent_str += in_parent_id;
+		}
+		if (!(id = grid.add_att(   "parent_id", parent_str.c_str() ))) return NC_ERR;
+	}
+
+	id_str = gen_random(ID_LEN);
+
+	if (!(history = grid.add_att(   "history", history_str.c_str() ))) return NC_ERR;
+	if (!(spec = grid.add_att(   "mesh_spec", in_mesh_spec ))) return NC_ERR;
+	if (!(conventions = grid.add_att(   "Conventions", "MPAS" ))) return NC_ERR;
+	if (!(source = grid.add_att(   "source", "MpasCellCuller.x" ))) return NC_ERR;
+	if (!(id = grid.add_att(   "mesh_id", id_str.c_str() ))) return NC_ERR;
+
+	grid.close();
+	
+	// file closed when file obj goes out of scope
+	return 0;
+}/*}}}*/
+int mapAndOutputGridCoordinates( const string inputFilename, const string outputFilename) {/*{{{*/
+	/************************************************************************
+	 *
+	 * This function writes the grid coordinates to the netcdf file named
+	 * outputFilename
+	 * This includes all cell centers, vertices, and edges.
+	 * Both cartesian and lat,lon, as well as all of their indices
+	 *
+	 * **********************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nCellsDim = grid.get_dim( "nCells" );
+	NcDim *nEdgesDim = grid.get_dim( "nEdges" );
+	NcDim *nVerticesDim = grid.get_dim( "nVertices" );
+
+	int nCellsNew = nCellsDim->size();
+	int nEdgesNew = nEdgesDim->size();
+	int nVerticesNew = nVerticesDim->size();
+
+	//Define nc variables
+	NcVar *xCellVar, *yCellVar, *zCellVar, *xEdgeVar, *yEdgeVar, *zEdgeVar, *xVertexVar, *yVertexVar, *zVertexVar;
+	NcVar *lonCellVar, *latCellVar, *lonEdgeVar, *latEdgeVar, *lonVertexVar, *latVertexVar;
+	NcVar *idx2cellVar, *idx2edgeVar, *idx2vertexVar;
+
+	int i, idx_map;
+	
+	double *xOld, *yOld, *zOld, *latOld, *lonOld;
+	double *xNew, *yNew, *zNew, *latNew, *lonNew;
+	int *idxToNew;
+
+	// Build and write cell coordinate arrays
+	xOld = new double[nCells];
+	yOld = new double[nCells];
+	zOld = new double[nCells];
+	latOld = new double[nCells];
+	lonOld = new double[nCells];
+
+	xNew = new double[nCellsNew];
+	yNew = new double[nCellsNew];
+	zNew = new double[nCellsNew];
+	latNew = new double[nCellsNew];
+	lonNew = new double[nCellsNew];
+	idxToNew = new int[nCellsNew];
+
+	netcdf_mpas_read_xyzcell ( inputFilename, nCells, xOld, yOld, zOld );
+	netcdf_mpas_read_latloncell ( inputFilename, nCells, latOld, lonOld );
+
+	idx_map = 0;
+	for(int iCell = 0; iCell < nCells; iCell++){
+		if(cellMap.at(iCell) != -1){
+			xNew[idx_map] = xOld[iCell];
+			yNew[idx_map] = yOld[iCell];
+			zNew[idx_map] = zOld[iCell];
+			latNew[idx_map] = latOld[iCell];
+			lonNew[idx_map] = lonOld[iCell];
+			idxToNew[idx_map] = idx_map;
+			idx_map++;
+		}
+	}
+
+	if (!(latCellVar = grid.add_var("latCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!latCellVar->put(latNew,nCellsNew)) return NC_ERR;
+	if (!(lonCellVar = grid.add_var("lonCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!lonCellVar->put(lonNew,nCellsNew)) return NC_ERR;
+	if (!(xCellVar = grid.add_var("xCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!xCellVar->put(xNew,nCellsNew)) return NC_ERR;
+	if (!(yCellVar = grid.add_var("yCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!yCellVar->put(yNew,nCellsNew)) return NC_ERR;
+	if (!(zCellVar = grid.add_var("zCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!zCellVar->put(zNew,nCellsNew)) return NC_ERR;
+	if (!(idx2cellVar = grid.add_var("indexToCellID", ncInt, nCellsDim))) return NC_ERR;
+	if (!idx2cellVar->put(idxToNew,nCellsNew)) return NC_ERR;
+	delete[] xOld;
+	delete[] yOld;
+	delete[] zOld;
+	delete[] latOld;
+	delete[] lonOld;
+
+	delete[] xNew;
+	delete[] yNew;
+	delete[] zNew;
+	delete[] latNew;
+	delete[] lonNew;
+	delete[] idxToNew;
+	
+	//Build and write edge coordinate arrays
+	xOld = new double[nEdges];
+	yOld = new double[nEdges];
+	zOld = new double[nEdges];
+	latOld = new double[nEdges];
+	lonOld = new double[nEdges];
+
+	xNew = new double[nEdgesNew];
+	yNew = new double[nEdgesNew];
+	zNew = new double[nEdgesNew];
+	latNew = new double[nEdgesNew];
+	lonNew = new double[nEdgesNew];
+	idxToNew = new int[nEdgesNew];
+
+	netcdf_mpas_read_xyzedge ( inputFilename, nEdges, xOld, yOld, zOld );
+	netcdf_mpas_read_latlonedge ( inputFilename, nEdges, latOld, lonOld );
+
+	idx_map = 0;
+	for(int iEdge = 0; iEdge < nEdges; iEdge++){
+		if(edgeMap.at(iEdge) != -1){
+			xNew[idx_map] = xOld[iEdge];
+			yNew[idx_map] = yOld[iEdge];
+			zNew[idx_map] = zOld[iEdge];
+			latNew[idx_map] = latOld[iEdge];
+			lonNew[idx_map] = lonOld[iEdge];
+			idxToNew[idx_map] = idx_map;
+			idx_map++;
+		}
+	}
+
+	if (!(latEdgeVar = grid.add_var("latEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!latEdgeVar->put(latNew,nEdgesNew)) return NC_ERR;
+	if (!(lonEdgeVar = grid.add_var("lonEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!lonEdgeVar->put(lonNew,nEdgesNew)) return NC_ERR;
+	if (!(xEdgeVar = grid.add_var("xEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!xEdgeVar->put(xNew,nEdgesNew)) return NC_ERR;
+	if (!(yEdgeVar = grid.add_var("yEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!yEdgeVar->put(yNew,nEdgesNew)) return NC_ERR;
+	if (!(zEdgeVar = grid.add_var("zEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!zEdgeVar->put(zNew,nEdgesNew)) return NC_ERR;
+	if (!(idx2edgeVar = grid.add_var("indexToEdgeID", ncInt, nEdgesDim))) return NC_ERR;
+	if (!idx2edgeVar->put(idxToNew, nEdgesNew)) return NC_ERR;
+	delete[] xOld;
+	delete[] yOld;
+	delete[] zOld;
+	delete[] latOld;
+	delete[] lonOld;
+
+	delete[] xNew;
+	delete[] yNew;
+	delete[] zNew;
+	delete[] latNew;
+	delete[] lonNew;
+	delete[] idxToNew;
+
+	//Build and write vertex coordinate arrays
+	xOld = new double[nVertices];
+	yOld = new double[nVertices];
+	zOld = new double[nVertices];
+	latOld = new double[nVertices];
+	lonOld = new double[nVertices];
+
+	xNew = new double[nVerticesNew];
+	yNew = new double[nVerticesNew];
+	zNew = new double[nVerticesNew];
+	latNew = new double[nVerticesNew];
+	lonNew = new double[nVerticesNew];
+	idxToNew = new int[nVerticesNew];
+
+	netcdf_mpas_read_xyzvertex ( inputFilename, nVertices, xOld, yOld, zOld );
+	netcdf_mpas_read_latlonvertex ( inputFilename, nVertices, latOld, lonOld );
+
+	idx_map = 0;
+	for(int iVertex = 0; iVertex < nVertices; iVertex++){
+		if(vertexMap.at(iVertex) != -1){
+			xNew[idx_map] = xOld[iVertex];
+			yNew[idx_map] = yOld[iVertex];
+			zNew[idx_map] = zOld[iVertex];
+			latNew[idx_map] = latOld[iVertex];
+			lonNew[idx_map] = lonOld[iVertex];
+			idxToNew[idx_map] = idx_map;
+			idx_map++;
+		}
+	}
+
+	if (!(latVertexVar = grid.add_var("latVertex", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!latVertexVar->put(latNew,nVerticesNew)) return NC_ERR;
+	if (!(lonVertexVar = grid.add_var("lonVertex", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!lonVertexVar->put(lonNew,nVerticesNew)) return NC_ERR;
+	if (!(xVertexVar = grid.add_var("xVertex", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!xVertexVar->put(xNew,nVerticesNew)) return NC_ERR;
+	if (!(yVertexVar = grid.add_var("yVertex", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!yVertexVar->put(yNew,nVerticesNew)) return NC_ERR;
+	if (!(zVertexVar = grid.add_var("zVertex", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!zVertexVar->put(zNew,nVerticesNew)) return NC_ERR;
+	if (!(idx2vertexVar = grid.add_var("indexToVertexID", ncInt, nVerticesDim))) return NC_ERR;
+	if (!idx2vertexVar->put(idxToNew, nVerticesNew)) return NC_ERR;
+	delete[] xOld;
+	delete[] yOld;
+	delete[] zOld;
+	delete[] latOld;
+	delete[] lonOld;
+
+	delete[] xNew;
+	delete[] yNew;
+	delete[] zNew;
+	delete[] latNew;
+	delete[] lonNew;
+	delete[] idxToNew;
+
+	grid.close();
+
+	return 0;
+}/*}}}*/
+int mapAndOutputCellFields( const string inputFilename, const string outputFilename) {/*{{{*/
+	/*****************************************************************
+	 *
+	 * This function maps and writes all of the cell related fields. Including
+	 * cellsOnCell
+	 * edgesOnCell
+	 * verticesOnCell
+	 * nEdgesonCell
+	 * areaCell
+	 * meshDensity
+	 *
+	 * ***************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nCellsDim = grid.get_dim( "nCells" );
+	NcDim *maxEdgesDim;
+	NcDim *maxEdges2Dim;
+
+	int nCellsNew = nCellsDim->size();
+	int maxEdgesNew;
+	int edgeCount;
+
+	// define nc variables
+	NcVar *cocVar, *nEocVar, *eocVar, *vocVar, *areacVar;
+	NcVar *cDensVar;
+
+	double *meshDensityOld, *meshDensityNew;
+	double *areaCellNew;
+	int *tmp_arr_old, *nEdgesOnCellNew;
+	int *tmp_arr_new;
+	
+	tmp_arr_old = new int[nCells*maxEdges];
+	nEdgesOnCellNew = new int[nCells];
+
+	netcdf_mpas_read_edgesoncell ( inputFilename, nCells, maxEdges, tmp_arr_old );
+
+	// Need to count edges on cell, to get maxEdgesNew
+	maxEdgesNew = 0;
+	for(int iCell = 0; iCell < nCells; iCell++){
+		if(cellMap.at(iCell) != -1){
+			edgeCount = 0;
+			for(int j = 0; j < maxEdges; j++){
+				int iEdge = tmp_arr_old[iCell*maxEdges + j] - 1;
+				if(iEdge != -1 && edgeMap.at( iEdge ) != -1){
+					edgeCount++;
+				}
+			}
+
+			nEdgesOnCellNew[cellMap.at(iCell)] = edgeCount;
+			maxEdgesNew = max(maxEdgesNew, edgeCount);
+		}
+	}
+	tmp_arr_new = new int[nCells * maxEdgesNew];
+
+	// Write maxEdges and maxEdges2 to output file.
+	if (!(maxEdgesDim =		grid.add_dim(	"maxEdges",		maxEdgesNew)			)) return NC_ERR;
+	if (!(maxEdges2Dim =	grid.add_dim(	"maxEdges2",	maxEdgesNew*2)			)) return NC_ERR;
+
+	// Write nEdgesOncell to output file
+	if (!(nEocVar = grid.add_var("nEdgesOnCell", ncInt, nCellsDim))) return NC_ERR;
+	if (!nEocVar->put(nEdgesOnCellNew,nCellsNew)) return NC_ERR;
+
+	delete[] nEdgesOnCellNew;
+
+	// Map edgesOnCell
+	for(int iCell = 0; iCell < nCells; iCell++){
+#ifdef _DEBUG
+		cout << "On cell: " << iCell << endl;
+#endif
+		if(cellMap.at(iCell) != -1){
+			for(int j = 0; j < maxEdgesNew; j++){
+				int iEdge = tmp_arr_old[iCell*maxEdges + j] - 1;
+
+				if(iEdge != -1){
+					tmp_arr_new[cellMap.at(iCell)*maxEdgesNew + j] = edgeMap.at(iEdge)+1;
+				} else {
+					tmp_arr_new[cellMap.at(iCell)*maxEdgesNew + j] = 0;
+				}
+
+#ifdef _DEBUG
+				cout << "    Mapping edge: " << iEdge << " to " << tmp_arr_new[cellMap.at(iCell)*maxEdgesNew + j] << " dbg info: " << tmp_arr_old[iCell*maxEdges + j] << " " << j << endl;
+#endif
+			}
+		}
+	}
+
+	if (!(eocVar = grid.add_var("edgesOnCell", ncInt, nCellsDim, maxEdgesDim))) return NC_ERR;
+	if (!eocVar->put(tmp_arr_new,nCellsNew,maxEdgesNew)) return NC_ERR;
+
+	netcdf_mpas_read_cellsoncell ( inputFilename, nCells, maxEdges, tmp_arr_old );
+
+	// Map cellsOnCell
+	for(int iCell = 0; iCell < nCells; iCell++){
+		if(cellMap.at(iCell) != -1){
+			for(int j = 0; j < maxEdgesNew; j++){
+				int coc = tmp_arr_old[iCell*maxEdges + j] - 1;
+
+				if(coc != -1){
+					tmp_arr_new[cellMap.at(iCell)*maxEdgesNew + j] = cellMap.at(coc)+1;
+				} else {
+					tmp_arr_new[cellMap.at(iCell)*maxEdgesNew + j] = 0;
+				}
+			}
+		}
+	}
+
+	if (!(cocVar = grid.add_var("cellsOnCell", ncInt, nCellsDim, maxEdgesDim))) return NC_ERR;
+	if (!cocVar->put(tmp_arr_new,nCellsNew,maxEdgesNew)) return NC_ERR;
+
+	netcdf_mpas_read_verticesoncell ( inputFilename, nCells, maxEdges, tmp_arr_old );
+
+	// Map verticesOnCell
+	for(int iCell = 0; iCell < nCells; iCell++){
+		if(cellMap.at(iCell) != -1){
+			for(int j = 0; j < maxEdgesNew; j++){
+				int iVertex = tmp_arr_old[iCell*maxEdges + j] - 1;
+
+				if(iVertex != -1){
+					tmp_arr_new[cellMap.at(iCell)*maxEdgesNew + j] = vertexMap.at(iVertex)+1;
+				} else {
+					tmp_arr_new[cellMap.at(iCell)*maxEdgesNew + j] = 0;
+				}
+			}
+		}
+	}
+
+	if (!(vocVar = grid.add_var("verticesOnCell", ncInt, nCellsDim, maxEdgesDim))) return NC_ERR;
+	if (!vocVar->put(tmp_arr_new,nCellsNew,maxEdgesNew)) return NC_ERR;
+
+	delete[] tmp_arr_old;
+	delete[] tmp_arr_new;
+
+	// Map areaCell
+	areaCellNew = new double[nCellsNew]; 
+
+	for(int iCell = 0; iCell < nCells; iCell++){
+		if(cellMap.at(iCell) != -1){
+			areaCellNew[cellMap.at(iCell)] = areaCell.at(iCell);
+		}
+	}
+
+	if (!(areacVar = grid.add_var("areaCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!areacVar->put(areaCellNew,nCellsNew)) return NC_ERR;
+
+	delete[] areaCellNew;
+
+	// Map meshDensity
+	meshDensityOld = new double[nCells];
+	meshDensityNew = new double[nCellsNew];
+
+	netcdf_mpas_read_mesh_density ( inputFilename, nCells, meshDensityOld );
+
+	for(int iCell = 0; iCell < nCells; iCell++){
+		if(cellMap.at(iCell) != -1){
+			meshDensityNew[cellMap.at(iCell)] = meshDensityOld[iCell];
+		}
+	}
+
+
+	//Write meshDensity
+	if (!(cDensVar = grid.add_var("meshDensity", ncDouble, nCellsDim))) return NC_ERR;
+	if (!cDensVar->put(meshDensityNew,nCellsNew)) return NC_ERR;
+
+	return 0;
+}/*}}}*/
+int mapAndOutputEdgeFields( const string inputFilename, const string outputFilename) {/*{{{*/
+	/*****************************************************************
+	 *
+	 * This function maps and writes all of the edge related fields. Including
+	 * cellsOnEdge
+	 * edgesOnEdge
+	 * verticesOnEdge
+	 * nEdgesOnEdge
+	 * weightsOnEdge
+	 * dvEdge
+	 * dcEdge
+	 * angleEdge
+	 *
+	 * ***************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nEdgesDim = grid.get_dim( "nEdges" );
+	NcDim *maxEdges2Dim = grid.get_dim( "maxEdges2" );
+	NcDim *vertexDegreeDim = grid.get_dim( "vertexDegree" );
+	NcDim *twoDim = grid.get_dim( "TWO" );
+
+	// define nc variables
+	NcVar *coeVar, *nEoeVar, *eoeVar, *voeVar, *woeVar;
+	NcVar *angleVar;
+	NcVar *dcEdgeVar, *dvEdgeVar;
+
+	int nEdgesNew = nEdgesDim->size();
+	int maxEdges2New = maxEdges2Dim->size();
+	int vertexDegree = vertexDegreeDim->size();
+	int two = twoDim->size();
+
+	int *nEdgesOnEdgeNew;
+	int *edgesOnEdgeOld, *edgesOnEdgeNew;
+	int *cellsOnEdgeOld, *cellsOnEdgeNew;
+	int *verticesOnEdgeOld, *verticesOnEdgeNew;
+	double *weightsOnEdgeOld, *weightsOnEdgeNew;
+	double *dvEdgeOld, *dvEdgeNew;
+	double *dcEdgeOld, *dcEdgeNew;
+	double *angleEdgeOld, *angleEdgeNew;
+
+	// Need to map cellsOnEdge and verticesOnEdge
+	cellsOnEdgeOld = new int[nEdges*2];
+	cellsOnEdgeNew = new int[nEdgesNew*2];
+	verticesOnEdgeOld = new int[nEdges*2];
+	verticesOnEdgeNew = new int[nEdgesNew*2];
+
+	netcdf_mpas_read_cellsonedge( inputFilename, nEdges, cellsOnEdgeOld);
+	netcdf_mpas_read_verticesonedge( inputFilename, nEdges, verticesOnEdgeOld);
+
+	// Map cellsOnEdge and verticesOnEdge
+	for(int iEdge = 0; iEdge < nEdges; iEdge++){
+		if(edgeMap.at(iEdge) != -1){
+			int cell1, cell2;
+			int vertex1, vertex2;
+
+			cell1 = cellsOnEdgeOld[iEdge * 2] - 1;
+			cell2 = cellsOnEdgeOld[iEdge * 2 + 1] - 1;
+			vertex1 = verticesOnEdgeOld[iEdge * 2] - 1;
+			vertex2 = verticesOnEdgeOld[iEdge * 2 + 1] - 1;
+
+#ifdef _DEBUG
+			cout << "Defining edge: " << endl;
+			cout << "   Old cell1: " << cell1 << endl;
+			cout << "   Old cell2: " << cell2 << endl;
+			cout << "   Old vertex1: " << vertex1 << endl;
+			cout << "   Old vertex2: " << vertex2 << endl;
+#endif
+
+			if(cell1 != -1 && cell2 != -1){
+				if(cellMap.at(cell1) != -1 && cellMap.at(cell2) != -1){
+					cellsOnEdgeNew[edgeMap.at(iEdge)*2] = cellMap.at(cell1) + 1;
+					cellsOnEdgeNew[edgeMap.at(iEdge)*2+1] = cellMap.at(cell2) + 1;
+
+					verticesOnEdgeNew[edgeMap.at(iEdge)*2] = vertexMap.at(vertex1) + 1;
+					verticesOnEdgeNew[edgeMap.at(iEdge)*2+1] = vertexMap.at(vertex2) + 1;
+				} else if (cellMap.at(cell2) == -1){
+					cellsOnEdgeNew[edgeMap.at(iEdge)*2] = cellMap.at(cell1) + 1;
+					cellsOnEdgeNew[edgeMap.at(iEdge)*2+1] = 0;
+
+					verticesOnEdgeNew[edgeMap.at(iEdge)*2] = vertexMap.at(vertex1) + 1;
+					verticesOnEdgeNew[edgeMap.at(iEdge)*2+1] = vertexMap.at(vertex2) + 1;
+				} else if (cellMap.at(cell1) == -1){
+					cellsOnEdgeNew[edgeMap.at(iEdge)*2] = cellMap.at(cell2) + 1;
+					cellsOnEdgeNew[edgeMap.at(iEdge)*2+1] = 0;
+
+					verticesOnEdgeNew[edgeMap.at(iEdge)*2] = vertexMap.at(vertex2) + 1;
+					verticesOnEdgeNew[edgeMap.at(iEdge)*2+1] = vertexMap.at(vertex1) + 1;
+				}
+			} else if(cell2 == -1){
+				if(cellMap.at(cell1) != -1){
+					cellsOnEdgeNew[edgeMap.at(iEdge)*2] = cellMap.at(cell1) + 1;
+					cellsOnEdgeNew[edgeMap.at(iEdge)*2+1] = 0;
+
+					verticesOnEdgeNew[edgeMap.at(iEdge)*2] = vertexMap.at(vertex1) + 1;
+					verticesOnEdgeNew[edgeMap.at(iEdge)*2+1] = vertexMap.at(vertex2) + 1;
+				} else {
+					cout << "ERROR: Edge mask is 1, but has no cells." << endl;
+				}
+			} else if(cell1 == -1){
+				cellsOnEdgeNew[edgeMap.at(iEdge)*2] = cellMap.at(cell2) + 1;
+				cellsOnEdgeNew[edgeMap.at(iEdge)*2+1] = 0;
+
+				verticesOnEdgeNew[edgeMap.at(iEdge)*2] = vertexMap.at(vertex2) + 1;
+				verticesOnEdgeNew[edgeMap.at(iEdge)*2+1] = vertexMap.at(vertex1) + 1;
+			} else {
+				cout << "ERROR: Edge mask is 1, but has no cells." << endl;
+			}
+
+#ifdef _DEBUG
+			cout << "   New cell1: " << cellsOnEdgeNew[edgeMap.at(iEdge)*2] << endl;
+			cout << "   New cell2: " << cellsOnEdgeNew[edgeMap.at(iEdge)*2+1] << endl;
+			cout << "   New vertex1: " << verticesOnEdgeNew[edgeMap.at(iEdge)*2] << endl;
+			cout << "   New vertex2: " << verticesOnEdgeNew[edgeMap.at(iEdge)*2+1] << endl;
+#endif
+		}
+	}
+	
+	if (!(voeVar = grid.add_var("verticesOnEdge", ncInt, nEdgesDim, twoDim))) return NC_ERR;
+	if (!voeVar->put(verticesOnEdgeNew,nEdgesNew,2)) return NC_ERR;
+	if (!(coeVar = grid.add_var("cellsOnEdge", ncInt, nEdgesDim, twoDim))) return NC_ERR;
+	if (!coeVar->put(cellsOnEdgeNew,nEdgesNew,2)) return NC_ERR;
+
+	// Don't delete cellsOnEdgeOld yet. It's needed to map edgesOnEdge and weightsOnEdge
+	delete[] cellsOnEdgeNew;
+	delete[] verticesOnEdgeOld;
+	delete[] verticesOnEdgeNew;
+
+	// Map edgesOnEdge, nEdgesOnEdge, and weightsOnEdge
+	nEdgesOnEdgeNew = new int[nEdges];
+	edgesOnEdgeOld = new int[nEdges*maxEdges*2];
+	edgesOnEdgeNew = new int[nEdgesNew*maxEdges2New];
+	weightsOnEdgeOld = new double[nEdges*maxEdges*2];
+	weightsOnEdgeNew = new double[nEdgesNew*maxEdges2New];
+
+	netcdf_mpas_read_edgesonedge( inputFilename, nEdges, maxEdges*2, edgesOnEdgeOld );
+	netcdf_mpas_read_weightsonedge( inputFilename, nEdges, maxEdges*2, weightsOnEdgeOld );
+
+	for(int iEdge = 0; iEdge < nEdges; iEdge++){
+		int edgeCount = 0;
+		if(edgeMap.at(iEdge) != -1){
+			int cell1, cell2;
+
+			cell1 = cellsOnEdgeOld[iEdge * 2] - 1;
+			cell2 = cellsOnEdgeOld[iEdge * 2 + 1] - 1;
+
+			if(cell1 != -1){
+				cell1 == cellMap.at(cell1);
+			}
+
+			if(cell2 != -1){
+				cell2 == cellMap.at(cell1);
+			}
+
+			if(cell1 != -1 && cell2 != -1){
+				for(int j = 0; j < maxEdges2New; j++){
+					int eoe = edgesOnEdgeOld[iEdge*maxEdges*2 + j] - 1;
+
+					if(eoe != -1){
+						edgesOnEdgeNew[edgeMap.at(iEdge)*maxEdges2New + j] = edgeMap.at(eoe) + 1;
+						weightsOnEdgeNew[edgeMap.at(iEdge)*maxEdges2New + j] = weightsOnEdgeOld[iEdge*maxEdges*2 + j];
+						edgeCount++;
+					} else {
+						edgesOnEdgeNew[edgeMap.at(iEdge)*maxEdges2New + j] = 0;
+						weightsOnEdgeNew[edgeMap.at(iEdge)*maxEdges2New + j] = 0;
+					}
+				}
+			} else if ( cell1 == -1  || cell2 == -1){
+				for(int j = 0; j < maxEdges2New; j++){
+					edgesOnEdgeNew[edgeMap.at(iEdge)*maxEdges2New + j] = 0;
+					weightsOnEdgeNew[edgeMap.at(iEdge)*maxEdges2New + j] = 0;
+				}
+			}
+		}
+		nEdgesOnEdgeNew[iEdge] = edgeCount;
+	}
+
+	if (!(nEoeVar = grid.add_var("nEdgesOnEdge", ncInt, nEdgesDim))) return NC_ERR;
+	if (!nEoeVar->put(nEdgesOnEdgeNew,nEdgesNew)) return NC_ERR;
+	if (!(eoeVar = grid.add_var("edgesOnEdge", ncInt, nEdgesDim, maxEdges2Dim))) return NC_ERR;
+	if (!eoeVar->put(edgesOnEdgeNew,nEdgesNew,maxEdges2New)) return NC_ERR;
+	if (!(woeVar = grid.add_var("weightsOnEdge", ncDouble, nEdgesDim, maxEdges2Dim))) return NC_ERR;
+	if (!woeVar->put(weightsOnEdgeNew,nEdgesNew,maxEdges2New)) return NC_ERR;
+
+	delete[] cellsOnEdgeOld;
+	delete[] edgesOnEdgeOld;
+	delete[] edgesOnEdgeNew;
+	delete[] weightsOnEdgeOld;
+	delete[] weightsOnEdgeNew;
+
+	// Map dvEdge, dcEdge, and angleEdge
+	dvEdgeOld = new double[nEdges];
+	dcEdgeOld = new double[nEdges];
+	angleEdgeOld = new double[nEdges];
+	dvEdgeNew = new double[nEdgesNew];
+	dcEdgeNew = new double[nEdgesNew];
+	angleEdgeNew = new double[nEdgesNew];
+
+	netcdf_mpas_read_dvedge ( inputFilename, nEdges, dvEdgeOld );
+	netcdf_mpas_read_dcedge ( inputFilename, nEdges, dcEdgeOld );
+	netcdf_mpas_read_angleedge ( inputFilename, nEdges, angleEdgeOld );
+
+	for(int iEdge = 0; iEdge < nEdges; iEdge++){
+		if(edgeMap.at(iEdge) != -1){
+			dvEdgeNew[edgeMap.at(iEdge)] = dvEdgeOld[iEdge];
+			dcEdgeNew[edgeMap.at(iEdge)] = dcEdgeOld[iEdge];
+			angleEdgeNew[edgeMap.at(iEdge)] = angleEdgeOld[iEdge];
+		}
+	}
+
+	if (!(dcEdgeVar = grid.add_var("dcEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!dcEdgeVar->put(dcEdgeNew,nEdgesNew)) return NC_ERR;
+	if (!(dvEdgeVar = grid.add_var("dvEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!dvEdgeVar->put(dvEdgeNew,nEdgesNew)) return NC_ERR;
+	if (!(angleVar = grid.add_var("angleEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!angleVar->put(angleEdgeNew,nEdgesNew)) return NC_ERR;
+
+	delete[] dvEdgeOld;
+	delete[] dvEdgeNew;
+	delete[] dcEdgeOld;
+	delete[] dcEdgeNew;
+	delete[] angleEdgeOld;
+	delete[] angleEdgeNew;
+
+	return 0;
+}/*}}}*/
+int mapAndOutputVertexFields( const string inputFilename, const string outputFilename) {/*{{{*/
+	/*****************************************************************
+	 *
+	 * This function maps and writes all of the vertex related fields. Including
+	 * cellsOnVertex
+	 * edgesOnVertex
+	 * areaTriangle
+	 * kiteAreasOnVertex
+	 *
+	 * ***************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nVerticesDim = grid.get_dim( "nVertices" );
+	NcDim *vertexDegreeDim = grid.get_dim( "vertexDegree" );
+
+	// define nc variables
+	NcVar *covVar, *eovVar, *kaovVar, *atVar;
+
+	int nVerticesNew = nVerticesDim->size();
+
+	int *cellsOnVertexOld, *cellsOnVertexNew;
+	int *edgesOnVertexOld, *edgesOnVertexNew;
+	double *kiteAreasOnVertexOld, *kiteAreasOnVertexNew;
+	double *areaTriangleOld, *areaTriangleNew;
+
+	cellsOnVertexOld = new int[nVertices * vertexDegree];
+	cellsOnVertexNew = new int[nVerticesNew * vertexDegree];
+	edgesOnVertexOld = new int[nVertices * vertexDegree];
+	edgesOnVertexNew = new int[nVerticesNew * vertexDegree];
+	kiteAreasOnVertexOld = new double[nVertices * vertexDegree];
+	kiteAreasOnVertexNew = new double[nVerticesNew * vertexDegree];
+	areaTriangleOld = new double[nVertices];
+	areaTriangleNew = new double[nVerticesNew];
+
+	netcdf_mpas_read_cellsonvertex ( inputFilename, nVertices, vertexDegree, cellsOnVertexOld );
+	netcdf_mpas_read_edgesonvertex ( inputFilename, nVertices, vertexDegree, edgesOnVertexOld );
+	netcdf_mpas_read_kiteareasonvertex ( inputFilename, nVertices, vertexDegree, kiteAreasOnVertexOld );
+	netcdf_mpas_read_areatriangle ( inputFilename, nVertices, areaTriangleOld );
+
+	for(int iVertex = 0; iVertex < nVertices; iVertex++){
+		double area = 0.0;
+		if(vertexMap.at(iVertex) != -1){
+			for(int j = 0; j < vertexDegree; j++){
+				int iCell, iEdge;
+
+				iCell = cellsOnVertexOld[iVertex*vertexDegree + j] - 1;
+				iEdge = edgesOnVertexOld[iVertex*vertexDegree + j] - 1;
+
+				if(iCell != -1){
+					cellsOnVertexNew[ vertexMap.at(iVertex) * vertexDegree + j] = cellMap.at(iCell) + 1;
+					if(cellMap.at(iCell) == -1){
+						kiteAreasOnVertexNew[ vertexMap.at(iVertex) * vertexDegree + j] = 0.0;
+					} else {
+						kiteAreasOnVertexNew[ vertexMap.at(iVertex) * vertexDegree + j] = kiteAreasOnVertexOld[iVertex*vertexDegree + j];
+					}
+					area += kiteAreasOnVertexNew[ vertexMap.at(iVertex) * vertexDegree + j];
+				} else {
+					cellsOnVertexNew[ vertexMap.at(iVertex) * vertexDegree + j] = 0;
+					kiteAreasOnVertexNew[ vertexMap.at(iVertex) * vertexDegree + j] = 0.0;
+				}
+
+				if(iEdge != -1){
+					edgesOnVertexNew[ vertexMap.at(iVertex) * vertexDegree + j] = edgeMap.at(iCell) + 1;
+				} else {
+					edgesOnVertexNew[ vertexMap.at(iVertex) * vertexDegree + j] = 0;
+				}
+			}
+
+			areaTriangleNew[vertexMap.at(iVertex)] = area;
+		}
+	}
+
+#ifdef _DEBUG
+	cout << "   Writing edgesOnVertex" << endl;
+#endif
+	if (!(eovVar = grid.add_var("edgesOnVertex", ncInt, nVerticesDim, vertexDegreeDim))) return NC_ERR;
+	if (!eovVar->put(edgesOnVertexNew,nVerticesNew,vertexDegree)) return NC_ERR;
+#ifdef _DEBUG
+	cout << "   Writing cellsOnVertex" << endl;
+#endif
+	if (!(covVar = grid.add_var("cellsOnVertex", ncInt, nVerticesDim, vertexDegreeDim))) return NC_ERR;
+	if (!covVar->put(cellsOnVertexNew,nVerticesNew,vertexDegree)) return NC_ERR;
+#ifdef _DEBUG
+	cout << "   Writing areaTriangle" << endl;
+#endif
+	if (!(atVar = grid.add_var("areaTriangle", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!atVar->put(areaTriangleNew, nVerticesNew)) return NC_ERR;
+#ifdef _DEBUG
+	cout << "   Writing kiteAreasOnVertex" << endl;
+#endif
+	if (!(kaovVar = grid.add_var("kiteAreasOnVertex", ncDouble, nVerticesDim, vertexDegreeDim))) return NC_ERR;
+	if (!kaovVar->put(kiteAreasOnVertexNew, nVerticesNew, vertexDegree)) return NC_ERR;
+
+	delete[] cellsOnVertexOld;
+	delete[] cellsOnVertexNew;
+	delete[] edgesOnVertexOld;
+	delete[] edgesOnVertexNew;
+	delete[] kiteAreasOnVertexOld;
+	delete[] kiteAreasOnVertexNew;
+	delete[] areaTriangleOld;
+	delete[] areaTriangleNew;
+
+	return 0;
+}/*}}}*/
+/*}}}*/
+
+string gen_random(const int len) {/*{{{*/
+	static const char alphanum[] =
+		"0123456789"
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		"abcdefghijklmnopqrstuvwxyz";
+
+	string rand_str = "";
+
+	for (int i = 0; i < len; ++i) {
+		rand_str += alphanum[rand() % (sizeof(alphanum) - 1)];
+	}
+
+	return rand_str;
+}/*}}}*/
+

--- a/grid_gen/mesh_conversion_tools/mpas_mesh_converter.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_mesh_converter.cpp
@@ -1,0 +1,2477 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <utility>
+#include <math.h>
+#include <assert.h>
+//#include <tr1/unordered_set>
+#include <unordered_set>
+#include <time.h>
+
+#include "netcdf_utils.h"
+#include "pnt.h"
+#include "edge.h"
+
+#define MESH_SPEC 1.0
+#define ID_LEN 40
+
+using namespace std;
+//using namespace tr1;
+
+int nCells, nVertices, vertex_degree;
+int maxEdges;
+bool spherical;
+double xCellRange[2];
+double yCellRange[2];
+double zCellRange[2];
+double xVertexRange[2];
+double yVertexRange[2];
+double zVertexRange[2];
+double xCellDistance, yCellDistance, zCellDistance;
+double xVertexDistance, yVertexDistance, zVertexDistance;
+double xPeriodicFix, yPeriodicFix;
+string in_history = "";
+string in_mesh_id = "";
+string in_parent_id = "";
+
+// Connectivity and location information {{{
+
+vector<pnt> cells;
+vector<pnt> edges;
+vector<pnt> vertices;
+vector< vector<int> > nEdgesOnCell;
+vector< vector<int> > cellsOnEdge;
+vector< vector<int> > verticesOnEdge;
+vector< vector<int> > edgesOnVertex;
+vector< vector<int> > cellsOnVertex;
+vector< vector<int> > cellsOnCell;
+vector< vector<int> > edgesOnCell;
+vector< vector<int> > verticesOnCell;
+vector< vector<int> > edgesOnEdge;
+vector< vector<double> > weightsOnEdge;
+vector< vector<double> > kiteAreasOnVertex;
+vector<double> dvEdge;
+vector<double> dcEdge;
+vector<double> areaCell;
+vector<double> areaTriangle;
+vector<double> angleEdge;
+vector<double> meshDensity;
+
+// }}}
+
+// Iterators {{{
+vector<pnt>::iterator pnt_itr;
+vector<int>::iterator int_itr;
+vector< vector<int> >::iterator vec_int_itr;
+vector< vector<double> >::iterator vec_dbl_itr;
+vector<double>::iterator dbl_itr;
+// }}}
+struct int_hasher {/*{{{*/
+	size_t operator()(const int i) const {
+		return (size_t)i;
+	}
+};/*}}}*/
+
+/* Building/Ordering functions {{{ */
+int readGridInput(const string inputFilename);
+int buildUnorderedCellConnectivity();
+int firstOrderingVerticesOnCell();
+int buildEdges();
+int orderVertexArrays();
+int orderCellArrays();
+int buildAreas();
+int buildEdgesOnEdgeArrays();
+int buildAngleEdge();
+/*}}}*/
+
+/* Output functions {{{*/
+int outputGridDimensions(const string outputFilename);
+int outputGridAttributes(const string outputFilename, const string inputFilename);
+int outputGridCoordinates(const string outputFilename);
+int outputCellConnectivity(const string outputFilename);
+int outputEdgeConnectivity(const string outputFilename);
+int outputVertexConnectivity(const string outputFilename);
+int outputCellParameters(const string outputFilename);
+int outputVertexParameters(const string outputFilename);
+int outputEdgeParameters(const string outputFilename);
+int outputMeshDensity(const string outputFilename);
+/*}}}*/
+
+string gen_random(const int len);
+
+int main ( int argc, char *argv[] ) {
+	int error;
+	string out_name = "output.nc";
+	string in_name = "grid.nc";
+
+	cout << endl << endl;
+	cout << "************************************************************" << endl;
+	cout << "MPAS_MESH_CONVERTER:\n";
+	cout << "  C++ version\n";
+	cout << "  Convert a NetCDF file describing Cell Locations, \n";
+	cout << "  Vertex Location, and Connectivity into a valid MPAS mesh.\n";
+	cout << endl << endl;
+	cout << "  Compiled on " << __DATE__ << " at " << __TIME__ << ".\n";
+	cout << "************************************************************" << endl;
+	cout << endl << endl;
+	//
+	//  If the input file was not specified, get it now.
+	//
+	if ( argc <= 1 )
+	{
+		cout << "\n";
+		cout << "MPAS_MESH_CONVERTER:\n";
+		cout << "  Please enter the NetCDF input filename.\n";
+
+		cin >> in_name;
+
+		cout << "\n";
+		cout << "MPAS_MESH_CONVERTER:\n";
+		cout << "  Please enter the output NetCDF MPAS Mesh filename.\n";
+
+		cin >> out_name;
+	}
+	else if (argc == 2)
+	{
+		in_name = argv[1];
+
+		cout << "\n";
+		cout << "MPAS_MESH_CONVERTER:\n";
+		cout << "  Output name not specified. Using default of output.nc\n";
+	}
+	else if (argc == 3)
+	{
+		in_name = argv[1];
+		out_name = argv[2];
+	}
+
+	if(in_name == out_name){
+		cout << "   ERROR: Input and output names are the same." << endl;
+		return 1;
+	}
+
+
+	srand(time(NULL));
+
+	cout << "Reading input grid." << endl;
+	error = readGridInput(in_name);
+	if(error) return 1;
+
+	cout << "Build prelimiary cell connectivity." << endl;
+	error = buildUnorderedCellConnectivity();
+	if(error) return 1;
+
+	cout << "Order vertices on cell." << endl;
+	error = firstOrderingVerticesOnCell();
+	if(error) return 1;
+
+	cout << "Build and order edges," << endl;
+	cout << "   dvEdge, and dcEdge." << endl;
+	error = buildEdges();
+	if(error) return 1;
+
+	cout << "Build and order vertex arrays," << endl;
+	error = orderVertexArrays();
+	if(error) return 1;
+
+	cout << "Build and order cell arrays," << endl;
+	error = orderCellArrays();
+	if(error) return 1;
+
+	cout << "Build areaCell, areaTriangle, and kiteAreasOnVertex." << endl;
+	error = buildAreas();
+	if(error) return 1;
+
+	cout << "Build edgesOnEdge and weightsOnEdge." << endl;
+	error = buildEdgesOnEdgeArrays();
+	if(error) return 1;
+
+	cout << "Build angleEdge." << endl;
+	error = buildAngleEdge();
+	if(error) return 1;
+
+	cout << "Writing grid dimensions" << endl;
+	if(error = outputGridDimensions(out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+	cout << "Writing grid attributes" << endl;
+	if(error = outputGridAttributes(out_name, in_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+	cout << "Writing grid coordinates" << endl;
+	if(error = outputGridCoordinates(out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+	cout << "Writing cell connectivity" << endl;
+	if(error = outputCellConnectivity(out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+	cout << "Writing edge connectivity" << endl;
+	if(error = outputEdgeConnectivity(out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+	cout << "Writing vertex connectivity" << endl;
+	if(error = outputVertexConnectivity(out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+	cout << "Writing cell parameters" << endl;
+	if(error = outputCellParameters(out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+	cout << "Writing edge parameters" << endl;
+	if(error = outputEdgeParameters(out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+	cout << "Writing vertex parameters" << endl;
+	if(error = outputVertexParameters(out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+	
+	cout << "Reading and writing meshDensity" << endl;
+	if(error = outputMeshDensity(out_name)){
+		cout << "Error - " << error << endl;
+		exit(error);
+	}
+}
+
+/* Building/Ordering functions {{{ */
+int readGridInput(const string inputFilename){/*{{{*/
+	int nCells, nVertices, vertexDegree;
+	double *xcell, *ycell,*zcell;
+	double *xvertex, *yvertex,*zvertex;
+	int *cellsonvertex_list;
+	pnt new_location;
+
+#ifdef _DEBUG
+	cout << endl << endl << "Begin function: readGridInput" << endl << endl;
+#endif
+
+	// Initialize range mins with huge values.
+	xCellRange[0] = 1E10;
+	yCellRange[0] = 1E10;
+	zCellRange[0] = 1E10;
+	xVertexRange[0] = 1E10;
+	yVertexRange[0] = 1E10;
+	zVertexRange[0] = 1E10;
+
+	// Initialize range maxes with small values.
+	xCellRange[1] = -1E10;
+	yCellRange[1] = -1E10;
+	zCellRange[1] = -1E10;
+	xVertexRange[1] = -1E10;
+	yVertexRange[1] = -1E10;
+	zVertexRange[1] = -1E10;
+
+
+	nCells = netcdf_mpas_read_dim(inputFilename, "nCells");
+	nVertices = netcdf_mpas_read_dim(inputFilename, "nVertices");
+	vertexDegree = netcdf_mpas_read_dim(inputFilename, "vertexDegree");
+	vertex_degree = vertexDegree;
+#ifdef _DEBUG
+	cout << "   Reading on_a_sphere" << endl;
+#endif
+	spherical = netcdf_mpas_read_onsphere(inputFilename);
+#ifdef _DEBUG
+	cout << "   Reading history" << endl;
+#endif
+	in_history = netcdf_mpas_read_history(inputFilename);
+#ifdef _DEBUG
+	cout << "   Reading mesh_id" << endl;
+#endif
+	in_mesh_id = netcdf_mpas_read_meshid(inputFilename);
+
+#ifdef _DEBUG
+	cout << "   Reading parent_id" << endl;
+#endif
+	in_parent_id = netcdf_mpas_read_parentid(inputFilename);
+
+	cout << "Read dimensions:" << endl;
+	cout << "    nCells = " << nCells << endl;
+	cout << "    nVertices = " << nVertices << endl;
+	cout << "    vertexDegree = " << vertexDegree << endl;
+	cout << "    Spherical? = " << spherical << endl;
+
+	// Build cell center location information
+	xcell = new double[nCells];
+	ycell = new double[nCells];
+	zcell = new double[nCells];
+
+	netcdf_mpas_read_xyzcell ( inputFilename, nCells, xcell, ycell, zcell );
+
+	cells.clear();
+	for(int i = 0; i < nCells; i++){
+		xCellRange[0] = min(xCellRange[0], xcell[i]);
+		xCellRange[1] = max(xCellRange[1], xcell[i]);
+
+		yCellRange[0] = min(yCellRange[0], ycell[i]);
+		yCellRange[1] = max(yCellRange[1], ycell[i]);
+
+		zCellRange[0] = min(zCellRange[0], zcell[i]);
+		zCellRange[1] = max(zCellRange[1], zcell[i]);
+
+		new_location = pnt(xcell[i], ycell[i], zcell[i], i);
+
+		if(spherical) new_location.normalize();
+		cells.push_back(new_location);
+	}
+
+	cout << "Built " << cells.size() << " cells." << endl;
+	delete[] xcell;
+	delete[] ycell;
+	delete[] zcell;
+
+	// Build vertex location information
+	xvertex = new double[nVertices];
+	yvertex = new double[nVertices];
+	zvertex = new double[nVertices];
+
+	netcdf_mpas_read_xyzvertex ( inputFilename, nVertices, xvertex, yvertex, zvertex );
+
+	vertices.clear();
+	for(int i = 0; i < nVertices; i++){
+		xVertexRange[0] = min(xVertexRange[0], xvertex[i]);
+		xVertexRange[1] = max(xVertexRange[1], xvertex[i]);
+
+		yVertexRange[0] = min(yVertexRange[0], yvertex[i]);
+		yVertexRange[1] = max(yVertexRange[1], yvertex[i]);
+
+		zVertexRange[0] = min(zVertexRange[0], zvertex[i]);
+		zVertexRange[1] = max(zVertexRange[1], zvertex[i]);
+
+		new_location = pnt(xvertex[i], yvertex[i], zvertex[i], i);
+		if(spherical) new_location.normalize();
+		vertices.push_back(new_location);
+	}
+
+	cout << "Built " << vertices.size() << " vertices." << endl;
+	delete[] xvertex;
+	delete[] yvertex;
+	delete[] zvertex;
+
+	// Build unordered cellsOnVertex information
+	cellsonvertex_list = new int[nVertices * vertexDegree];
+
+	netcdf_mpas_read_cellsonvertex ( inputFilename, nVertices, vertexDegree, cellsonvertex_list );
+	cellsOnVertex.resize(nVertices);
+
+	for(int i = 0; i < nVertices; i++){
+		for(int j = 0; j < vertexDegree; j++){
+			// Subtract 1 to convert into base 0 (c index space).
+			cellsOnVertex.at(i).push_back(cellsonvertex_list[i*vertexDegree + j] - 1);
+		}
+	}
+
+	delete[] cellsonvertex_list;
+
+	meshDensity.clear();
+	meshDensity.resize(cells.size());
+	netcdf_mpas_read_mesh_density ( inputFilename, cells.size(), &meshDensity[0]);
+
+	xCellDistance = fabs(xCellRange[1] - xCellRange[0]);
+	yCellDistance = fabs(yCellRange[1] - yCellRange[0]);
+	zCellDistance = fabs(zCellRange[1] - zCellRange[0]);
+
+	xVertexDistance = fabs(xVertexRange[1] - xVertexRange[0]);
+	yVertexDistance = fabs(yVertexRange[1] - yVertexRange[0]);
+	zVertexDistance = fabs(zVertexRange[1] - zVertexRange[0]);
+
+	if(vertexDegree == 4){
+		// Quads are not staggered in the y direction, so need to offset by
+		// max distance + min distance
+		xPeriodicFix = xCellRange[0] + xCellRange[1];
+		yPeriodicFix = yCellRange[0] + yCellRange[1];
+	} else {
+		// Triangles can be staggered, so only offset my max distance
+		xPeriodicFix = xCellRange[1];
+		yPeriodicFix = yCellRange[1];
+	}
+
+#ifdef _DEBUG
+	cout << "cell Mins: " << xCellRange[0] << " " << yCellRange[0] << " " << zCellRange[0] << endl;
+	cout << "vertex Mins: " << xVertexRange[0] << " " << yVertexRange[0] << " " << zVertexRange[0] << endl;
+	cout << "cell Maxes: " << xCellRange[1] << " " << yCellRange[1] << " " << zCellRange[1] << endl;
+	cout << "vertex Maxes: " << xVertexRange[1] << " " << yVertexRange[1] << " " << zVertexRange[1] << endl;
+	cout << "cell Distances: " << xCellDistance << " " << yCellDistance << " " << zCellDistance << endl;
+	cout << "vertex Distances: " << xVertexDistance << " " << yVertexDistance << " " << zVertexDistance << endl;
+#endif
+
+	if(!spherical && (zCellDistance > 0.0 || zVertexDistance > 0.0)){
+		cout << "ERROR:" << endl;
+		cout << "  This point set is defined in the plane, but has non-zero Z coordinates." << endl;
+		cout << endl;
+		return 1;
+	}
+
+	return 0;
+}/*}}}*/
+int buildUnorderedCellConnectivity(){/*{{{*/
+	// buildVerticesOnCell should assume that cellsOnVertex hasn't been ordered properly yet.
+	//    It should compute the inverse of cellsOnVertex (verticesOnCell) and order the vertices CCW around the cell.
+	//    This ordering should happen regardless of it the mesh is planar or spherical.
+	
+	int iVertex, iCell, j;
+	bool add;
+
+#ifdef _DEBUG
+	cout << endl << endl << "Begin function: buildUnorderedCellConnectivity" << endl << endl;
+#endif
+	
+	verticesOnCell.clear();
+	verticesOnCell.resize(cells.size());
+
+	for(iVertex = 0; iVertex < vertices.size(); iVertex++){
+		for(j = 0; j < cellsOnVertex.at(iVertex).size(); j++){
+			iCell = cellsOnVertex.at(iVertex).at(j);
+			if(iCell != -1){
+				add = true;
+				for(int k = 0; k < verticesOnCell.at(iCell).size(); k++){
+					if(verticesOnCell.at(iCell).at(k) == iVertex){
+						add = false;
+					}
+				}
+
+				if(add) {
+					verticesOnCell.at(iCell).push_back(iVertex);
+				}
+			}
+		}
+	}
+
+	return 0;
+}/*}}}*/
+int firstOrderingVerticesOnCell(){/*{{{*/
+	/*
+	 * firstOrderingVerticesOnCell should order the vertices around a cell such that they are connected.
+	 *		i.e. verticesOnCell.at(iCell).at(i) should be the tail of a vector pointing to
+	 *		     verticesOnCell.at(iCell).at(i+1)
+	 *
+	 *		This is done by computing angles between vectors pointing from the cell center
+	 *		to each individual vertex. The next vertex in the list, has the smallest positive angle.
+	 *
+	 */
+
+	pnt vec1, vec2, cross, normal;
+	pnt vertex1, vertex2;
+	int iCell, iVertex1, iVertex2, j, k, l, swp_idx, swp;
+	double dot, mag1, mag2, angle, min_angle;
+
+#ifdef _DEBUG
+	cout << endl << endl << "Begin function: firstOrderingVerticesOnCell" << endl << endl;
+#endif
+
+	if(!spherical){
+		normal = pnt(0.0, 0.0, 1.0);
+	}
+
+	for(iCell = 0; iCell < cells.size(); iCell++){
+#ifdef _DEBUG
+		cout << "new cell:" << endl;
+#endif
+		if(spherical){
+			normal = cells.at(iCell);
+		}
+
+#ifdef _DEBUG
+		cout << "  Unsorted verticesOnCell: ";
+		for(j = 0; j < verticesOnCell.at(iCell).size(); j++){
+			cout << verticesOnCell.at(iCell).at(j) << " ";
+		}
+		cout << endl;
+		for(j = 0; j < verticesOnCell.at(iCell).size(); j++){
+			cout << "  cellsOnVertex " << verticesOnCell.at(iCell).at(j) << ": ";
+			for(k = 0; k < cellsOnVertex.at(verticesOnCell.at(iCell).at(j)).size(); k++){
+				cout <<  cellsOnVertex.at(verticesOnCell.at(iCell).at(j)).at(k) << " ";
+			}
+			cout << endl;
+		}
+#endif
+
+		// Loop over all vertices except the last two as a starting vertex
+		for(j = 0; j < verticesOnCell.at(iCell).size()-1; j++){
+			iVertex1 = verticesOnCell.at(iCell).at(j);
+
+			vertex1 = vertices.at(iVertex1);
+
+			//Check for, and fix up periodicity
+			if(!spherical){
+				vertex1.fixPeriodicity(cells.at(iCell), xPeriodicFix, yPeriodicFix);
+			}
+			vec1 = vertex1 - cells.at(iCell);
+
+			mag1 = vec1.magnitude();
+			min_angle = 2.0*M_PI;
+			angle = 0.0;
+			swp_idx = -1;
+
+			// Don't sort any vertices that have already been sorted.
+			for(k = j+1; k < verticesOnCell.at(iCell).size(); k++){
+#ifdef _DEBUG
+				cout << "    Comparing " << j << " " << k << endl;
+#endif
+				iVertex2 = verticesOnCell.at(iCell).at(k);
+
+				vertex2 = vertices.at(iVertex2);
+
+				//Check for, and fix up periodicity
+				if(!spherical){
+					vertex2.fixPeriodicity(cells.at(iCell), xPeriodicFix, yPeriodicFix);
+				}
+				vec2 = vertex2 - cells.at(iCell);
+
+				mag2 = vec2.magnitude();
+
+				cross = vec1.cross(vec2);
+				dot = cross.dot(normal) / (cross.magnitude() * normal.magnitude());
+#ifdef _DEBUG
+				cout << "    dot = " << dot << endl;
+#endif
+
+				// Only look at vertices that are CCW from the current vertex.
+				if(dot > 0){
+					angle = acos(vec1.dot(vec2) / (mag1 * mag2));
+#ifdef _DEBUG
+					cout << "    angle = " << angle << endl;
+#endif
+					if(angle < min_angle){
+						min_angle = angle;
+						swp_idx = k;
+					}
+				}
+			}
+
+			if(swp_idx != -1 && swp_idx != j+1){
+				swp = verticesOnCell.at(iCell).at(j+1);
+				verticesOnCell.at(iCell).at(j+1) = verticesOnCell.at(iCell).at(swp_idx);
+				verticesOnCell.at(iCell).at(swp_idx) = swp;
+			}
+
+#ifdef _DEBUG
+			if(swp_idx != -1 && swp_idx != j+1){
+				cout << "      swapped " << j << " " << swp_idx << endl;
+			} else {
+				cout << "      no swap" << endl;
+			}
+			cout << "      cellsOnVertex(" << iVertex1 << "): ";
+			for(k = 0; k < cellsOnVertex.at(iVertex1).size(); k++){
+				cout << cellsOnVertex.at(iVertex1).at(k) << " ";
+			}
+			cout << endl;
+			iVertex2 = verticesOnCell.at(iCell).at(j+1);
+			cout << "      cellsOnVertex(" << iVertex2 << "): ";
+			for(k = 0; k < cellsOnVertex.at(iVertex2).size(); k++){
+				cout << cellsOnVertex.at(iVertex2).at(k) << " ";
+			}
+			cout << endl;
+#endif
+		}
+	}
+	
+	return 0;
+}/*}}}*/
+int buildEdges(){/*{{{*/
+	/*
+	 * buildEdges is intended to build a hash table that contains the
+	 *    cellsOnEdge and verticesonEdge pairs for each edge.  The actual edge
+	 *    location is not constructed at this point in time, as we need to
+	 *    determine the four constituent locations for each edge before we can
+	 *    compute it.
+	 *
+	 *    This function assumes the cellsOnVertex array is ordered such that
+	 *    two consecutive cell indices make up an edge.  This isn't an issue
+	 *    for triangular dual grids, but quadrilateral dual grids have an issue
+	 *    where every cell is not connected with every other cell. So, the tool
+	 *    that generates input data for this program needs to ensure that
+	 *    ordering.
+	 *
+	 *    After the hash table is created, it is iterated over to create each
+	 *    individual edge and ensure ordering is properly right handed.
+	 *
+	 */
+	unordered_set<edge, edge::edge_hasher> edge_idx_hash;
+	unordered_set<edge, edge::edge_hasher>::iterator edge_idx_itr;
+	unordered_set<edge, edge::edge_hasher>::const_iterator edge_idx_search;
+
+	int iCell, iVertex, iEdge, j, k, l;
+	int cell1, cell2;
+	int vertex1, vertex2, swp;
+	int land;
+	pair<unordered_set<edge,edge::edge_hasher>::iterator,bool> out_pair;
+	edge new_edge;
+	pnt edge_loc, normal;
+	pnt cell_loc1, cell_loc2, vert_loc1, vert_loc2, dist_vec;
+	pnt u_vec, v_vec, cross;
+	double vert1_x_movement, vert1_y_movement;
+	double vert2_x_movement, vert2_y_movement;
+	double temp, dot;
+	bool vert1_periodic, vert2_periodic;
+	bool fixed_edge;
+
+#ifdef _DEBUG
+	cout << endl << endl << "Begin function: buildEdges" << endl << endl;
+#endif
+
+	edge_idx_hash.clear();
+
+	land = 0;
+
+	for(iCell = 0; iCell < cells.size(); iCell++){
+		vertex1 = verticesOnCell.at(iCell).at(verticesOnCell.at(iCell).size()-1);
+		vertex2 = verticesOnCell.at(iCell).at(0);
+		cell1 = iCell;
+		cell2 = -1;
+
+		// Find matching cells for vertex pair.
+		for(k = 0; k < cellsOnVertex.at(vertex1).size(); k++){
+			if(cellsOnVertex.at(vertex1).at(k) != iCell){
+				for(l = 0; l < cellsOnVertex.at(vertex2).size(); l++){
+					if(cellsOnVertex.at(vertex1).at(k) >= 0){
+						if(cellsOnVertex.at(vertex1).at(k) == cellsOnVertex.at(vertex2).at(l)){
+							if(cell2 == -1){
+								cell2 = cellsOnVertex.at(vertex1).at(k);
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		new_edge.vertex1 = min(vertex1, vertex2);
+		new_edge.vertex2 = max(vertex1, vertex2);
+		if(cell2 == -1){
+			new_edge.cell1 = cell1;
+			new_edge.cell2 = -1;
+		} else {
+			new_edge.cell1 = min(cell1, cell2);
+			new_edge.cell2 = max(cell1, cell2);
+		}
+
+		out_pair = edge_idx_hash.insert(new_edge);
+
+		for(j = 1; j < verticesOnCell.at(iCell).size(); j++){
+			vertex1 = verticesOnCell.at(iCell).at(j-1);
+			vertex2 = verticesOnCell.at(iCell).at(j);
+			cell1 = iCell;
+			cell2 = -1;
+
+			// Find matching cells for vertex pair.
+			for(k = 0; k < cellsOnVertex.at(vertex1).size(); k++){
+				if(cellsOnVertex.at(vertex1).at(k) != iCell){
+					for(l = 0; l < cellsOnVertex.at(vertex2).size(); l++){
+						if(cellsOnVertex.at(vertex1).at(k) >= 0){
+							if(cellsOnVertex.at(vertex1).at(k) == cellsOnVertex.at(vertex2).at(l)){
+								if(cell2 == -1){
+									cell2 = cellsOnVertex.at(vertex1).at(k);
+								}
+							}
+						}
+					}
+				}
+			}
+
+			new_edge.vertex1 = min(vertex1, vertex2);
+			new_edge.vertex2 = max(vertex1, vertex2);
+			if(cell2 == -1){
+				new_edge.cell1 = cell1;
+				new_edge.cell2 = -1;
+			} else {
+				new_edge.cell1 = min(cell1, cell2);
+				new_edge.cell2 = max(cell1, cell2);
+			}
+
+			out_pair = edge_idx_hash.insert(new_edge);
+		}
+	}
+
+	cout << "Built " << edge_idx_hash.size() << " edge indices..." << endl;
+
+	cellsOnEdge.clear();
+	verticesOnEdge.clear();
+	dvEdge.clear();
+	dcEdge.clear();
+	cellsOnEdge.resize(edge_idx_hash.size());
+	verticesOnEdge.resize(edge_idx_hash.size());
+	dvEdge.resize(edge_idx_hash.size());
+	dcEdge.resize(edge_idx_hash.size());
+
+	if(!spherical){
+		normal = pnt(0.0, 0.0, 1.0);
+	}
+
+	iEdge = 0;
+	for(edge_idx_itr = edge_idx_hash.begin(); edge_idx_itr != edge_idx_hash.end(); ++edge_idx_itr){
+#ifdef _DEBUG
+		cout << "new edge: " << endl;
+#endif
+		fixed_edge = false;
+		cell1 = (*edge_idx_itr).cell1;
+		cell2 = (*edge_idx_itr).cell2;
+		vertex1 = (*edge_idx_itr).vertex1;
+		vertex2 = (*edge_idx_itr).vertex2;
+
+		cell_loc1 = cells.at(cell1);
+		vert_loc1 = vertices.at(vertex1);
+		vert_loc2 = vertices.at(vertex2);
+		if(spherical){
+			normal = cells.at(cell1);
+		} else {
+			// Clean up periodic edges. See mesh specification document for how periodicity is defined.
+			// These edges are special in the sense that they must be across a "uniform" edge.
+			// So, they are exactly the mid point between vertices.
+			// Since the edge will be "owned" by whatever processor owns cell1, make sure edge is close to cell1.
+			// So, fix periodicity relative to cell1.
+
+#ifdef _DEBUG
+			cout << "   Fixing periodicity of vertex 1" << endl;
+#endif
+			vert_loc1.fixPeriodicity(cell_loc1, xPeriodicFix, yPeriodicFix);
+
+#ifdef _DEBUG
+			cout << "   Fixing periodicity of vertex 2" << endl;
+#endif
+			vert_loc2.fixPeriodicity(cell_loc1, xPeriodicFix, yPeriodicFix);
+		}
+
+		if(cell2 != -1){
+			cell_loc2 = cells.at(cell2);
+
+			if(!spherical) {
+#ifdef _DEBUG
+				cout << "   Fixing periodicity of cell 2" << endl;
+#endif
+				cell_loc2.fixPeriodicity(cell_loc1, xPeriodicFix, yPeriodicFix);
+				edge_loc = planarIntersect(cell_loc1, cell_loc2, vert_loc1, vert_loc2);
+				dvEdge.at(iEdge) = (vert_loc2 - vert_loc1).magnitude();
+				dcEdge.at(iEdge) = (cell_loc2 - cell_loc1).magnitude();
+			} else { // If spherical
+				edge_loc = gcIntersect(cell_loc1, cell_loc2, vert_loc1, vert_loc2);
+				dvEdge.at(iEdge) = vert_loc2.sphereDistance(vert_loc1);
+				dcEdge.at(iEdge) = cell_loc2.sphereDistance(cell_loc1);
+			}
+		} else {
+			edge_loc = (vert_loc1 + vert_loc2) * 0.5;
+			cell_loc2 = edge_loc;
+			if(!spherical){
+				// Set dv and dc Edge values on plane
+				dvEdge.at(iEdge) = (vert_loc2 - vert_loc1).magnitude();
+				dcEdge.at(iEdge) = sqrt(3.0) * dvEdge.at(iEdge);
+			} else {
+				// Set dv and dc Edge values on Sphere
+				dvEdge.at(iEdge) = vert_loc2.sphereDistance(vert_loc1);
+				dcEdge.at(iEdge) = sqrt(3.0) * dvEdge.at(iEdge);
+			}
+		}
+
+		if(spherical) edge_loc.normalize();
+
+		edge_loc.idx = iEdge;
+
+#ifdef _DEBUG
+		cout << "New Edge At: " << edge_loc << endl;
+		cout << "         c1: " << cells.at(cell1) << endl;
+		if(cell2 > -1) { 
+			cout << "         c2: " << cells.at(cell2) << endl;
+			cout << "    mod? c2: " << cell_loc2 << endl;
+		} else {
+			cout << "         c2: land" << endl;
+			cout << "    mod? c2: " << cell_loc2 << endl;
+		}
+		cout << "         v1: " << vertices.at(vertex1) << endl;
+		cout << "    mod? v1: " << vert_loc1 << endl;
+		cout << "         v2: " << vertices.at(vertex2) << endl;
+		cout << "    mod? v2: " << vert_loc2 << endl;
+#endif
+
+		u_vec = cell_loc2 - cell_loc1;
+		v_vec = vert_loc2 - vert_loc1;
+
+		cross = u_vec.cross(v_vec);
+		dot = cross.dot(normal);
+
+		if(dot < 0){
+#ifdef _DEBUG
+			cout << "   swapping vertex " << vertex1 << " and " << vertex2 << endl;
+#endif
+			swp = vertex2;
+			vertex2 = vertex1;
+			vertex1 = swp;
+		}
+
+		edges.push_back(edge_loc);
+		cellsOnEdge.at(iEdge).clear();
+		cellsOnEdge.at(iEdge).push_back(cell1);
+		cellsOnEdge.at(iEdge).push_back(cell2);
+		verticesOnEdge.at(iEdge).clear();
+		verticesOnEdge.at(iEdge).push_back(vertex1);
+		verticesOnEdge.at(iEdge).push_back(vertex2);
+
+		iEdge++;
+	}
+
+	edge_idx_hash.clear();
+
+	return 0;
+}/*}}}*/
+int orderVertexArrays(){/*{{{*/
+	/*
+	 * orderVertexArrays builds and orders the connectivity arrays for vertices.
+	 *		This includes edgesOnVertex and cellsOnvertex.
+	 *      First, edgeSOnVertex is built and ordered correctly, then using
+	 *      that ordering cellsOnVertex is built and ordered correctly as well.
+	 */
+	int iEdge, iVertex, vertex1, vertex2, cell1, cell2, edge1, edge2;
+	int i, j, k, l, swp_idx, swp;
+	pnt normal;
+	pnt cross;
+	pnt vec1, vec2;
+	pnt cell_loc, edge_loc1, edge_loc2;
+	double mag1, mag2, min_angle, angle;
+	double dvEdge, dot, area;
+	bool fixed_area;
+
+#ifdef _DEBUG
+	cout << endl << endl << "Begin function: orderVertexArrays" << endl << endl;
+#endif
+
+	edgesOnVertex.clear();
+	edgesOnVertex.resize(vertices.size());
+	cellsOnVertex.clear();
+	cellsOnVertex.resize(vertices.size());
+
+	// Get lists of edges for each vertex
+	for(iEdge = 0; iEdge < edges.size(); iEdge++){/*{{{*/
+		vertex1 = verticesOnEdge.at(iEdge).at(0);
+		vertex2 = verticesOnEdge.at(iEdge).at(1);
+
+		edgesOnVertex.at(vertex1).push_back(iEdge);
+		edgesOnVertex.at(vertex2).push_back(iEdge);
+	}/*}}}*/
+
+	if(!spherical){
+		normal = pnt(0.0, 0.0, 1.0);
+	}
+
+	// Order edges counter-clockwise
+	for(iVertex = 0; iVertex < vertices.size(); iVertex++){/*{{{*/
+		if(spherical){
+			normal = vertices.at(iVertex);
+		}
+
+		//Loop over all edges except the last two as a starting edge.
+		for(j = 0; j < edgesOnVertex.at(iVertex).size(); j++){
+			edge1 = edgesOnVertex.at(iVertex).at(j);
+
+			edge_loc1 = edges.at(edge1);
+
+			// Fix edge1 periodicity
+			if(!spherical){
+				edge_loc1.fixPeriodicity(vertices.at(iVertex), xPeriodicFix, yPeriodicFix);
+			}
+			vec1 = edge_loc1 - vertices.at(iVertex);
+
+			mag1 = vec1.magnitude();
+			min_angle = 2.0*M_PI;
+			angle = 0.0;
+			swp_idx = -1;
+
+			//Don't sort any edges that have already been sorted.
+			for(k = j+1; k < edgesOnVertex.at(iVertex).size(); k++){
+				edge2 = edgesOnVertex.at(iVertex).at(k);
+
+				edge_loc2 = edges.at(edge2);
+
+				// Fix edge2 periodicity
+				if(!spherical){
+					edge_loc2.fixPeriodicity(vertices.at(iVertex), xPeriodicFix, yPeriodicFix);
+				}
+				vec2 = edge_loc2 - vertices.at(iVertex);
+				mag2 = vec2.magnitude();
+
+				cross = vec1.cross(vec2);
+				dot = cross.dot(normal) / (cross.magnitude() * normal.magnitude());
+				angle = acos(vec1.dot(vec2) / (mag1 * mag2));
+
+				// Only look at vertices that are CCW from the current edge.
+				if(dot > 0){
+					angle = acos(vec1.dot(vec2) / (mag1 * mag2));
+					if(angle < min_angle){
+						min_angle = angle;
+						swp_idx = k;
+					}
+				}
+			}
+
+			if(swp_idx != -1 && swp_idx != j+1){
+				swp = edgesOnVertex.at(iVertex).at(j+1);
+				edgesOnVertex.at(iVertex).at(j+1) = edgesOnVertex.at(iVertex).at(swp_idx);
+				edgesOnVertex.at(iVertex).at(swp_idx) = swp;
+			}
+		}
+
+		cellsOnVertex.at(iVertex).clear();
+
+		// Using the ordered edges. Buld cellsOnVertex in the correct order.
+		for(j = 0; j < edgesOnVertex.at(iVertex).size(); j++){
+			edge1 = edgesOnVertex.at(iVertex).at(j);
+			fixed_area = false;
+
+			// Get cell id and add it to list of cells
+			if(iVertex == verticesOnEdge.at(edge1).at(0)){
+				cell1 = cellsOnEdge.at(edge1).at(0);
+				cellsOnVertex.at(iVertex).push_back( cellsOnEdge.at(edge1).at(0) );
+			} else {
+				cell1 = cellsOnEdge.at(edge1).at(1);
+				cellsOnVertex.at(iVertex).push_back( cellsOnEdge.at(edge1).at(1) );
+			}
+		}
+	}/*}}}*/
+
+	return 0;
+}/*}}}*/
+int orderCellArrays(){/*{{{*/
+	/*
+	 * orderCellArrays assumes verticesOnCell are ordered CCW already.
+	 *
+	 */
+	int iCell, iVertex, iEdge, iEdge2, add_cell;	
+	int cell1, cell2, vertex1, vertex2, prev_vertex;
+	int edge_idx;
+	int i, j, k, swp_idx;
+	pnt normal, cross;
+	pnt vec1, vec2;
+	pnt vert_loc, edge_loc, cell_loc;
+	pnt next_edge_loc;
+	double swp;
+	double dot, mag1, mag2, angle, min_angle;
+	bool found;
+
+#ifdef _DEBUG
+	cout << endl << endl << "Begin function: orderCellArrays" << endl << endl;
+#endif
+
+	maxEdges = 0;
+
+	verticesOnCell.clear();
+	edgesOnCell.clear();
+	cellsOnCell.clear();
+
+	verticesOnCell.resize(cells.size());
+	edgesOnCell.resize(cells.size());
+	cellsOnCell.resize(cells.size());
+
+	if(!spherical){
+		normal = pnt(0.0, 0.0, 1.0);
+	}
+
+	// First, build full list of edges on cell.
+	for(iEdge = 0; iEdge < edges.size(); iEdge++){
+		cell1 = cellsOnEdge.at(iEdge).at(0);	
+		cell2 = cellsOnEdge.at(iEdge).at(1);	
+
+		edgesOnCell.at(cell1).push_back(iEdge);
+		if(cell2 != -1){
+			edgesOnCell.at(cell2).push_back(iEdge);
+		}
+	}
+
+	// Loop over all cells.
+	for(iCell = 0; iCell < cells.size(); iCell++){
+#ifdef _DEBUG
+		cout << "New Cell " << cells.at(iCell) << endl;
+#endif
+		if(spherical){
+			normal = cells.at(iCell);
+		}
+
+
+
+		// Order all edges in CCW relative to the first edge.
+		// Loop over all vertices except the last two as a starting vertex.
+		for(j = 0; j < edgesOnCell.at(iCell).size(); j++){
+			iEdge = edgesOnCell.at(iCell).at(j);
+			edge_loc = edges.at(iEdge);
+
+			// Add cell and vertex from first edge.
+			// Add cell across edge to cellsOnCell
+			// Also, add vertex that is CCW relative to current edge location.
+			if(cellsOnEdge.at(iEdge).at(0) == iCell){
+				cellsOnCell.at(iCell).push_back(cellsOnEdge.at(iEdge).at(1));
+				verticesOnCell.at(iCell).push_back(verticesOnEdge.at(iEdge).at(1));
+			} else {
+				cellsOnCell.at(iCell).push_back(cellsOnEdge.at(iEdge).at(0));
+				verticesOnCell.at(iCell).push_back(verticesOnEdge.at(iEdge).at(0));
+			}
+
+
+			if(!spherical){
+#ifdef _DEBUG
+				cout << "   checking periodicity on edge 1" << endl;
+#endif
+				edge_loc.fixPeriodicity(cells.at(iCell), xPeriodicFix, yPeriodicFix);
+			}
+
+			vec1 = edge_loc - cells.at(iCell);
+			mag1 = vec1.magnitude();
+
+			min_angle = 2.0 * M_PI;
+			angle = 0.0;
+			swp_idx = -1;
+
+			for(k = j+1; k < edgesOnCell.at(iCell).size(); k++){
+				iEdge2 = edgesOnCell.at(iCell).at(k);
+
+				next_edge_loc = edges.at(iEdge2);
+
+				if(!spherical){
+#ifdef _DEBUG
+					cout << "   checking periodicity on edge 2" << endl;
+#endif
+					next_edge_loc.fixPeriodicity(cells.at(iCell), xPeriodicFix, yPeriodicFix);
+				}
+
+				vec2 = next_edge_loc - cells.at(iCell);
+				mag2 = vec2.magnitude();
+
+				cross = vec1.cross(vec2);
+				dot = cross.dot(normal) / (cross.magnitude() * normal.magnitude());
+
+				// Only look at edges that are CCW from the current edge
+				if(dot > 0){
+					angle = acos(vec1.dot(vec2) / (mag1 * mag2));
+					if(angle < min_angle){
+						min_angle = angle;
+						swp_idx = k;
+					}
+				}
+			}
+
+			if(swp_idx != -1 && swp_idx != j+1){
+				swp = edgesOnCell.at(iCell).at(j+1);
+				edgesOnCell.at(iCell).at(j+1) = edgesOnCell.at(iCell).at(swp_idx);
+				edgesOnCell.at(iCell).at(swp_idx) = swp;
+
+				/* 
+				iEdge = edgesOnCell.at(iCell).at(j+1);
+				// Add cell across edge to cellsOnCell
+				// Also, add vertex that is CCW relative to current edge location.
+				if(cellsOnEdge.at(iEdge).at(0) == iCell){
+					cellsOnCell.at(iCell).push_back(cellsOnEdge.at(iEdge).at(1));
+					verticesOnCell.at(iCell).push_back(verticesOnEdge.at(iEdge).at(1));
+				} else {
+					cellsOnCell.at(iCell).push_back(cellsOnEdge.at(iEdge).at(0));
+					verticesOnCell.at(iCell).push_back(verticesOnEdge.at(iEdge).at(0));
+				} // */
+			} else {
+				/*
+				iEdge = edgesOnCell.at(iCell).at(j+1);
+				// Add cell across edge to cellsOnCell
+				// Also, add vertex that is CCW relative to current edge location.
+				if(cellsOnEdge.at(iEdge).at(0) == iCell){
+					cellsOnCell.at(iCell).push_back(cellsOnEdge.at(iEdge).at(1));
+					verticesOnCell.at(iCell).push_back(verticesOnEdge.at(iEdge).at(1));
+				} else {
+					cellsOnCell.at(iCell).push_back(cellsOnEdge.at(iEdge).at(0));
+					verticesOnCell.at(iCell).push_back(verticesOnEdge.at(iEdge).at(0));
+				} // */
+			}
+		}
+
+
+#ifdef _DEBUG
+		cout << "   cellsOnCell: ";
+		for(i = 0; i < cellsOnCell.at(iCell).size(); i++){
+			cout << cellsOnCell.at(iCell).at(i) << " ";
+		}
+		cout << endl;
+		cout << "   verticesOnCell: ";
+		for(i = 0; i < verticesOnCell.at(iCell).size(); i++){
+			cout << verticesOnCell.at(iCell).at(i) << " ";
+		}
+		cout << endl;
+		cout << "   edgesOnCell: ";
+		for(i = 0; i < edgesOnCell.at(iCell).size(); i++){
+			cout << edgesOnCell.at(iCell).at(i) << " ";
+		}
+		cout << endl;
+#endif
+
+		maxEdges = max(maxEdges, (int)edgesOnCell.at(iCell).size());
+	}
+
+	return 0;
+}/*}}}*/
+int buildAreas(){/*{{{*/
+	/*
+	 * buildAreas constructs the area arrays.
+	 *    This includes areaCell, areaTriangle, and kiteAreasOnVertex
+	 *
+	 * Before constructing areaCell, the cell is checked for completeness.
+	 *    This is accomplished by looping over each edge. For each edge,
+	 *    the angle between it's vertices is computed and added to a running total.
+	 *    If the total is significantly less than 2*Pi, the cell is not complete.
+	 *
+	 * Non-complete cells are given a negative area, to ease removal at a later stage.
+	 */
+	int iVertex, iCell, iEdge, i, j;
+	int vertex1, vertex2;
+	int edge1, edge2;
+	pnt vert_loc1, vert_loc2;
+	pnt edge_loc1, edge_loc2;
+	pnt cell_loc;
+	pnt vec1, vec2;
+	double angle_sum;
+	double angle;
+
+#ifdef _DEBUG
+	cout << endl << endl << "Begin function: buildAreas" << endl << endl;
+#endif
+
+	areaCell.clear();
+	areaTriangle.clear();
+	kiteAreasOnVertex.clear();
+
+	areaCell.resize(cells.size());
+	areaTriangle.resize(vertices.size());
+	kiteAreasOnVertex.resize(vertices.size());
+
+	for(iCell = 0; iCell < cells.size(); iCell++){
+		areaCell.at(iCell) = 0.0;
+
+		// Check for full cells, by summing the angles between the two vertices of each edge.
+		// If they sum to something close to 2*Pi, it's a full cell, otherwise it's not.
+		// Non-complete cells get negative area so we can easily remove later.
+		angle_sum = 0.0;
+		for(j = 0; j < edgesOnCell.at(iCell).size()-1; j++){
+			iEdge = edgesOnCell.at(iCell).at(j);
+			vertex1 = verticesOnEdge.at(iEdge).at(0);
+			vertex2 = verticesOnEdge.at(iEdge).at(1);
+
+			vert_loc1 = vertices.at(vertex1);
+			vert_loc2 = vertices.at(vertex2);
+
+			if(!spherical){
+				vert_loc1.fixPeriodicity(cells.at(iCell), xPeriodicFix, yPeriodicFix);
+				vert_loc2.fixPeriodicity(cells.at(iCell), xPeriodicFix, yPeriodicFix);
+			}
+
+			vec1 = vert_loc1 - cells.at(iCell);
+			vec2 = vert_loc2 - cells.at(iCell);
+
+			angle = acos( vec2.dot(vec1) / (vec1.magnitude() * vec2.magnitude()));
+			angle_sum += angle;
+		}
+
+		if(angle_sum > M_2_PI * 0.8){ // Not likely to be a full cell if angle_sum is less than 80% of 2*Pi
+			for(j = 0; j < edgesOnCell.at(iCell).size(); j++){
+				iEdge = edgesOnCell.at(iCell).at(j);
+
+				if(cellsOnEdge.at(iEdge).at(0) == iCell){
+					vertex1 = verticesOnEdge.at(iEdge).at(0);
+					vertex2 = verticesOnEdge.at(iEdge).at(1);
+				} else {
+					vertex1 = verticesOnEdge.at(iEdge).at(1);
+					vertex2 = verticesOnEdge.at(iEdge).at(0);
+				}
+
+				vert_loc1 = vertices.at(vertex1);
+				vert_loc2 = vertices.at(vertex2);
+
+				if(!spherical){
+					vert_loc1.fixPeriodicity(cells.at(iCell), xPeriodicFix, yPeriodicFix);
+					vert_loc2.fixPeriodicity(cells.at(iCell), xPeriodicFix, yPeriodicFix);
+					areaCell.at(iCell) += planarTriangleArea(cells.at(iCell), vert_loc1, vert_loc2);
+				} else {
+					areaCell.at(iCell) += sphericalTriangleArea(cells.at(iCell), vert_loc1, vert_loc2);
+				}
+			}
+		} else {
+			cout << "   Non complete cell found at " << iCell << endl;
+			cout << "   angles (rad) sum to " << angle_sum << endl;
+			cout << "   angles (deg) sum to " << angle_sum*180.0/M_PI << endl;
+			areaCell.at(iCell) = -1;
+		}
+	}
+
+	for(iVertex = 0; iVertex < vertices.size(); iVertex++){
+		areaTriangle.at(iVertex) = 0.0;
+		kiteAreasOnVertex.at(iVertex).resize(cellsOnVertex.at(iVertex).size());
+		for(j = 0; j < cellsOnVertex.at(iVertex).size(); j++){
+			kiteAreasOnVertex.at(iVertex).at(j) = 0.0;
+			iCell = cellsOnVertex.at(iVertex).at(j);
+
+			if(iCell != -1){
+				edge1 = edgesOnVertex.at(iVertex).at(j);
+
+				if(j == cellsOnVertex.at(iVertex).size()-1){
+					edge2 = edgesOnVertex.at(iVertex).at(0);
+				} else {
+					edge2 = edgesOnVertex.at(iVertex).at(j+1);
+				}
+
+				cell_loc = cells.at(iCell);
+				edge_loc1 = edges.at(edge1);
+				edge_loc2 = edges.at(edge2);
+
+				if(!spherical){
+					cell_loc.fixPeriodicity(vertices.at(iVertex), xPeriodicFix, yPeriodicFix);
+					edge_loc1.fixPeriodicity(vertices.at(iVertex), xPeriodicFix, yPeriodicFix);
+					edge_loc2.fixPeriodicity(vertices.at(iVertex), xPeriodicFix, yPeriodicFix);
+					kiteAreasOnVertex.at(iVertex).at(j) += planarTriangleArea(vertices.at(iVertex), edge_loc1, cell_loc);
+					kiteAreasOnVertex.at(iVertex).at(j) += planarTriangleArea(vertices.at(iVertex), cell_loc, edge_loc2);
+				} else {
+					kiteAreasOnVertex.at(iVertex).at(j) += sphericalTriangleArea(vertices.at(iVertex), edge_loc1, cell_loc);
+					kiteAreasOnVertex.at(iVertex).at(j) += sphericalTriangleArea(vertices.at(iVertex), cell_loc, edge_loc2);
+				}
+
+				areaTriangle.at(iVertex) += kiteAreasOnVertex.at(iVertex).at(j);
+			}
+		}
+	}
+
+	return 0;
+}/*}}}*/
+int buildEdgesOnEdgeArrays(){/*{{{*/
+	/*
+	 * buildEdgesOnEdgeArrays builds both edgesOnEdge and weightsOnEdge
+	 *
+	 * The weights correspond to edgesOnEdge and allow MPAS to reconstruct the
+	 * edge perpendicular (previously defined as v) velocity using the edge
+	 * neighbors
+	 *
+	 * Weight formulation is defined in J. Thurburn, et al. JCP 2009
+	 * Numerical representation of geostrophic modes on arbitrarily
+	 * structured C-grids
+	 *
+	 * Before using this function, dcEdge, dvEdge, areaCell, and kiteAreasOnVertex
+	 * all need to be computed correctly.
+	 */
+	int iEdge, iCell, cell1, cell2;
+	int i, j, k;
+	int shared_vertex;
+	int last_edge, cur_edge;
+	double area_sum;
+	bool found;
+
+#ifdef _DEBUG
+	cout << endl << endl << "Begin function: buildEdgesOnEdgeArrays" << endl << endl;
+#endif
+
+	edgesOnEdge.clear();
+	edgesOnEdge.resize(edges.size());
+
+	weightsOnEdge.clear();
+	weightsOnEdge.resize(edges.size());
+
+	for(iEdge = 0; iEdge < edges.size(); iEdge++){
+#ifdef _DEBUG
+		cout << "New edge: " << edges.at(iEdge) << endl;
+#endif
+		cell1 = cellsOnEdge.at(iEdge).at(0);
+		cell2 = cellsOnEdge.at(iEdge).at(1);
+		found = false;
+
+		// Loop over cell 1. Starting from the edge after the current edge, add
+		// all edges counter clockwise around the cell.  Don't add the current
+		// edge to the list.
+#ifdef _DEBUG
+		cout << "   On cell1: " << cell1 << endl;
+#endif
+		last_edge = iEdge;
+		area_sum = 0;
+		for(i = 0; i < edgesOnCell.at(cell1).size(); i++){
+#ifdef _DEBUG
+			cout << "      checking edge: " << edgesOnCell.at(cell1).at(i) << endl;
+#endif
+			if(edgesOnCell.at(cell1).at(i) == iEdge){
+				found = true;
+#ifdef _DEBUG
+				cout << "        -- found -- " << endl;
+#endif
+			}
+
+			if(found && edgesOnCell.at(cell1).at(i) != iEdge){
+				cur_edge = edgesOnCell.at(cell1).at(i);
+				edgesOnEdge.at(iEdge).push_back(cur_edge);
+
+				// Find shared vertex between newly added edge
+				// and last_edge
+				if(verticesOnEdge.at(last_edge).at(0) == verticesOnEdge.at(cur_edge).at(0) ||
+						verticesOnEdge.at(last_edge).at(0) == verticesOnEdge.at(cur_edge).at(1)){
+
+					shared_vertex = verticesOnEdge.at(last_edge).at(0);
+
+				} else if(verticesOnEdge.at(last_edge).at(1) == verticesOnEdge.at(cur_edge).at(0) ||
+						verticesOnEdge.at(last_edge).at(1) == verticesOnEdge.at(cur_edge).at(1)){
+
+					shared_vertex = verticesOnEdge.at(last_edge).at(1);
+				}
+
+				// Find cell 1 on shared vertex (to get kite area)
+				for(j = 0; j < cellsOnVertex.at(shared_vertex).size(); j++){
+					iCell = cellsOnVertex.at(shared_vertex).at(j);
+
+					if(iCell == cell1){
+						area_sum += kiteAreasOnVertex.at(shared_vertex).at(j) / areaCell.at(cell1);
+					}
+				}
+
+				if(cell1 == cellsOnEdge.at(cur_edge).at(0)){
+					weightsOnEdge.at(iEdge).push_back( 1.0 * (0.5 - area_sum) * dvEdge.at(cur_edge) / dcEdge.at(iEdge) );
+				} else {
+					weightsOnEdge.at(iEdge).push_back( -1.0 * (0.5 - area_sum) * dvEdge.at(cur_edge) / dcEdge.at(iEdge) );
+				}
+
+				last_edge = edgesOnCell.at(cell1).at(i);
+#ifdef _DEBUG
+				cout << "        added " << edgesOnCell.at(cell1).at(i) << endl;
+#endif
+			}
+		}
+		if(!found) {
+			cout << "Error finding edge " << iEdge << " on cell " << cell1 << " 1" << endl;
+			return 1;
+		}
+
+		for(i = 0; i < edgesOnCell.at(cell1).size() && found; i++){
+#ifdef _DEBUG
+			cout << "      checking edge: " << edgesOnCell.at(cell1).at(i) << endl;
+#endif
+			if(edgesOnCell.at(cell1).at(i) == iEdge){
+#ifdef _DEBUG
+				cout << "        -- found -- " << endl;
+#endif
+				found = false;
+			}
+
+			if(found && edgesOnCell.at(cell1).at(i) != iEdge){
+				cur_edge = edgesOnCell.at(cell1).at(i);
+				edgesOnEdge.at(iEdge).push_back(cur_edge);
+
+				// Find shared vertex between newly added edge
+				// and last_edge
+				if(verticesOnEdge.at(last_edge).at(0) == verticesOnEdge.at(cur_edge).at(0) ||
+						verticesOnEdge.at(last_edge).at(0) == verticesOnEdge.at(cur_edge).at(1)){
+
+					shared_vertex = verticesOnEdge.at(last_edge).at(0);
+
+				} else if(verticesOnEdge.at(last_edge).at(1) == verticesOnEdge.at(cur_edge).at(0) ||
+						verticesOnEdge.at(last_edge).at(1) == verticesOnEdge.at(cur_edge).at(1)){
+
+					shared_vertex = verticesOnEdge.at(last_edge).at(1);
+				}
+
+				// Find cell 1 on shared vertex (to get kite area)
+				for(j = 0; j < cellsOnVertex.at(shared_vertex).size(); j++){
+					iCell = cellsOnVertex.at(shared_vertex).at(j);
+
+					if(iCell == cell1){
+						area_sum += kiteAreasOnVertex.at(shared_vertex).at(j) / areaCell.at(cell1);
+					}
+				}
+
+				if(cell1 == cellsOnEdge.at(cur_edge).at(0)){
+					weightsOnEdge.at(iEdge).push_back( 1.0 * (0.5 - area_sum) * dvEdge.at(cur_edge) / dcEdge.at(iEdge) );
+				} else {
+					weightsOnEdge.at(iEdge).push_back( -1.0 * (0.5 - area_sum) * dvEdge.at(cur_edge) / dcEdge.at(iEdge) );
+				}
+
+				last_edge = edgesOnCell.at(cell1).at(i);
+#ifdef _DEBUG
+				cout << "        added " << edgesOnCell.at(cell1).at(i) << endl;
+#endif
+			}
+		}
+		if(found) {
+			cout << "Error finding edge " << iEdge << " on cell " << cell1 << " 1" << endl;
+			return 1;
+		}
+
+		// Check if cell1 is a real cell or not.
+		if(cell2 > -1){
+			last_edge = iEdge;
+			area_sum = 0.0;
+#ifdef _DEBUG
+			cout << "   On cell2: " << cell2 << endl;
+#endif
+			found = false;
+			// Loop over cell 2. Starting from the edge after the current edge,
+			// add all edges counter clockwise around the cell.  Don't add the
+			// current edge to the list.
+			for(i = 0; i < edgesOnCell.at(cell2).size(); i++){
+#ifdef _DEBUG
+				cout << "      checking edge: " << edgesOnCell.at(cell2).at(i) << endl;
+#endif
+				if(edgesOnCell.at(cell2).at(i) == iEdge){
+					found = true;
+#ifdef _DEBUG
+					cout << "        -- found -- " << endl;
+#endif
+				}
+
+				if(found && edgesOnCell.at(cell2).at(i) != iEdge){
+					cur_edge = edgesOnCell.at(cell2).at(i);
+					edgesOnEdge.at(iEdge).push_back(cur_edge);
+
+					// Find shared vertex between newly added edge
+					// and last_edge
+					if(verticesOnEdge.at(last_edge).at(0) == verticesOnEdge.at(cur_edge).at(0) ||
+							verticesOnEdge.at(last_edge).at(0) == verticesOnEdge.at(cur_edge).at(1)){
+
+						shared_vertex = verticesOnEdge.at(last_edge).at(0);
+
+					} else if(verticesOnEdge.at(last_edge).at(1) == verticesOnEdge.at(cur_edge).at(0) ||
+							verticesOnEdge.at(last_edge).at(1) == verticesOnEdge.at(cur_edge).at(1)){
+
+						shared_vertex = verticesOnEdge.at(last_edge).at(1);
+					}
+
+					// Find cell 1 on shared vertex (to get kite area)
+					for(j = 0; j < cellsOnVertex.at(shared_vertex).size(); j++){
+						iCell = cellsOnVertex.at(shared_vertex).at(j);
+
+						if(iCell == cell2){
+							area_sum += kiteAreasOnVertex.at(shared_vertex).at(j) / areaCell.at(cell2);
+						}
+					}
+
+					if(cell1 == cellsOnEdge.at(cur_edge).at(0)){
+						weightsOnEdge.at(iEdge).push_back( 1.0 * (0.5 - area_sum) * dvEdge.at(cur_edge) / dcEdge.at(iEdge) );
+					} else {
+						weightsOnEdge.at(iEdge).push_back( -1.0 * (0.5 - area_sum) * dvEdge.at(cur_edge) / dcEdge.at(iEdge) );
+					}
+
+					last_edge = edgesOnCell.at(cell2).at(i);
+#ifdef _DEBUG
+					cout << "        added " << edgesOnCell.at(cell2).at(i) << endl;
+#endif
+				}
+			}
+			if(!found) {
+				cout << "Error finding edge " << iEdge << " on cell " << cell2 << " 2" << endl;
+				return 1;
+			}
+
+			for(i = 0; i < edgesOnCell.at(cell2).size(); i++){
+#ifdef _DEBUG
+				cout << "      checking edge: " << edgesOnCell.at(cell2).at(i) << endl;
+#endif
+				if(edgesOnCell.at(cell2).at(i) == iEdge){
+					found = false;
+#ifdef _DEBUG
+					cout << "        -- found -- " << endl;
+#endif
+				}
+
+				if(found && edgesOnCell.at(cell2).at(i) != iEdge){
+					cur_edge = edgesOnCell.at(cell2).at(i);
+					edgesOnEdge.at(iEdge).push_back(cur_edge);
+
+					// Find shared vertex between newly added edge
+					// and last_edge
+					if(verticesOnEdge.at(last_edge).at(0) == verticesOnEdge.at(cur_edge).at(0) ||
+							verticesOnEdge.at(last_edge).at(0) == verticesOnEdge.at(cur_edge).at(1)){
+
+						shared_vertex = verticesOnEdge.at(last_edge).at(0);
+
+					} else if(verticesOnEdge.at(last_edge).at(1) == verticesOnEdge.at(cur_edge).at(0) ||
+							verticesOnEdge.at(last_edge).at(1) == verticesOnEdge.at(cur_edge).at(1)){
+
+						shared_vertex = verticesOnEdge.at(last_edge).at(1);
+					}
+
+					// Find cell 1 on shared vertex (to get kite area)
+					for(j = 0; j < cellsOnVertex.at(shared_vertex).size(); j++){
+						iCell = cellsOnVertex.at(shared_vertex).at(j);
+
+						if(iCell == cell2){
+							area_sum += kiteAreasOnVertex.at(shared_vertex).at(j) / areaCell.at(cell2);
+						}
+					}
+
+					if(cell1 == cellsOnEdge.at(cur_edge).at(0)){
+						weightsOnEdge.at(iEdge).push_back( 1.0 * (0.5 - area_sum) * dvEdge.at(cur_edge) / dcEdge.at(iEdge) );
+					} else {
+						weightsOnEdge.at(iEdge).push_back( -1.0 * (0.5 - area_sum) * dvEdge.at(cur_edge) / dcEdge.at(iEdge) );
+					}
+
+					last_edge = edgesOnCell.at(cell2).at(i);
+#ifdef _DEBUG
+					cout << "        added " << edgesOnCell.at(cell2).at(i) << endl;
+#endif
+				}
+			}
+			if(found) {
+				cout << "Error finding edge " << iEdge << " on cell " << cell2 << " 2" << endl;
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}/*}}}*/
+int buildAngleEdge(){/*{{{*/
+	/*
+	 * buildAngleEdge constructs angle edge for each edge.
+	 *
+	 * angleEdge is either:
+	 * 1. The angle the positive tangential direction (v)
+	 *    makes with the local northward direction.
+	 *    or
+	 * 2. The angles the positive normal direction (u)
+	 * 	  makes with the local eastward direction.
+	 * 	  
+	 * 	  In a plane, local eastward is defined as the x axis, and
+	 * 	  nortward is defined as the y axis.
+	 */
+	int iEdge;
+	int cell1, cell2;
+	int vertex1, vertex2;
+	pnt np, x_axis, normal;
+	pnt cell_loc1, cell_loc2;
+	pnt vertex_loc1, vertex_loc2;
+	double angle, sign;
+
+#ifdef _DEBUG
+	cout << endl << endl << "Begin function: buildAngleEdge" << endl << endl;
+#endif
+
+	angleEdge.clear();
+	angleEdge.resize(edges.size());
+
+	x_axis = pnt(1.0, 0.0, 0.0);
+
+	for(iEdge = 0; iEdge < edges.size(); iEdge++){
+
+#ifdef _DEBUG
+		cout << "New edge: " << edges.at(iEdge) << endl;
+#endif
+		cell1 = cellsOnEdge.at(iEdge).at(0);
+		cell2 = cellsOnEdge.at(iEdge).at(1);
+
+		vertex1 = verticesOnEdge.at(iEdge).at(0);
+		vertex2 = verticesOnEdge.at(iEdge).at(1);
+
+		cell_loc1 = cells.at(cell1);
+		if(cell2 != -1){
+			cell_loc2 = cells.at(cell2);
+		} else {
+			cell_loc2 = edges.at(iEdge);
+		}
+
+		vertex_loc1 = vertices.at(vertex1);
+		vertex_loc2 = vertices.at(vertex2);
+
+		if(!spherical){
+			cell_loc2.fixPeriodicity(cell_loc1, xPeriodicFix, yPeriodicFix);	
+
+			normal = cell_loc2 - cell_loc1;
+			angleEdge.at(iEdge) = acos( x_axis.dot(normal) / (x_axis.magnitude() * normal.magnitude()));
+		} else {
+
+			np = pntFromLatLon(edges.at(iEdge).getLat()+0.05, edges.at(iEdge).getLon());
+			np.normalize();
+
+#ifdef _DEBUG
+			cout << "     NP: " << np << endl;
+#endif
+
+			angle = (vertex_loc2.getLat() - vertex_loc1.getLat()) / dvEdge.at(iEdge);
+			angle = max( min(angle, 1.0), -1.0);
+			angle = acos(angle);
+
+#ifdef _DEBUG
+			cout << "  angle: " << angle << endl;
+#endif
+
+			sign = planeAngle(edges.at(iEdge), np, vertex_loc2, edges.at(iEdge));
+			if(sign != 0.0){
+				sign = sign / fabs(sign);
+			} else {
+				sign = 1.0;
+			}
+
+
+#ifdef _DEBUG
+			cout << "  sign : " << sign << endl;
+			cout << "  a*s  : " << angle * sign << endl;
+#endif
+
+			angle = angle * sign;
+			if(angle > M_PI) angle = angle - 2.0 * M_PI;
+			if(angle < -M_PI) angle = angle + 2.0 * M_PI;
+
+#ifdef _DEBUG
+			cout << " fangle: " << angle << endl;
+#endif
+
+			angleEdge.at(iEdge) = angle;
+		}
+	}
+
+	return 0;
+}/*}}}*/
+/*}}}*/
+
+/* Output functions {{{*/
+int outputGridDimensions( const string outputFilename ){/*{{{*/
+	/************************************************************************
+	 *
+	 * This function writes the grid dimensions to the netcdf file named
+	 * outputFilename
+	 *
+	 * **********************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Replace, NULL, 0, NcFile::Offset64Bits);
+
+	int junk;
+
+	nCells = cells.size();
+
+	/*
+	for(vec_int_itr = edgesOnCell.begin(); vec_int_itr != edgesOnCell.end(); ++vec_int_itr){
+		maxEdges = std::max(maxEdges, (int)(*vec_int_itr).size());	
+	}*/
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// define dimensions
+	NcDim *nCellsDim;
+	NcDim *nEdgesDim;
+	NcDim *nVerticesDim;
+	NcDim *maxEdgesDim;
+	NcDim *maxEdges2Dim;
+	NcDim *TWODim;
+	NcDim *THREEDim;
+	NcDim *vertexDegreeDim;
+	NcDim *timeDim;
+	
+	// write dimensions
+	if (!(nCellsDim =		grid.add_dim(	"nCells",		cells.size())		)) return NC_ERR;
+	if (!(nEdgesDim =		grid.add_dim(	"nEdges",		edges.size())		)) return NC_ERR;
+	if (!(nVerticesDim =	grid.add_dim(	"nVertices",	vertices.size())	)) return NC_ERR;
+	if (!(maxEdgesDim =		grid.add_dim(	"maxEdges",		maxEdges)			)) return NC_ERR;
+	if (!(maxEdges2Dim =	grid.add_dim(	"maxEdges2",	maxEdges*2)			)) return NC_ERR;
+	if (!(TWODim =			grid.add_dim(	"TWO",			2)					)) return NC_ERR;
+	if (!(vertexDegreeDim = grid.add_dim(   "vertexDegree", vertex_degree)		)) return NC_ERR;
+	if (!(timeDim = 		grid.add_dim(   "Time")								)) return NC_ERR;
+
+	grid.close();
+	
+	// file closed when file obj goes out of scope
+	return 0;
+}/*}}}*/
+int outputGridAttributes( const string outputFilename, const string inputFilename ){/*{{{*/
+	/************************************************************************
+	 *
+	 * This function writes the grid dimensions to the netcdf file named
+	 * outputFilename
+	 *
+	 * **********************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	NcBool sphereAtt, radiusAtt;
+	NcBool history, id, spec, conventions, source, parent_id;
+	string history_str = "";
+	string id_str = "";
+	string parent_str ="";
+	
+	// write attributes
+	if(!spherical){
+		if (!(sphereAtt = grid.add_att(   "on_a_sphere", "NO\0"))) return NC_ERR;
+		if (!(radiusAtt = grid.add_att(   "sphere_radius", 0.0))) return NC_ERR;
+	} else {
+		if (!(sphereAtt = grid.add_att(   "on_a_sphere", "YES\0"))) return NC_ERR;
+		if (!(radiusAtt = grid.add_att(   "sphere_radius", 1.0))) return NC_ERR;
+	}
+
+	history_str += "MpasMeshConverter.x ";
+	history_str += inputFilename;
+	history_str += " ";
+	history_str += outputFilename;
+	if(in_history != ""){
+		history_str += "\n";
+		history_str += in_history;
+	}
+
+	if(in_mesh_id != "" ){
+		parent_str = in_mesh_id;
+		if(in_parent_id != ""){
+			parent_str += "\n";
+			parent_str += in_parent_id;
+		}
+		if (!(id = grid.add_att(   "parent_id", parent_str.c_str() ))) return NC_ERR;
+	}
+	id_str = gen_random(ID_LEN);
+
+	if (!(history = grid.add_att(   "history", history_str.c_str() ))) return NC_ERR;
+	if (!(spec = grid.add_att(   "mesh_spec", (double)MESH_SPEC ))) return NC_ERR;
+	if (!(conventions = grid.add_att(   "Conventions", "MPAS" ))) return NC_ERR;
+	if (!(source = grid.add_att(   "source", "MpasMeshConverter.x" ))) return NC_ERR;
+	if (!(id = grid.add_att(   "mesh_id", id_str.c_str() ))) return NC_ERR;
+
+	grid.close();
+	
+	// file closed when file obj goes out of scope
+	return 0;
+}/*}}}*/
+int outputGridCoordinates( const string outputFilename) {/*{{{*/
+	/************************************************************************
+	 *
+	 * This function writes the grid coordinates to the netcdf file named
+	 * outputFilename
+	 * This includes all cell centers, vertices, and edges.
+	 * Both cartesian and lat,lon, as well as all of their indices
+	 *
+	 * **********************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nCellsDim = grid.get_dim( "nCells" );
+	NcDim *nEdgesDim = grid.get_dim( "nEdges" );
+	NcDim *nVerticesDim = grid.get_dim( "nVertices" );
+
+	int nCells = nCellsDim->size();
+	int nEdges = nEdgesDim->size();
+	int nVertices = nVerticesDim->size();
+
+	//Define nc variables
+	NcVar *xCellVar, *yCellVar, *zCellVar, *xEdgeVar, *yEdgeVar, *zEdgeVar, *xVertexVar, *yVertexVar, *zVertexVar;
+	NcVar *lonCellVar, *latCellVar, *lonEdgeVar, *latEdgeVar, *lonVertexVar, *latVertexVar;
+	NcVar *idx2cellVar, *idx2edgeVar, *idx2vertexVar;
+
+	int i;
+	
+	double *x, *y, *z, *lat, *lon;
+	int *idxTo;
+
+	// Build and write cell coordinate arrays
+	x = new double[nCells];
+	y = new double[nCells];
+	z = new double[nCells];
+	lat = new double[nCells];
+	lon = new double[nCells];
+	idxTo = new int[nCells];
+	i = 0;
+	for(pnt_itr = cells.begin(); pnt_itr != cells.end(); ++pnt_itr){
+		x[i] = (*pnt_itr).x;
+		y[i] = (*pnt_itr).y;
+		z[i] = (*pnt_itr).z;
+		if(!spherical){
+			lat[i] = 0.0;
+			lon[i] = 0.0;
+		} else {
+			lat[i] = (*pnt_itr).getLat();
+			lon[i] = (*pnt_itr).getLon();
+		}
+		idxTo[i] = (*pnt_itr).idx+1;
+
+		i++;
+	}
+	if (!(latCellVar = grid.add_var("latCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!latCellVar->put(lat,nCells)) return NC_ERR;
+	if (!(lonCellVar = grid.add_var("lonCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!lonCellVar->put(lon,nCells)) return NC_ERR;
+	if (!(xCellVar = grid.add_var("xCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!xCellVar->put(x,nCells)) return NC_ERR;
+	if (!(yCellVar = grid.add_var("yCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!yCellVar->put(y,nCells)) return NC_ERR;
+	if (!(zCellVar = grid.add_var("zCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!zCellVar->put(z,nCells)) return NC_ERR;
+	if (!(idx2cellVar = grid.add_var("indexToCellID", ncInt, nCellsDim))) return NC_ERR;
+	if (!idx2cellVar->put(idxTo,nCells)) return NC_ERR;
+	delete[] x;
+	delete[] y;
+	delete[] z;
+	delete[] lat;
+	delete[] lon;
+	delete[] idxTo;
+	
+	//Build and write edge coordinate arrays
+	x = new double[nEdges];
+	y = new double[nEdges];
+	z = new double[nEdges];
+	lat = new double[nEdges];
+	lon = new double[nEdges];
+	idxTo = new int[nEdges];
+
+	i = 0;
+	for(pnt_itr = edges.begin(); pnt_itr != edges.end(); ++pnt_itr){
+		x[i] = (*pnt_itr).x;
+		y[i] = (*pnt_itr).y;
+		z[i] = (*pnt_itr).z;
+		if(!spherical){
+			lat[i] = 0.0;
+			lon[i] = 0.0;
+		} else {
+			lat[i] = (*pnt_itr).getLat();
+			lon[i] = (*pnt_itr).getLon();
+		}
+		idxTo[i] = (*pnt_itr).idx+1;
+
+		i++;
+	}
+	if (!(latEdgeVar = grid.add_var("latEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!latEdgeVar->put(lat,nEdges)) return NC_ERR;
+	if (!(lonEdgeVar = grid.add_var("lonEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!lonEdgeVar->put(lon,nEdges)) return NC_ERR;
+	if (!(xEdgeVar = grid.add_var("xEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!xEdgeVar->put(x,nEdges)) return NC_ERR;
+	if (!(yEdgeVar = grid.add_var("yEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!yEdgeVar->put(y,nEdges)) return NC_ERR;
+	if (!(zEdgeVar = grid.add_var("zEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!zEdgeVar->put(z,nEdges)) return NC_ERR;
+	if (!(idx2edgeVar = grid.add_var("indexToEdgeID", ncInt, nEdgesDim))) return NC_ERR;
+	if (!idx2edgeVar->put(idxTo, nEdges)) return NC_ERR;
+	delete[] x;
+	delete[] y;
+	delete[] z;
+	delete[] lat;
+	delete[] lon;
+	delete[] idxTo;
+
+	//Build and write vertex coordinate arrays
+	x = new double[nVertices];
+	y = new double[nVertices];
+	z = new double[nVertices];
+	lat = new double[nVertices];
+	lon = new double[nVertices];
+	idxTo = new int[nVertices];
+
+	i = 0;
+	for(pnt_itr = vertices.begin(); pnt_itr != vertices.end(); ++pnt_itr){
+		x[i] = (*pnt_itr).x;
+		y[i] = (*pnt_itr).y;
+		z[i] = (*pnt_itr).z;
+		if(!spherical){
+			lat[i] = 0.0;
+			lon[i] = 0.0;
+		} else {
+			lat[i] = (*pnt_itr).getLat();
+			lon[i] = (*pnt_itr).getLon();
+		}
+		idxTo[i] = (*pnt_itr).idx+1;
+
+		i++;
+	}
+	if (!(latVertexVar = grid.add_var("latVertex", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!latVertexVar->put(lat,nVertices)) return NC_ERR;
+	if (!(lonVertexVar = grid.add_var("lonVertex", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!lonVertexVar->put(lon,nVertices)) return NC_ERR;
+	if (!(xVertexVar = grid.add_var("xVertex", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!xVertexVar->put(x,nVertices)) return NC_ERR;
+	if (!(yVertexVar = grid.add_var("yVertex", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!yVertexVar->put(y,nVertices)) return NC_ERR;
+	if (!(zVertexVar = grid.add_var("zVertex", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!zVertexVar->put(z,nVertices)) return NC_ERR;
+	if (!(idx2vertexVar = grid.add_var("indexToVertexID", ncInt, nVerticesDim))) return NC_ERR;
+	if (!idx2vertexVar->put(idxTo, nVertices)) return NC_ERR;
+	delete[] x;
+	delete[] y;
+	delete[] z;
+	delete[] lat;
+	delete[] lon;
+	delete[] idxTo;
+
+	grid.close();
+
+	return 0;
+}/*}}}*/
+int outputCellConnectivity( const string outputFilename) {/*{{{*/
+	/*****************************************************************
+	 *
+	 * This function writes all of the *OnCell arrays. Including
+	 * cellsOnCell
+	 * edgesOnCell
+	 * verticesOnCell
+	 * nEdgesonCell
+	 *
+	 * ***************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nCellsDim = grid.get_dim( "nCells" );
+	NcDim *maxEdgesDim = grid.get_dim( "maxEdges" );
+
+	int nCells = nCellsDim->size();
+	int maxEdges = maxEdgesDim->size();
+	int i, j;
+
+	// define nc variables
+	NcVar *cocVar, *nEocVar, *eocVar, *vocVar;
+
+	int *tmp_arr;
+	
+	// Build and write COC array
+	tmp_arr = new int[nCells*maxEdges];
+
+	for(i = 0; i < nCells; i++){
+		for(j = 0; j < maxEdges; j++){
+			tmp_arr[i*maxEdges + j] = 0;
+		}
+	}
+
+	i = 0;
+	for(vec_int_itr = cellsOnCell.begin(); vec_int_itr != cellsOnCell.end(); ++vec_int_itr){
+		j = 0;
+		for(int_itr = (*vec_int_itr).begin(); int_itr != (*vec_int_itr).end(); ++int_itr){
+			tmp_arr[i*maxEdges + j] = (*int_itr) + 1;
+			j++;
+		}
+		i++;
+	}
+	if (!(cocVar = grid.add_var("cellsOnCell", ncInt, nCellsDim, maxEdgesDim))) return NC_ERR;
+	if (!cocVar->put(tmp_arr,nCells,maxEdges)) return NC_ERR;
+
+	// Build and write EOC array
+	for(i = 0; i < nCells; i++){
+		for(j = 0; j < maxEdges; j++){
+			tmp_arr[i*maxEdges + j] = 0;
+		}
+	}
+
+	i = 0;
+	for(vec_int_itr = edgesOnCell.begin(); vec_int_itr != edgesOnCell.end(); ++vec_int_itr){
+		j = 0;
+		for(int_itr = (*vec_int_itr).begin(); int_itr != (*vec_int_itr).end(); ++int_itr){
+			tmp_arr[i*maxEdges + j] = (*int_itr) + 1;	
+			j++;
+		}
+
+		i++;
+	}
+
+	if (!(eocVar = grid.add_var("edgesOnCell", ncInt, nCellsDim, maxEdgesDim))) return NC_ERR;
+	if (!eocVar->put(tmp_arr,nCells,maxEdges)) return NC_ERR;
+
+	// Build and write VOC array 
+	for(i = 0; i < nCells; i++){
+		for(j = 0; j < maxEdges; j++){
+			tmp_arr[i*maxEdges + j] = 0;
+		}
+	}
+
+	i = 0;
+	for(vec_int_itr = verticesOnCell.begin(); vec_int_itr != verticesOnCell.end(); ++vec_int_itr){
+		j = 0;
+		for(int_itr = (*vec_int_itr).begin(); int_itr != (*vec_int_itr).end(); ++int_itr){
+			tmp_arr[i*maxEdges + j] = (*int_itr) + 1;	
+			j++;
+		}
+		i++;
+	}
+
+	if (!(vocVar = grid.add_var("verticesOnCell", ncInt, nCellsDim, maxEdgesDim))) return NC_ERR;
+	if (!vocVar->put(tmp_arr,nCells,maxEdges)) return NC_ERR;
+	delete[] tmp_arr;
+
+	//Build and write nEOC array
+	tmp_arr = new int[nCells];
+
+	i = 0;
+	for(vec_int_itr = edgesOnCell.begin(); vec_int_itr != edgesOnCell.end(); ++vec_int_itr){
+		tmp_arr[i] = (*vec_int_itr).size();
+		i++;
+	}
+
+	if (!(nEocVar = grid.add_var("nEdgesOnCell", ncInt, nCellsDim))) return NC_ERR;
+	if (!nEocVar->put(tmp_arr,nCells)) return NC_ERR;
+	verticesOnCell.clear();
+	edgesOnCell.clear();
+
+	delete[] tmp_arr;
+
+	return 0;
+}/*}}}*/
+int outputEdgeConnectivity( const string outputFilename) {/*{{{*/
+	/*****************************************************************
+	 *
+	 * This function writes all of the *OnEdge arrays. Including
+	 * cellsOnEdge
+	 * edgesOnEdge
+	 * verticesOnEdge
+	 * nEdgesOnEdge
+	 *
+	 * ***************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nEdgesDim = grid.get_dim( "nEdges" );
+	NcDim *maxEdges2Dim = grid.get_dim( "maxEdges2" );
+	NcDim *vertexDegreeDim = grid.get_dim( "vertexDegree" );
+	NcDim *twoDim = grid.get_dim( "TWO" );
+
+	// define nc variables
+	NcVar *coeVar, *nEoeVar, *eoeVar, *voeVar;
+
+	int nEdges = nEdgesDim->size();
+	int maxEdges2 = maxEdges2Dim->size();
+	int vertexDegree = vertexDegreeDim->size();
+	int two = twoDim->size();
+	int i, j;
+
+	int *tmp_arr;
+
+	// Build and write EOE array
+	tmp_arr = new int[nEdges*maxEdges2];
+
+	for(i = 0; i < nEdges; i++){
+		for(j = 0; j < maxEdges2; j++){
+			tmp_arr[i*maxEdges2 + j] = 0;
+		}
+	}
+
+	i = 0;
+	for(vec_int_itr = edgesOnEdge.begin(); vec_int_itr != edgesOnEdge.end(); ++vec_int_itr){
+		j = 0;
+		for(int_itr = (*vec_int_itr).begin(); int_itr != (*vec_int_itr).end(); ++int_itr){
+			tmp_arr[i*maxEdges2 + j] = (*int_itr) + 1;	
+			j++;
+		}
+
+		i++;
+	}
+
+	if (!(eoeVar = grid.add_var("edgesOnEdge", ncInt, nEdgesDim, maxEdges2Dim))) return NC_ERR;
+	if (!eoeVar->put(tmp_arr,nEdges,maxEdges2)) return NC_ERR;
+	delete[] tmp_arr;
+
+	// Build and write COE array
+	tmp_arr = new int[nEdges*two];
+	for(i = 0; i < nEdges; i++){
+		for(j = 0; j < two; j++){
+			tmp_arr[i*two + j] = 0;
+		}
+	}
+	i = 0;
+	for(vec_int_itr = cellsOnEdge.begin(); vec_int_itr != cellsOnEdge.end(); ++vec_int_itr){
+		j = 0;
+		for(int_itr = (*vec_int_itr).begin(); int_itr != (*vec_int_itr).end(); ++int_itr){
+			tmp_arr[i*two + j] = (*int_itr) + 1;	
+			j++;
+		}
+
+		i++;
+	}
+
+	if (!(coeVar = grid.add_var("cellsOnEdge", ncInt, nEdgesDim, twoDim))) return NC_ERR;
+	if (!coeVar->put(tmp_arr,nEdges,two)) return NC_ERR;
+
+	// Build VOE array
+	i = 0;
+	for(vec_int_itr = verticesOnEdge.begin(); vec_int_itr != verticesOnEdge.end(); ++vec_int_itr){
+		j = 0;
+		for(int_itr = (*vec_int_itr).begin(); int_itr != (*vec_int_itr).end(); ++int_itr){
+			tmp_arr[i*two + j] = (*int_itr) + 1;	
+			j++;
+		}
+
+		i++;
+	}
+
+	if (!(voeVar = grid.add_var("verticesOnEdge", ncInt, nEdgesDim, twoDim))) return NC_ERR;
+	if (!voeVar->put(tmp_arr,nEdges,two)) return NC_ERR;
+	delete[] tmp_arr;
+
+	// Build and write nEoe array
+	tmp_arr = new int[nEdges];
+	i = 0;
+	for(vec_int_itr = edgesOnEdge.begin(); vec_int_itr != edgesOnEdge.end(); ++vec_int_itr){
+		tmp_arr[i] = (*vec_int_itr).size();
+		i++;
+	}
+
+	if (!(nEoeVar = grid.add_var("nEdgesOnEdge", ncInt, nEdgesDim))) return NC_ERR;
+	if (!nEoeVar->put(tmp_arr,nEdges)) return NC_ERR;
+
+	delete[] tmp_arr;
+
+	cellsOnEdge.clear();
+//	verticesOnEdge.clear(); // Needed for Initial conditions.
+	edgesOnEdge.clear();
+	
+	return 0;
+}/*}}}*/
+int outputVertexConnectivity( const string outputFilename) {/*{{{*/
+	/*****************************************************************
+	 *
+	 * This function writes all of the *OnVertex arrays. Including
+	 * cellsOnVertex
+	 * edgesOnVertex
+	 *
+	 * ***************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nVerticesDim = grid.get_dim( "nVertices" );
+	NcDim *vertexDegreeDim = grid.get_dim( "vertexDegree" );
+
+	// define nc variables
+	NcVar *covVar, *eovVar, *bdryVertVar;
+
+	int nVertices = nVerticesDim->size();
+	int vertexDegree = vertexDegreeDim->size();
+	int i, j;
+
+	int *tmp_arr;
+
+	// Build and write COV array
+	tmp_arr = new int[nVertices*vertexDegree];
+	
+	for(i = 0; i < nVertices; i++){
+		for(j = 0; j < vertexDegree; j++){
+			tmp_arr[i*vertexDegree + j] = 0;
+		}
+	}
+
+	i = 0;
+	for(vec_int_itr = cellsOnVertex.begin(); vec_int_itr != cellsOnVertex.end(); ++vec_int_itr){
+		j = 0;
+		for(int_itr = (*vec_int_itr).begin(); int_itr != (*vec_int_itr).end(); ++int_itr){
+			tmp_arr[i*vertexDegree + j] = (*int_itr) + 1;	
+			j++;
+		}
+		i++;
+	}
+
+	if (!(covVar = grid.add_var("cellsOnVertex", ncInt, nVerticesDim, vertexDegreeDim))) return NC_ERR;
+	if (!covVar->put(tmp_arr,nVertices,vertexDegree)) return NC_ERR;
+
+	// Build and write EOV array
+	for(i = 0; i < nVertices; i++){
+		for(j = 0; j < vertexDegree; j++){
+			tmp_arr[i*vertexDegree + j] = 0;
+		}
+	}
+	i = 0;
+	for(vec_int_itr = edgesOnVertex.begin(); vec_int_itr != edgesOnVertex.end(); ++vec_int_itr){
+		j = 0;
+		for(int_itr = (*vec_int_itr).begin(); int_itr != (*vec_int_itr).end(); ++int_itr){
+			tmp_arr[i*vertexDegree + j] = (*int_itr) + 1;	
+			j++;
+		}
+
+		i++;
+	}
+	if (!(eovVar = grid.add_var("edgesOnVertex", ncInt, nVerticesDim, vertexDegreeDim))) return NC_ERR;
+	if (!eovVar->put(tmp_arr,nVertices,vertexDegree)) return NC_ERR;
+	delete[] tmp_arr;
+
+	// Build and write bdryVert array
+	tmp_arr = new int[nVertices];
+	
+	i = 0;
+	for(vec_int_itr = cellsOnVertex.begin(); vec_int_itr != cellsOnVertex.end(); ++vec_int_itr){
+		if((*vec_int_itr).size() == vertexDegree){
+			tmp_arr[i] = 0;
+		} else {
+			tmp_arr[i] = 1;
+		}
+		i++;
+	}
+
+	if (!(bdryVertVar = grid.add_var("boundaryVertex", ncInt, nVerticesDim))) return NC_ERR;
+	if (!bdryVertVar->put(tmp_arr, nVertices)) return NC_ERR;
+
+	delete[] tmp_arr;
+
+	cellsOnVertex.clear();
+	edgesOnVertex.clear();
+
+	return 0;
+}/*}}}*/
+int outputCellParameters( const string outputFilename) {/*{{{*/
+	/*********************************************************
+	 *
+	 * This function writes all cell parameters, including
+	 * 	areaCell
+	 *
+	 * *******************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nCellsDim = grid.get_dim( "nCells" );
+
+	// define nc variables
+	NcVar *areacVar;
+
+	int nCells = nCellsDim->size();
+	int i, j;
+
+	if (!(areacVar = grid.add_var("areaCell", ncDouble, nCellsDim))) return NC_ERR;
+	if (!areacVar->put(&areaCell[0],nCells)) return NC_ERR;
+
+	areaCell.clear();
+
+	return 0;
+}/*}}}*/
+int outputVertexParameters( const string outputFilename) {/*{{{*/
+	/*********************************************************
+	 *
+	 * This function writes all vertex parameters, including
+	 * 	areaTriangle
+	 * 	kiteAreasOnVertex
+	 *
+	 * *******************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nVerticesDim = grid.get_dim( "nVertices" );
+	NcDim *vertexDegreeDim = grid.get_dim( "vertexDegree" );
+
+	// define nc variables
+	NcVar *areatVar;
+	NcVar *kareaVar;
+
+	int nVertices = nVerticesDim->size();
+	int vertexDegree = vertexDegreeDim->size();
+	int i, j;
+	int count;
+
+	double *tmp_arr;
+
+	// Build and write areaTriangle
+	if (!(areatVar = grid.add_var("areaTriangle", ncDouble, nVerticesDim))) return NC_ERR;
+	if (!areatVar->put(&areaTriangle[0],nVertices)) return NC_ERR;
+
+	// Build and write kiteAreasOnVertex
+	// TODO: Fix kite area for quads?
+	tmp_arr = new double[nVertices*vertexDegree];
+	i = 0;
+	count = 0;
+	for(vec_dbl_itr = kiteAreasOnVertex.begin(); vec_dbl_itr != kiteAreasOnVertex.end(); ++vec_dbl_itr){
+		j = 0;
+		for(dbl_itr = (*vec_dbl_itr).begin(); dbl_itr != (*vec_dbl_itr).end(); ++dbl_itr){
+			tmp_arr[i*vertexDegree + j] = (*dbl_itr);
+			j++;
+			count++;
+		}
+		i++;
+	}
+
+	if (!(kareaVar = grid.add_var("kiteAreasOnVertex", ncDouble, nVerticesDim, vertexDegreeDim))) return NC_ERR;
+	if (!kareaVar->put(tmp_arr,nVertices,vertexDegree)) return NC_ERR;
+
+	delete[] tmp_arr;
+
+	kiteAreasOnVertex.clear();
+
+	return 0;
+}/*}}}*/
+int outputEdgeParameters( const string outputFilename) {/*{{{*/
+	/*********************************************************
+	 *
+	 * This function writes all grid parameters, including
+	 *	angleEdge
+	 *	dcEdge
+	 *	dvEdge
+	 *	weightsOnEdge
+	 *
+	 * *******************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+	
+	// fetch dimensions
+	NcDim *nEdgesDim = grid.get_dim( "nEdges" );
+	NcDim *maxEdges2Dim = grid.get_dim( "maxEdges2" );
+
+	// define nc variables
+	NcVar *angleVar;
+	NcVar *kareaVar, *dcEdgeVar, *dvEdgeVar;
+	NcVar *woeVar;
+
+	int nEdges = nEdgesDim->size();
+	int maxEdges2 = maxEdges2Dim->size();
+	int i, j;
+
+	double *tmp_arr;
+
+	//Build and write angleEdge
+	if (!(angleVar = grid.add_var("angleEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!angleVar->put(&angleEdge[0],nEdges)) return NC_ERR;
+
+	//Build and write dcEdge
+	if (!(dcEdgeVar = grid.add_var("dcEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!dcEdgeVar->put(&dcEdge[0],nEdges)) return NC_ERR;
+
+	//Build and write dvEdge
+	if (!(dvEdgeVar = grid.add_var("dvEdge", ncDouble, nEdgesDim))) return NC_ERR;
+	if (!dvEdgeVar->put(&dvEdge[0],nEdges)) return NC_ERR;
+
+	//Build and write weightsOnEdge
+	tmp_arr = new double[nEdges*maxEdges2];
+
+	i = 0;
+	for(vec_dbl_itr = weightsOnEdge.begin(); vec_dbl_itr != weightsOnEdge.end(); ++vec_dbl_itr){
+		for(j = 0; j < maxEdges2; j++){
+			tmp_arr[i*maxEdges2 + j] = 0.0;
+		}
+
+		j = 0;
+		for(dbl_itr = (*vec_dbl_itr).begin(); dbl_itr != (*vec_dbl_itr).end(); ++dbl_itr){
+			tmp_arr[i*maxEdges2 + j] = (*dbl_itr);
+			j++;
+		}
+		i++;
+	}
+
+	if (!(woeVar = grid.add_var("weightsOnEdge", ncDouble, nEdgesDim, maxEdges2Dim))) return NC_ERR;
+	if (!woeVar->put(tmp_arr,nEdges,maxEdges2)) return NC_ERR;
+
+	delete[] tmp_arr;
+
+	angleEdge.clear();
+	dcEdge.clear();
+	dvEdge.clear();
+	weightsOnEdge.clear();
+
+	return 0;
+}/*}}}*/
+int outputMeshDensity( const string outputFilename) {/*{{{*/
+	/***************************************************************************
+	 *
+	 * This function writes the meshDensity variable. Read in from the file SaveDensity
+	 *
+	 * *************************************************************************/
+	// Return this code to the OS in case of failure.
+	static const int NC_ERR = 2;
+	
+	// set error behaviour (matches fortran behaviour)
+	NcError err(NcError::verbose_nonfatal);
+	
+	// open the scvtmesh file
+	NcFile grid(outputFilename.c_str(), NcFile::Write);
+	
+	// check to see if the file was opened
+	if(!grid.is_valid()) return NC_ERR;
+
+	// fetch dimensions
+	NcDim *nCellsDim = grid.get_dim( "nCells" );
+
+	NcVar *cDensVar;
+
+	int nCells = nCellsDim->size();
+	int i, j, k;
+	int junk_int;
+	double junk_dbl;
+
+	vector<double> dbl_tmp_arr;
+
+	//Write meshDensity
+	if (!(cDensVar = grid.add_var("meshDensity", ncDouble, nCellsDim))) return NC_ERR;
+	if (!cDensVar->put(&meshDensity.at(0),nCells)) return NC_ERR;
+
+	return 0;
+}/*}}}*/
+/*}}}*/
+
+string gen_random(const int len) {/*{{{*/
+	static const char alphanum[] =
+		"0123456789"
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		"abcdefghijklmnopqrstuvwxyz";
+
+	string rand_str = "";
+
+	for (int i = 0; i < len; ++i) {
+		rand_str += alphanum[rand() % (sizeof(alphanum) - 1)];
+	}
+
+	return rand_str;
+}/*}}}*/
+

--- a/grid_gen/mesh_conversion_tools/netcdf_utils.cpp
+++ b/grid_gen/mesh_conversion_tools/netcdf_utils.cpp
@@ -1,0 +1,2061 @@
+#include <string>
+#include <string.h>
+#include <netcdfcpp.h>
+#include <cstdlib>
+#include <vector>
+
+using namespace std;
+
+int netcdf_mpas_read_num_vars(string filename){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_NUM_VARS gets the number of variables in the netcdf file
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Output, int NETCDF_MPAS_READ_NUM_VARS, the number of variables
+	//
+	long int var_size;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get Ntime, which is a NETCDF dimension.
+	//
+	var_size = ncid.num_vars();
+
+	ncid.close();
+
+	return var_size;
+}/*}}}*/
+
+/* Attribute reading functions {{{*/
+bool netcdf_mpas_read_onsphere(string filename){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_ONSPHERE determines if points are on a sphere, or in a plane
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//     Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Output, int NETCDF_MPAS_READ_ONSPHERE, true or false based on the global
+	//    										 attribute, on_a_sphere
+	//
+	NcAtt *att_id;
+	NcValues *vals;
+	bool valid;
+	string tmp_name;
+	string sph_name = "on_a_sphere";
+	//
+	//  Open the file.
+	//
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//  Get Ntime, which is a NETCDF dimension.
+	//
+	valid = false;
+
+	for(int i = 0; i < ncid.num_atts() && !valid; i++){
+		tmp_name = ncid.get_att(i)->name();
+
+		if(sph_name == tmp_name){
+			valid = true;
+		}
+	}
+
+	if(valid){
+		att_id = ncid.get_att(sph_name.c_str());
+		
+		vals = att_id -> values();
+
+		sph_name = "YES";
+
+		for(int i = 0; i < vals -> num(); i++){
+			tmp_name = vals -> as_string(i);
+			if(tmp_name.find(sph_name) != string::npos){
+				return true;
+			}
+		}
+	} else {
+		return true;
+	}
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return false;
+
+}/*}}}*/
+//****************************************************************************80
+double netcdf_mpas_read_sphereradius(string filename){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_SPHERERADIUS determines if the radius of the sphere.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//     Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Output, double NETCDF_MPAS_READ_SPHERERADIUS, true or false based on the global
+	//    										 attribute, on_a_sphere
+	//
+	NcAtt *att_id;
+	NcValues *vals;
+	bool valid;
+	string tmp_name;
+	string sph_name = "sphere_radius";
+	//
+	//  Open the file.
+	//
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//  Get Ntime, which is a NETCDF dimension.
+	//
+	valid = false;
+
+	for(int i = 0; i < ncid.num_atts() && !valid; i++){
+		tmp_name = ncid.get_att(i)->name();
+
+		if(sph_name == tmp_name){
+			valid = true;
+		}
+	}
+
+	if(valid){
+		att_id = ncid.get_att(sph_name.c_str());
+		
+		vals = att_id -> values();
+
+		sph_name = "YES             ";
+
+		for(int i = 0; i < vals -> num(); i++){
+			tmp_name = vals -> as_string(i);
+
+			return atof(vals -> as_string(i));
+		}
+	} else {
+		return 0.0;
+	}
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return 0.0;
+
+}/*}}}*/
+//****************************************************************************80
+string netcdf_mpas_read_history(string filename){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_HISTORY reads the history attribute from a file.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Output, string NETCDF_MPAS_READ_HISTORY, the value of the history attribute
+	//
+	NcAtt *att_id;
+	NcValues *vals;
+	bool valid;
+	string tmp_name;
+	string sph_name = "history";
+	string history = "";
+	//
+	//  Open the file.
+	//
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//  Get Ntime, which is a NETCDF dimension.
+	//
+	valid = false;
+
+	for(int i = 0; i < ncid.num_atts() && !valid; i++){
+		tmp_name = ncid.get_att(i)->name();
+
+		if(sph_name == tmp_name){
+			valid = true;
+		}
+	}
+
+	if(valid){
+		att_id = ncid.get_att(sph_name.c_str());
+		
+		vals = att_id -> values();
+
+		for(int i = 0; i < vals -> num(); i++){
+			history += vals -> as_string(i);
+			return history;
+		}
+	} else {
+		return history;
+	}
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return history;
+
+}/*}}}*/
+//****************************************************************************80
+string netcdf_mpas_read_meshid(string filename){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_MESHID reads the mesh_id attribute from a file.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Output, string NETCDF_MPAS_READ_MESHID, the value of the mesh_id attribute
+	//
+	NcAtt *att_id;
+	NcValues *vals;
+	bool valid;
+	string tmp_name;
+	string sph_name = "mesh_id";
+	string id_str = "";
+	//
+	//  Open the file.
+	//
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//  Get Ntime, which is a NETCDF dimension.
+	//
+	valid = false;
+
+	for(int i = 0; i < ncid.num_atts() && !valid; i++){
+		tmp_name = ncid.get_att(i)->name();
+
+		if(sph_name == tmp_name){
+			valid = true;
+		}
+	}
+
+	if(valid){
+		att_id = ncid.get_att(sph_name.c_str());
+		
+		vals = att_id -> values();
+
+		for(int i = 0; i < vals -> num(); i++){
+			id_str += vals -> as_string(i);
+			return id_str;
+		}
+	} else {
+		return id_str;
+	}
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return id_str;
+
+}/*}}}*/
+//****************************************************************************80
+string netcdf_mpas_read_parentid(string filename){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_PARENTID reads the parent_id attribute from a file.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Output, string NETCDF_MPAS_READ_PARENTID, the value of the parent_id attribute
+	//
+	NcAtt *att_id;
+	NcValues *vals;
+	bool valid;
+	string tmp_name;
+	string sph_name = "parent_id";
+	string id_str = "";
+	//
+	//  Open the file.
+	//
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+
+//	NcError err(NcError::silent_nonfatal); // Don't error if the variable isn't found.
+	//
+	//  Get Ntime, which is a NETCDF dimension.
+	//
+	valid = false;
+
+	for(int i = 0; i < ncid.num_atts() && !valid; i++){
+		tmp_name = ncid.get_att(i)->name();
+
+		if(sph_name == tmp_name){
+			valid = true;
+		}
+	}
+
+	if(valid){
+		att_id = ncid.get_att(sph_name.c_str());
+		
+		vals = att_id -> values();
+
+		for(int i = 0; i < vals -> num(); i++){
+			id_str += vals -> as_string(i);
+			return id_str;
+		}
+	} else {
+		return id_str;
+	}
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return id_str;
+
+}/*}}}*/
+//****************************************************************************80
+double netcdf_mpas_read_meshspec(string filename){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_MESHSPEC returns the mesh_spec attribute.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    18 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Output, double NETCDF_MPAS_READ_MESHSPEC, the value of the mesh_spec attribute
+	//
+	NcAtt *att_id;
+	NcValues *vals;
+	bool valid;
+	string tmp_name;
+	string sph_name = "mesh_spec";
+	//
+	//  Open the file.
+	//
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//  Get Ntime, which is a NETCDF dimension.
+	//
+	valid = false;
+
+	for(int i = 0; i < ncid.num_atts() && !valid; i++){
+		tmp_name = ncid.get_att(i)->name();
+
+		if(sph_name == tmp_name){
+			valid = true;
+		}
+	}
+
+	if(valid){
+		att_id = ncid.get_att(sph_name.c_str());
+		
+		vals = att_id -> values();
+
+		sph_name = "YES             ";
+
+		for(int i = 0; i < vals -> num(); i++){
+			tmp_name = vals -> as_string(i);
+
+			return atof(vals -> as_string(i));
+		}
+	} else {
+		return 0.0;
+	}
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return 0.0;
+
+}/*}}}*/
+/*}}}*/
+
+/* Dimension reading functions {{{*/
+//****************************************************************************80
+int netcdf_mpas_read_dim ( string filename, string dim_name ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_DIM gets the size of the dimension with name dim_name
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, string DIM_NAME, the name of the dimension in question
+	//
+	//    Output, int NETCDF_MPAS_READ_DIM, the value of the dimension.
+	//
+	int ntime;
+	long int dim_size;
+	NcDim *dim_id;
+	bool valid;
+	string tmp_name;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get Ntime, which is a NETCDF dimension.
+	//
+	valid = false;
+
+	for(int i = 0; i < ncid.num_dims() && !valid; i++){
+		tmp_name = ncid.get_dim(i)->name();
+
+		if(dim_name == tmp_name){
+			valid = true;
+		}
+	}
+
+	if(valid){
+		dim_id = ncid.get_dim(dim_name.c_str());
+		dim_size = (*dim_id).size ( );
+	} else {
+		dim_size = 1;
+	}
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	ntime = ( int ) dim_size;
+
+	return ntime;
+}/*}}}*/
+/*}}}*/
+
+/* Cell Reading Functions {{{*/
+//****************************************************************************80
+void netcdf_mpas_read_xyzcell ( string filename, int ncells, double xcell[], double ycell[], double zcell[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_XYZCELL reads xCell, yCell, zCell.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NCELLS, the number of nodes.
+	//
+	//    Output, double XCELL[NCELLS], YCELL[NCELLS], ZCELL[NCELLS], the
+	//    coordinates of the nodes.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "    Reading xCell" << endl;
+#endif
+	var_id = ncid.get_var ( "xCell" );
+	(*var_id).get ( &xcell[0], ncells );
+#ifdef _DEBUG
+	cout << "    Reading yCell" << endl;
+#endif
+	var_id = ncid.get_var ( "yCell" );
+	(*var_id).get ( &ycell[0], ncells );
+#ifdef _DEBUG
+	cout << "    Reading zCell" << endl;
+#endif
+	var_id = ncid.get_var ( "zCell" );
+	(*var_id).get ( &zcell[0], ncells );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_latloncell ( string filename, int ncells, double latcell[], double loncell[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_LATLONCELL reads latCell, lonCell
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NCELLS, the number of nodes.
+	//
+	//    Output, double LATCELL[NCELLS], LONCELL[NCELLS], the coordinates of the cell centers.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading latCell" << endl;
+#endif
+	var_id = ncid.get_var ( "latCell" );
+	(*var_id).get ( &latcell[0], ncells );
+#ifdef _DEBUG
+	cout << "   Reading lonCell" << endl;
+#endif
+	var_id = ncid.get_var ( "lonCell" );
+	(*var_id).get ( &loncell[0], ncells );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_areacell ( string filename, int ncells, double areacell[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_AREACELL reads areaCell
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NCELLS, the number of nodes.
+	//
+	//    Output, double AREACELL[NCELLS] the area of each cell
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading areaCell" << endl;
+#endif
+	var_id = ncid.get_var ( "areaCell" );
+	(*var_id).get ( &areacell[0], ncells );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_cellsoncell ( string filename, int ncells, int maxedges, int cellsoncell[] ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_CELLSONCELL gets the cellsOnCell information.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/12/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NCELLS, the number of cells.
+	//
+	//    Input, int MAXEDGES, the maximum number of edges around each cell.
+	//
+	//    Output, int CELLSONCELL[MAXEDGES*NCELLS];
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading cellsOnCell" << endl;
+#endif
+	var_id = ncid.get_var ( "cellsOnCell" );
+	(*var_id).get ( &cellsoncell[0], ncells, maxedges );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_edgesoncell ( string filename, int ncells, int maxedges, int edgesoncell[] ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_EDGESONCELL gets the edgesOnCell information.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/12/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NCELLS, the number of cells.
+	//
+	//    Input, int MAXEDGES, the maximum number of edges around each cell.
+	//
+	//    Output, int EDGESONCELL[MAXEDGES*NCELLS];
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading edgesOnCell" << endl;
+#endif
+	var_id = ncid.get_var ( "edgesOnCell" );
+	(*var_id).get ( &edgesoncell[0], ncells, maxedges );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_verticesoncell ( string filename, int ncells, int maxedges, int verticesoncell[] ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_VERTICESONCELL gets the verticesOnCell information.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/12/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NCELLS, the number of cells.
+	//
+	//    Input, int MAXEDGES, the maximum number of edges around each cell.
+	//
+	//    Output, int VERTICESONCELL[MAXEDGES*NCELLS];
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading verticesOnCell" << endl;
+#endif
+	var_id = ncid.get_var ( "verticesOnCell" );
+	(*var_id).get ( &verticesoncell[0], ncells, maxedges );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_mesh_density ( string filename, int ncells, double mesh_density[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_MESH_DENSITY reads meshDensity
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NCELLS, the number of nodes.
+	//
+	//    Output, double mesh_density[NCELLS] value of the density function at each cell center.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+	NcError err(NcError::silent_nonfatal); // Don't error if the variable isn't found.
+	
+#ifdef _DEBUG
+	cout << "   Reading meshDensity" << endl;
+#endif
+	var_id = ncid.get_var ( "meshDensity" );
+	if(var_id == NULL){
+		for(int i = 0; i < ncells; i++){
+			mesh_density[i] = 1.0;
+		}
+	} else {
+		(*var_id).get ( &mesh_density[0], ncells );
+	}
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_cellmask ( string filename, int ncells, int cellmask[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_MESH_CELLMASK reads cellMask
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NCELLS, the number of nodes.
+	//
+	//    Output, int cellmask[NCELLS] a mask on cells, 1 if the cell is kept, 0 if it's removed.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	NcError err(NcError::silent_nonfatal); // Don't error if the variable isn't found.
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading cellMask" << endl;
+#endif
+	var_id = ncid.get_var ( "cellMask" );
+	if(var_id == NULL){
+		for(int i = 0; i < ncells; i++){
+			cellmask[i] = 1;
+		}
+	} else {
+		(*var_id).get ( &cellmask[0], ncells );
+	}
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+/* }}} */
+
+/* Vertex Reading Functions {{{*/
+//****************************************************************************80
+void netcdf_mpas_read_xyzvertex ( string filename, int nvertices, double xvertex[], double yvertex[], double zvertex[] ){/*{{{*/
+	//****************************************************************************80
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_CELLS gets the cell center coordinates.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    01 January 2011
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NVERTICES, the number of vertices.
+	//
+	//    Output, double XVERTEX[NVERTICES], YVERTEXL[NVERTICES], 
+	//    ZVERTEX[NVERTICES], the coordinates of the nodes.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading xVertex" << endl;
+#endif
+	var_id = ncid.get_var ( "xVertex" );
+	(*var_id).get ( &xvertex[0], nvertices );
+#ifdef _DEBUG
+	cout << "   Reading yVertex" << endl;
+#endif
+	var_id = ncid.get_var ( "yVertex" );
+	(*var_id).get ( &yvertex[0], nvertices );
+#ifdef _DEBUG
+	cout << "   Reading zVertex" << endl;
+#endif
+	var_id = ncid.get_var ( "zVertex" );
+	(*var_id).get ( &zvertex[0], nvertices );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_latlonvertex ( string filename, int nvertices, double latvertex[], double lonvertex[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_LATLONVERTEX reads latVertex, lonVertex
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    11 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NVERTICES, the number of nodes.
+	//
+	//    Output, double LATVERTEX[NVERTICES], LONVERTEX[NVERTICES], the coordinates of the vertices.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading latVertex" << endl;
+#endif
+	var_id = ncid.get_var ( "latVertex" );
+	(*var_id).get ( &latvertex[0], nvertices );
+#ifdef _DEBUG
+	cout << "   Reading lonVertex" << endl;
+#endif
+	var_id = ncid.get_var ( "lonVertex" );
+	(*var_id).get ( &lonvertex[0], nvertices );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_areatriangle ( string filename, int nvertices, double areatriangle[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_AREATRIANGLE reads areaTriangle
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/12/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NVERTICES, the number of nodes.
+	//
+	//    Output, double AREATRIANGLE[NVERTICES] the area of each dual cell
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading areaTriangle" << endl;
+#endif
+	var_id = ncid.get_var ( "areaTriangle" );
+	(*var_id).get ( &areatriangle[0], nvertices );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_cellsonvertex ( string filename, int nvertices, int vertexdegree, int cellsonvertex[] ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_CELLSONVERTEX gets the cellsOnVertex information.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    13 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of edges.
+	//
+	//    Output, int CELLSONVERTEX[3*NVERTICES];
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading cellsOnVertex" << endl;
+#endif
+	var_id = ncid.get_var ( "cellsOnVertex" );
+	(*var_id).get ( &cellsonvertex[0], nvertices, vertexdegree );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_kiteareasonvertex ( string filename, int nvertices, int vertexdegree, double kiteareasonvertex[] ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_KITEAREASONVERTEX gets the kiteAreasOnVertex information.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/13/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of edges.
+	//
+	//    Input, int VERTEXDEGREE, the number of cells the border each vertex.
+	//
+	//    Output, double KITEAREASONVERTEX[VERTEXDEGREE*NVERTICES];
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading kiteAreasOnVertex" << endl;
+#endif
+	var_id = ncid.get_var ( "kiteAreasOnVertex" );
+	(*var_id).get ( &kiteareasonvertex[0], nvertices, vertexdegree );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_edgesonvertex ( string filename, int nvertices, int vertexdegree, int edgesonvertex[] ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_EDGESONVERTEX gets the edgesOnVertex information.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/13/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NVERTICES, the number of vertices.
+	//
+	//    Input, int VERTEXDEGREE, the number of cells that border each vertex.
+	//
+	//    Output, int EDGESONVERTEX[VERTEXDEGREE*NVERTICES], the indices of edges that radiate from a vertex.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading edgesOnVertex" << endl;
+#endif
+	var_id = ncid.get_var ( "edgesOnVertex" );
+	(*var_id).get ( &edgesonvertex[0], nvertices, vertexdegree );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+
+/* }}} */
+
+/* Edge Reading Functions {{{*/
+//****************************************************************************80
+void netcdf_mpas_read_xyzedge ( string filename, int nedges, double xedge[], double yedge[], double zedge[] ){/*{{{*/
+	//****************************************************************************80
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_XYZEDGES gets the edge coordinates.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    12 Feb. 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of edges.
+	//
+	//    Output, double XEDGE[NEDGES], YEDGE[NEDGES], 
+	//    ZEDGE[NEDGES], the coordinates of the edges.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading xEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "xEdge" );
+	(*var_id).get ( &xedge[0], nedges );
+#ifdef _DEBUG
+	cout << "   Reading yEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "yEdge" );
+	(*var_id).get ( &yedge[0], nedges );
+#ifdef _DEBUG
+	cout << "   Reading zEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "zEdge" );
+	(*var_id).get ( &zedge[0], nedges );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_latlonedge ( string filename, int nedges, double latedge[], double lonedge[]){/*{{{*/
+	//****************************************************************************80
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_LATLONEDGE gets the edge coordinates.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    12 Feb. 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of edges.
+	//
+	//    Output, double LATEDGE[NEDGES], LONEDGE[NEDGES], the coordinates of the edges.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading latEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "latEdge" );
+	(*var_id).get ( &latedge[0], nedges );
+#ifdef _DEBUG
+	cout << "   Reading lonEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "lonEdge" );
+	(*var_id).get ( &lonedge[0], nedges );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_verticesonedge ( string filename, int nedges, int verticesonedge[] ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_VERTICESONEDGE gets the verticesOnEdge information.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    13 February 2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of edges.
+	//
+	//    Output, int VERTICESONEDGE[2*NVERTICES];
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading verticesOnEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "verticesOnEdge" );
+	(*var_id).get ( &verticesonedge[0], nedges, 2 );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_cellsonedge ( string filename, int nedges, int cellsonedge[] ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_CELLSONEDGE gets the cellsOnEdge information.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/13/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of edges.
+	//
+	//    Output, int CELLSONEDGE[2*NVERTICES];
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading cellsOnEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "cellsOnEdge" );
+	(*var_id).get ( &cellsonedge[0], nedges, 2 );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_dvedge ( string filename, int nedges, double dvedge[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_DVEDGE reads dvEdge
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/12/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of nodes.
+	//
+	//    Output, double DVEDGE[NEDGES] the length between vertices of an edge.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading dvEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "dvEdge" );
+	(*var_id).get ( &dvedge[0], nedges );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_dcedge ( string filename, int nedges, double dcedge[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_DVEDGE reads dcEdge
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/12/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of nodes.
+	//
+	//    Output, double DVEDGE[NEDGES] the length between the cells on an edge.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading dcEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "dcEdge" );
+	(*var_id).get ( &dcedge[0], nedges );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_angleedge ( string filename, int nedges, double angleedge[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_ANGLEEDGE reads angleEdge
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/12/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of nodes.
+	//
+	//    Output, double ANGLEEDGE[NEDGES] the length between the cells on an edge.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading angleEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "angleEdge" );
+	(*var_id).get ( &angleedge[0], nedges );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_weightsonedge ( string filename, int nedges, int maxedges2, double weightsonedge[] ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_WEIGHTSONEDGE gets the weightsOnEdge information.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/13/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of edges.
+	//
+	//    Input, int MAXEDGES2, two times the maximum number of edges around a cell.
+	//
+	//    Output, double WEIGHTSONEDGE[MAXEDGES2*NEDGES], the weights for each edge on edge.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading weightsOnEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "weightsOnEdge" );
+	(*var_id).get ( &weightsonedge[0], nedges, maxedges2 );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_edgesonedge ( string filename, int nedges, int maxedges2, int edgesonedge[] ){/*{{{*/
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_EDGESONEDGE gets the edgesOnEdge information.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    02/13/2014
+	//
+	//  Author:
+	//
+	//    Doug Jacobsen
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NEDGES, the number of edges.
+	//
+	//    Input, int MAXEDGES2, two times the maximum number of edges around a cell.
+	//
+	//    Output, int EDGESONEDGE[MAXEDGES2*NEDGES], the weights for each edge on edge.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITOFFSET
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Offset64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "   Reading edgesOnEdge" << endl;
+#endif
+	var_id = ncid.get_var ( "edgesOnEdge" );
+	(*var_id).get ( &edgesonedge[0], nedges, maxedges2 );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+
+/* }}} */
+

--- a/grid_gen/mesh_conversion_tools/netcdf_utils.h
+++ b/grid_gen/mesh_conversion_tools/netcdf_utils.h
@@ -1,0 +1,52 @@
+#include <string>
+#include <netcdfcpp.h>
+
+using namespace std;
+
+int netcdf_mpas_read_num_vars(string filename);
+
+/* Attribute reading functions {{{*/
+bool netcdf_mpas_read_onsphere(string filename);
+double netcdf_mpas_read_sphereradius(string filename);
+string netcdf_mpas_read_history(string filename);
+string netcdf_mpas_read_meshid(string filename);
+string netcdf_mpas_read_parentid(string filename);
+double netcdf_mpas_read_meshspec(string filename);
+/*}}}*/
+
+/* Dimension reading functions {{{*/
+int netcdf_mpas_read_dim ( string filename, string dim_name );
+/*}}}*/
+
+/* Cell Reading Functions {{{*/
+void netcdf_mpas_read_xyzcell ( string filename, int ncells, double xcell[], double ycell[], double zcell[] );
+void netcdf_mpas_read_latloncell ( string filename, int ncells, double latcell[], double loncell[] );
+void netcdf_mpas_read_areacell ( string filename, int ncells, double areacell[] );
+void netcdf_mpas_read_cellsoncell ( string filename, int ncells, int maxedges, int cellsoncell[] );
+void netcdf_mpas_read_edgesoncell ( string filename, int ncells, int maxedges, int edgesoncell[] );
+void netcdf_mpas_read_verticesoncell ( string filename, int ncells, int maxedges, int verticesoncell[] );
+void netcdf_mpas_read_mesh_density ( string filename, int ncells, double mesh_density[] );
+void netcdf_mpas_read_cellmask ( string filename, int ncells, int cellmask[] );
+/* }}} */
+
+/* Vertex Reading Functions {{{*/
+void netcdf_mpas_read_xyzvertex ( string filename, int nvertices, double xvertex[], double yvertex[], double zvertex[] );
+void netcdf_mpas_read_latlonvertex ( string filename, int nvertices, double latvertex[], double lonvertex[] );
+void netcdf_mpas_read_areatriangle ( string filename, int nvertices, double areatriangle[] );
+void netcdf_mpas_read_cellsonvertex ( string filename, int nvertices, int vertexdegree, int cellsonvertex[] );
+void netcdf_mpas_read_kiteareasonvertex ( string filename, int nvertices, int vertexdegree, double kiteareasonvertex[] );
+void netcdf_mpas_read_edgesonvertex ( string filename, int nvertices, int vertexdegree, int edgesonvertex[] );
+/* }}} */
+
+/* Edge Reading Functions {{{*/
+void netcdf_mpas_read_xyzedge ( string filename, int nedges, double xedge[], double yedge[], double zedge[] );
+void netcdf_mpas_read_latlonedge ( string filename, int nedges, double latedge[], double lonedge[]);
+void netcdf_mpas_read_verticesonedge ( string filename, int nedges, int verticesonedge[] );
+void netcdf_mpas_read_cellsonedge ( string filename, int nedges, int cellsonedge[] );
+void netcdf_mpas_read_dvedge ( string filename, int nedges, double dvedge[] );
+void netcdf_mpas_read_dcedge ( string filename, int nedges, double dcedge[] );
+void netcdf_mpas_read_angleedge ( string filename, int nedges, double angleedge[] );
+void netcdf_mpas_read_weightsonedge ( string filename, int nedges, int maxedges2, double weightsonedge[] );
+void netcdf_mpas_read_edgesonedge ( string filename, int nedges, int maxedges2, int edgesonedge[] );
+/* }}} */
+

--- a/grid_gen/mesh_conversion_tools/pnt.h
+++ b/grid_gen/mesh_conversion_tools/pnt.h
@@ -1,0 +1,471 @@
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <cmath>
+
+class pnt {/*{{{*/
+	public:
+		double x, y, z;
+		int idx;
+
+		pnt(double x_, double y_, double z_, int idx_)
+			:  x(x_), y(y_), z(z_), idx(idx_) {	}
+
+		pnt(double x_, double y_, double z_)
+			: x(x_), y(y_), z(z_), idx(0) { }
+
+		pnt()
+			: x(0.0), y(0.0), z(0.0), idx(0) { }
+
+		friend pnt operator*(const double d, const pnt &p);
+		friend std::ostream & operator<<(std::ostream &os, const pnt &p);
+		friend std::istream & operator>>(std::istream &is, pnt &p);
+
+		pnt& operator=(const pnt &p){/*{{{*/
+			x = p.x;
+			y = p.y;
+			z = p.z;
+			idx = p.idx;
+			return *this;
+		}/*}}}*/
+		bool operator==(const pnt &p) const {/*{{{*/
+			return (x == p.x) & (y == p.y) & (z == p.z);
+		}/*}}}*/
+		pnt operator-(const pnt &p) const {/*{{{*/
+			double x_, y_, z_;
+
+			x_ = x-p.x;
+			y_ = y-p.y;
+			z_ = z-p.z;
+
+			return pnt(x_,y_,z_,0);
+		}/*}}}*/
+		pnt operator+(const pnt &p) const {/*{{{*/
+			double x_, y_, z_;
+
+			x_ = x+p.x;
+			y_ = y+p.y;
+			z_ = z+p.z;
+
+			return pnt(x_,y_,z_,0);
+		}/*}}}*/
+		pnt operator*(double d) const {/*{{{*/
+			double x_, y_, z_;
+			x_ = x*d;
+			y_ = y*d;
+			z_ = z*d;
+			return pnt(x_,y_,z_,0);
+		}/*}}}*/
+		pnt operator/(double d) const {/*{{{*/
+			double x_, y_, z_;
+
+			if(d == 0.0){
+				std::cout << "pnt: operator/" << std::endl;
+				std::cout << (*this) << std::endl;
+			}
+
+			assert(d != 0.0);
+			x_ = x/d;
+			y_ = y/d;
+			z_ = z/d;
+			return pnt(x_,y_,z_,0);
+		}/*}}}*/
+		pnt& operator/=(double d){/*{{{*/
+			if(d == 0.0){
+				std::cout << "pnt: operator /=" << std::endl << (*this) << std::endl;
+			}
+			assert(d != 0.0);
+			x = x/d;
+			y = y/d;
+			z = z/d;
+			return *this;
+		}/*}}}*/
+		pnt& operator+=(const pnt &p){/*{{{*/
+			x += p.x;
+			y += p.y;
+			z += p.z;
+			return *this;
+		}/*}}}*/
+		double operator[](int i) const {/*{{{*/
+			if(i == 0){
+				return x;
+			} else if(i == 1){
+				return y;
+			} else {
+				return z;
+			}
+		}/*}}}*/
+		void normalize(){/*{{{*/
+			double norm;
+
+			norm = x*x + y*y + z*z;
+			if(norm == 0){
+				std::cout << "pnt: normalize" << std::endl;
+				std::cout << x << " " << y << " " << z << " " << idx << std::endl;
+
+				assert(norm != 0);
+			}	
+			norm = sqrt(norm);
+
+			x = x/norm;
+			y = y/norm;
+			z = z/norm;
+		}/*}}}*/
+		double dot(const pnt &p) const {/*{{{*/
+			double junk;
+			junk = x*p.x+y*p.y+z*p.z;
+
+			return junk;
+		}/*}}}*/
+		double dotForAngle(const pnt &p) const {/*{{{*/
+			double junk;
+			junk = x*p.x+y*p.y+z*p.z;
+			if(junk > 1.0){
+				junk = 1.0;
+			}
+
+			if(junk < -1.0){
+				junk = -1.0;
+			}
+			return acos(junk);
+		}/*}}}*/
+		pnt cross(const pnt &p) const {/*{{{*/
+			double x_, y_, z_;
+
+			x_ = y*p.z - p.y*z;
+			y_ = z*p.x - p.z*x;
+			z_ = x*p.y - p.x*y;
+
+			return pnt(x_,y_,z_,0);
+		}/*}}}*/
+		void fixPeriodicity(const pnt &p, const double xRef, const double yRef){/*{{{*/
+			/* The fixPeriodicity function fixes the periodicity of the current point relative
+			 *     to point p. It should only be used on a point in the x/y plane.
+			 *     xRef and yRef should be the extents of the non-periodic plane.
+			 */
+
+			pnt dist_vec;
+
+			dist_vec = (*this) - p;
+
+			if(fabs(dist_vec.x) > xRef * 0.5){
+#ifdef _DEBUG
+				std::cout << "   Fixing x periodicity " << endl;
+#endif
+				(*this).x += -(dist_vec.x/fabs(dist_vec.x)) * xRef;
+			}
+			if(fabs(dist_vec.y) > yRef * 0.5){
+#ifdef _DEBUG
+				std::cout << "   Fixing y periodicity " << endl;
+#endif
+				(*this).y += -(dist_vec.y/fabs(dist_vec.y)) * yRef;
+			}
+
+		}/*}}}*/
+		double magnitude() const{/*{{{*/
+			return sqrt(x*x + y*y + z*z);
+		}/*}}}*/
+		double magnitude2() const {/*{{{*/
+			return x*x + y*y + z*z;
+		}/*}}}*/
+		void rotate(const pnt &vec, const double angle){/*{{{*/
+			double x_, y_, z_;
+			double cos_t, sin_t;
+
+			cos_t = cos(angle);
+			sin_t = sin(angle);
+
+			x_ = (cos_t + vec.x*vec.x *(1.0-cos_t)) * x
+				+(vec.x*vec.y*(1.0-cos_t) - vec.z * sin_t) * y
+				+(vec.x*vec.z*(1.0-cos_t) + vec.y * sin_t) * z;
+
+			y_ = (vec.y*vec.x*(1.0-cos_t) + vec.z*sin_t) * x
+				+(cos_t + vec.y*vec.x*(1.0 - cos_t)) * y
+				+(vec.y*vec.z*(1.0-cos_t) - vec.x*sin_t) * z;
+
+			z_ = (vec.z*vec.x*(1.0-cos_t)-vec.y*sin_t)*x
+				+(vec.z*vec.y*(1.0-cos_t)-vec.x*sin_t)*y
+				+(cos_t + vec.x*vec.x*(1.0-cos_t))*z;
+
+			x = x_;
+			y = y_;
+			z = z_;
+		}/*}}}*/
+		double getLat() const {/*{{{*/
+			double dl;
+
+			dl = sqrt((*this).x*(*this).x + (*this).y*(*this).y + (*this).z*(*this).z);
+			return asin(z/dl);
+		}/*}}}*/
+		double getLon() const {/*{{{*/
+			double lon;
+
+			lon = atan2(y,x);
+
+			if(lon < -M_PI){
+				lon = lon + M_2_PI;
+			} else if (lon > M_PI) {
+				lon = lon - M_2_PI;
+			}
+
+			return lon+M_PI;
+
+		}/*}}}*/
+		double sphereDistance(const pnt &p) const {/*{{{*/
+			double arg;
+
+			arg = sqrt( powf(sin(0.5*((*this).getLat()-p.getLat())),2) +
+					cos(p.getLat())*cos((*this).getLat())*powf(sin(0.5*((*this).getLon()-p.getLon())),2));
+			return 2.0*asin(arg);
+
+			/*
+			pnt temp, cross;
+			double dot;
+			temp.x = x;
+			temp.y = y;
+			temp.z = z;
+
+			cross = temp.cross(p);
+			dot = temp.dot(p);
+
+
+
+			return atan2(cross.magnitude(),dot);
+			// */
+		}/*}}}*/
+	struct hasher {/*{{{*/
+		size_t operator()(const pnt &p) const {
+			uint32_t hash; 
+			size_t i, key[3] = { (size_t)p.x, (size_t)p.y, (size_t)p.z };
+			for(hash = i = 0; i < sizeof(key); ++i) {
+				hash += ((uint8_t *)key)[i];
+				hash += (hash << 10);
+				hash ^= (hash >> 6);
+			}
+			hash += (hash << 3);
+			hash ^= (hash >> 11);
+			hash += (hash << 15);
+			return hash;
+		}
+	};/*}}}*/
+	struct idx_hasher {/*{{{*/
+		size_t operator()(const pnt &p) const {
+			return (size_t)p.idx;
+		}
+	};/*}}}*/
+};/*}}}*/
+
+inline pnt operator*(const double d, const pnt &p){/*{{{*/
+	return pnt(d*p.x, d*p.y, d*p.z, 0);
+}/*}}}*/
+
+inline std::ostream & operator<<(std::ostream &os, const pnt &p){/*{{{*/
+	os << '(' << p.x << ", " << p.y << ", " << p.z << ")  idx=" << p.idx << ' ';
+	//os << p.x << " " << p.y << " " << p.z;
+	return os;
+}/*}}}*/
+inline std::istream & operator>>(std::istream &is, pnt &p){/*{{{*/
+	//is >> p.x >> p.y >> p.z >> p.idx;
+	is >> p.x >> p.y >> p.z;
+	return is;
+}/*}}}*/
+
+/* Geometric utility functions {{{ */
+pnt gcIntersect(const pnt &c1, const pnt &c2, const pnt &v1, const pnt &v2){/*{{{*/
+	/*
+	 * gcIntersect is intended to compute the intersection of two great circles.
+	 *   The great circles pass through the point sets c1-c2 and v1-v2.
+	 */
+
+	/*
+	pnt n, m,c ;
+	double dot;
+
+
+	//n = c1 cross c2
+	n = c1.cross(c2);
+
+	//m = v1 cross v2
+	m = v1.cross(v2);
+
+	//c = n cross m
+	c = n.cross(m);
+
+	dot = c1.dot(c);
+
+	dot = dot/fabs(dot);
+
+	c = c*dot;
+
+	c.normalize();
+
+	return c;
+	// */
+
+	double n1, n2, n3;
+	double m1, m2, m3;
+	double xc, yc, zc;
+	double dot;
+	pnt c;
+
+	n1 =  (c1.y * c2.z - c2.y * c1.z);
+	n2 = -(c1.x * c2.z - c2.x * c1.z);
+	n3 =  (c1.x * c2.y - c2.x * c1.y);
+
+	m1 =  (v1.y * v2.z - v2.y * v1.z);
+	m2 = -(v1.x * v2.z - v2.x * v1.z);
+	m3 =  (v1.x * v2.y - v2.x * v1.y);
+
+	xc =  (n2 * m3 - n3 * m2);
+	yc = -(n1 * m3 - n3 * m1);
+	zc =  (n1 * m2 - n2 * m1);
+
+	dot = c1.x*xc + c1.y*yc + c1.z*zc;
+
+	if (dot < 0.0) {
+		xc = -xc;
+		yc = -yc;
+		zc = -zc;
+	}
+
+	c.x = xc;
+	c.y = yc;
+	c.z = zc;
+
+	c.normalize();
+	return c;
+}/*}}}*/
+pnt planarIntersect(const pnt &c1, const pnt &c2, const pnt &v1, const pnt &v2){/*{{{*/
+	/*
+	 * planarIntersect is intended to compute the point of intersection
+	 *    of the lines c1-c2 and v1-v2 in a plane.
+	 */
+	double alpha_numerator, beta_numerator, denom;
+	double alpha, beta;
+	pnt c;
+
+	alpha_numerator = (v2.x - v1.x) * (c1.y - v2.y) - (v2.y - v1.y) * (c1.x - v2.x);
+//	beta_numerator = (c1.x - v2.x) * (c2.y - c1.y) - (c1.y - v2.y) * (c2.x - c1.x);
+	denom = (c2.x - c1.x) * (v2.y - v1.y) - (c2.y - c1.y) * (v2.x - v1.x);
+
+	alpha = alpha_numerator / denom;
+//	beta = beta_numerator / demon;
+
+	c = alpha * (v2 - v1) + v1;
+
+	return c;
+}/*}}}*/
+
+double planarTriangleArea(const pnt &A, const pnt &B, const pnt &C){/*{{{*/
+	/*
+	 * planarTriangleArea uses Heron's formula to compute the area of a triangle in a plane.
+	 */
+	pnt ab, bc, ca;
+	double s, a, b, c, e;
+
+	ab = B - A;
+	bc = C - B;
+	ca = A - C;
+
+	// Get side lengths
+	a = ab.magnitude();
+	b = bc.magnitude();
+	c = ca.magnitude();
+
+	// Semi-perimeter of TRI(ABC)
+	s = (a + b + c) * 0.5;
+
+	return sqrt(s * (s - a) * (s - b) * (s - c));
+}/*}}}*/
+double sphericalTriangleArea(const pnt &A, const pnt &B, const pnt &C){/*{{{*/
+	/*
+	 * sphericalTriangleArea uses the spherical analog of Heron's formula to compute
+	 *    the area of a triangle on the surface of a sphere.
+	 *
+	 */
+	double tanqe, s, a, b, c, e;
+
+	a = A.sphereDistance(B);
+	b = B.sphereDistance(C);
+	c = C.sphereDistance(A);
+	s = 0.5*(a+b+c);
+
+	tanqe = sqrt(tan(0.5*s)*tan(0.5*(s-a))*tan(0.5*(s-b))*tan(0.5*(s-c)));
+	e = 4.*atan(tanqe);
+
+	return e;
+}/*}}}*/
+
+double planeAngle(const pnt &A, const pnt &B, const pnt &C, const pnt &n){/*{{{*/
+	/*
+	 * planeAngle computes the angles between the vectors AB and AC in a plane defined with
+	 *    the normal vector n
+	 */
+
+	/*
+	pnt ab;
+	pnt ac;
+	pnt cross;
+	double cos_angle;
+
+	ab = B - A;
+	ac = C - A;
+	cross = ab.cross(ac);
+	cos_angle = ab.dot(ac)/(ab.magnitude() * ac.magnitude());
+
+	cos_angle = std::min(std::max(cos_angle,-1.0),1.0);
+
+	if(cross.x*n.x + cross.y*n.y + cross.z*n.z >= 0){
+		return acos(cos_angle);
+	} else {
+		return -acos(cos_angle);
+	}
+	// */
+
+	double ABx, ABy, ABz, mAB;
+	double ACx, ACy, ACz, mAC;
+	double Dx, Dy, Dz;
+	double cos_angle;
+
+	ABx = B.x - A.x;
+	ABy = B.y - A.y;
+	ABz = B.z - A.z;
+	mAB = sqrt(ABx*ABx + ABy*ABy + ABz*ABz);
+
+	ACx = C.x - A.x;
+	ACy = C.y - A.y;
+	ACz = C.z - A.z;
+	mAC = sqrt(ACx*ACx + ACy*ACy + ACz*ACz);
+
+
+	Dx =   (ABy * ACz) - (ABz * ACy);
+	Dy = -((ABx * ACz) - (ABz * ACx));
+	Dz =   (ABx * ACy) - (ABy * ACx);
+
+	cos_angle = (ABx*ACx + ABy*ACy + ABz*ACz) / (mAB * mAC);
+
+	if (cos_angle < -1.0) {
+		cos_angle = -1.0;
+	} else if (cos_angle > 1.0) {
+		cos_angle = 1.0;
+	}
+
+	if ((Dx*n.x + Dy*n.y + Dz*n.z) >= 0.0) {
+		return acos(cos_angle);
+	} else {
+		return -acos(cos_angle);
+	}
+}/*}}}*/
+pnt pntFromLatLon(const double &lat, const double &lon){/*{{{*/
+	/*
+	 * pntFromLatLon constructs a point location in 3-Space
+	 *    from an initial latitude and longitude location.
+	 */
+	pnt temp;
+	temp.x = cos(lon) * cos(lat);
+	temp.y = sin(lon) * cos(lat);
+	temp.z = sin(lat);
+	temp.normalize();
+	return temp;
+}/*}}}*/
+/*}}}*/


### PR DESCRIPTION
Adding two different tools for use in the front end of MPAS.

First is MpasMeshConverter.x:
    This tool converts cell and vertex location infomation along with
    cellsOnVertex into a full valid MPAS mesh that should be following
    the mesh specification.

Second is MpasCellCuller.x:
    This tool reads a valid MPAS mesh that contains a cellMask field,
    and removes cells/edges/vertices from the mesh.

MpasMeshConverter.x and MpasCellCuller.x output complete MPAS meshes, only including fields described as "required" by the mesh specification document. If the input mesh to either of these contains initial conditions, they not be present in the output file.
