### PR TITLE
Add flexibility to CISM-to-MPAS mesh conversion scripts

### DIFF
--- a/grid_gen/landice_grid_tools/create_landice_grid_from_generic_MPAS_grid.py
+++ b/grid_gen/landice_grid_tools/create_landice_grid_from_generic_MPAS_grid.py
@@ -112,8 +112,12 @@ datatypeInt = filein.variables['indexToCellID'].dtype  # Get the datatype for in
 layerThicknessFractions = fileout.createVariable('layerThicknessFractions', datatype, ('nVertLevels', ))
 layerThicknessFractions[:] = numpy.zeros(layerThicknessFractions.shape)
 # Assign default values to layerThicknessFractions.  By default they will be uniform fractions.  Users can modify them in a subsequent step, but doing this here ensures the most likely values are already assigned. (Useful for e.g. setting up Greenland where the state variables are copied over but the grid variables are not modified.)
+
+# uniform layer fractions (default)
 layerThicknessFractions[:] = 1.0 / nVertLevels
 
+# explictly specify layer fractions
+#layerThicknessFractions[:] = [0.1663,0.1516,0.1368,0.1221,0.1074,0.0926,0.0779,0.0632,0.0484,0.0337]
 
 # With Scientific.IO.netCDF, entries are appended along the unlimited dimension one at a time by assigning to a slice.
 # Therefore we need to assign to time level 0, and what we need to assign is a zeros array that is the shape of the new variable, exluding the time dimension!

--- a/grid_gen/landice_grid_tools/interpolate_cism_grid_to_mpas_grid.py
+++ b/grid_gen/landice_grid_tools/interpolate_cism_grid_to_mpas_grid.py
@@ -57,8 +57,8 @@ fieldInfo = OrderedDict()
 fieldInfo['thickness'] =     {'CISMname':'thk',  'scalefactor':1.0, 'CISMgrid':1, 'vertDim':False}
 fieldInfo['bedTopography'] = {'CISMname':'topg', 'scalefactor':1.0, 'CISMgrid':1, 'vertDim':False}
 fieldInfo['sfcMassBal'] =    {'CISMname':'acab', 'scalefactor':910.0/(3600.0*24.0*365.0), 'CISMgrid':1, 'vertDim':False}  # Assuming default CISM density
-fieldInfo['temperature'] =   {'CISMname':'temp', 'scalefactor':1.0, 'CISMgrid':1, 'vertDim':True}
-#fieldInfo['temperature'] =   {'CISMname':'tempstag', 'scalefactor':1.0, 'CISMgrid':1, 'vertDim':True}  # pick one or the other
+#fieldInfo['temperature'] =   {'CISMname':'temp', 'scalefactor':1.0, 'CISMgrid':1, 'vertDim':True}
+fieldInfo['temperature'] =   {'CISMname':'tempstag', 'scalefactor':1.0, 'CISMgrid':1, 'vertDim':True}  # pick one or the other
 fieldInfo['beta'] =          {'CISMname':'beta', 'scalefactor':1.0, 'CISMgrid':0, 'vertDim':False} # needs different mapping file...
 #fieldInfo['observedSpeed'] = {'CISMname':'balvel', 'scalefactor':1.0/(365.0*24.0*3600.0), 'CISMgrid':0, 'vertDim':False} # needs different mapping file...
 
@@ -124,7 +124,11 @@ def BilinearInterp(Value, CISMgridType):
 def interpolate_field(MPASfieldName):
 
     CISMfieldName = fieldInfo[MPASfieldName]['CISMname']
-    CISMfield = CISMfile.variables[CISMfieldName][timelev,:,:]
+    if 'time' in CISMfile.variables[CISMfieldName].dimensions:
+        CISMfield = CISMfile.variables[CISMfieldName][timelev,:,:]
+    else:
+        CISMfield = CISMfile.variables[CISMfieldName][:,:]
+
     print '  CISM %s min/max:'%CISMfieldName, CISMfield.min(), CISMfield.max()
 
     # Call the appropriate routine for actually doing the interpolation
@@ -149,8 +153,10 @@ def interpolate_field(MPASfieldName):
 def interpolate_field_with_layers(MPASfieldName):
 
     CISMfieldName = fieldInfo[MPASfieldName]['CISMname']
-    CISMfield = CISMfile.variables[CISMfieldName][timelev,:,:,:]
-
+    if 'time' in CISMfile.variables[CISMfieldName].dimensions:
+        CISMfield = CISMfile.variables[CISMfieldName][timelev,:,:]
+    else:
+        CISMfield = CISMfile.variables[CISMfieldName][:,:]
 
     # create array for interpolated CISM field at all layers
     cismVerticalDimSize = CISMfield.shape[0] # vertical index is the first (since we've eliminated time already)


### PR DESCRIPTION
In create_landice_grid_from_generic_MPAS_grid.py, added ability to
set vertical level spacing explicitly from a vector.
In interpolate_cism_grid_to_mpas_grid.py, added logic to look for
time dimension in input (CISM) files and deal with it gracefully
if time is not there.
