### PR TITLE
Added offsets x0 and y0 to periodic hex

### DIFF
--- a/grid_gen/periodic_hex/Makefile
+++ b/grid_gen/periodic_hex/Makefile
@@ -34,7 +34,7 @@ LDFLAGS = -O3 -m64
 #LDFLAGS = -O3
 
 
-CPP = cpp -C -P -traditional
+CPP = cpp -P -traditional
 CPPFLAGS = 
 CPPINCLUDES = 
 INCLUDES = -I$(NETCDF)/include

--- a/grid_gen/periodic_hex/module_cell_indexing.F
+++ b/grid_gen/periodic_hex/module_cell_indexing.F
@@ -5,7 +5,7 @@ module cell_indexing
    integer, parameter :: maxEdges = 6
 
    integer :: nx, ny, nVertLevels, nTracers, vertexDegree
-   real (kind=8) :: dc
+   real (kind=8) :: dc, x0, y0
    integer, dimension(20) :: nproc
 
 
@@ -16,11 +16,13 @@ module cell_indexing
 
       implicit none
 
-      namelist /periodic_grid/ nx, ny, dc, nVertLevels, nTracers, nproc, vertexDegree
+      namelist /periodic_grid/ nx, ny, dc, x0, y0, nVertLevels, nTracers, nproc, vertexDegree
 
       nx = 200
       ny = 200
       dc = 10000.
+      x0 = 0.
+      y0 = 0.
       nVertLevels = 1
       nTracers = 2
       nproc(:) = -1

--- a/grid_gen/periodic_hex/periodic_grid.F
+++ b/grid_gen/periodic_hex/periodic_grid.F
@@ -217,12 +217,12 @@ program hexagonal_periodic_grid
       lonCell(iCell) = 0.0
 
       if (mod(iRow,2) == 1) then
-         xCell(iCell) = dc*real(iCol) - 0.5*dc
-         yCell(iCell) = dc*real(iRow)*sqrt(THREE) / TWO
+         xCell(iCell) = x0 + dc*real(iCol) - 0.5*dc
+         yCell(iCell) = y0 + dc*real(iRow)*sqrt(THREE) / TWO
          zCell(iCell) = 0.0
       else
-         xCell(iCell) = dc*real(iCol)
-         yCell(iCell) = dc*real(iRow)*sqrt(THREE) / TWO
+         xCell(iCell) = x0 + dc*real(iCol)
+         yCell(iCell) = y0 + dc*real(iRow)*sqrt(THREE) / TWO
          zCell(iCell) = 0.0
       end if
 


### PR DESCRIPTION
These offsets make it much more intuitive when one later culls out the periodic boundaries from the mesh, as in the ISOMIP test case.  These offsets are added to xCell and yCell, respectively, and propagate to xEdge, xVertex, etc.

Then change to the Makefile (removing -C from cpp) was necessary on my system but may not be desired in the trunk.
