### PR TITLE
Fixing some issues with the ocean users guide script

### DIFF
--- a/python_scripts/namelist_generation/parse_ocean_xml_registry.py
+++ b/python_scripts/namelist_generation/parse_ocean_xml_registry.py
@@ -884,9 +884,9 @@ def write_variable_sections(latex, sorted_structs, forward_registry, analysis_re
 				latex.write('        \hline \n')
 
 				if(in_var_array):
-					latex.write("		 Index in %s Array: & '%s' in '%s' pool \\\\\n"%(var_name.replace('_','\_'), var_name.replace('_', '\_'), struct_name.replace('_','\_')))
+					latex.write("		 Index in `%s' Array: & `index\_%s' in `%s' pool \\\\\n"%(var_path.replace('_','\_'), var_name.replace('_', '\_'), struct_name.replace('_','\_')))
 					latex.write('		 \hline \n')
-				pool_path="'%s' in '%s' pool"%(var_path, struct_name)
+				pool_path="`%s' in `%s' pool"%(var_path, struct_name)
 				latex.write('            Pool path: & %s \\\\\n'%pool_path.replace('_', '\_'))
 				latex.write('		 \hline \n')
 				if(in_var_array):


### PR DESCRIPTION
The underscores in stream names need to be escaped to generate proper latex.
The streams attached to a variable are incorrect currently, so they are removed.
Left quotes need to be back tics to show up correctly, and the index_ portion of consitituents of var_arrays needed to be added.
