### PR TITLE
Add files for new "minimal" version of periodic_grid (see README).

### DIFF
--- a/grid_gen/periodic_hex_minimal/Makefile
+++ b/grid_gen/periodic_hex_minimal/Makefile
@@ -1,0 +1,79 @@
+# IBM with Xlf compilers
+#FC = xlf90
+#CC = xlc
+#FFLAGS = -qrealsize=8 -g -C
+#CFLAGS = -g
+#LDFLAGS = -g -C
+
+# pgf90
+#FC = pgf90
+#CC = pgcc
+#FFLAGS = -r8 -O3
+#CFLAGS = -O3
+#LDFLAGS = -O3
+
+# gfortran
+FC = gfortran
+CC = gcc
+#FFLAGS = -O3 -m64 -ffree-line-length-none -fdefault-real-8 -fconvert=big-endian
+FFLAGS = -g -m64 -ffree-line-length-none -fdefault-real-8 -fconvert=big-endian
+CFLAGS = -O3 -m64
+LDFLAGS = -O3 -m64
+
+# ifort
+#FC = ifort
+#CC = icc
+#FFLAGS = -real-size 64 -O3
+#CFLAGS = -O3
+#LDFLAGS = -O3
+
+# absoft
+#FC = f90
+#CC = gcc
+#FFLAGS = -dp -O3
+#CFLAGS = -O3
+#LDFLAGS = -O3
+
+
+CPP = cpp -P -traditional
+CPPFLAGS = 
+CPPINCLUDES = 
+INCLUDES = -I$(NETCDF)/include
+
+# Specify NetCDF libraries, checking if netcdff is required (it will be present in v4 of netCDF)
+LIBS = -L$(NETCDF)/lib
+NCLIB = -lnetcdf
+NCLIBF = -lnetcdff
+ifneq ($(wildcard $(NETCDF)/lib/libnetcdff.*), ) # CHECK FOR NETCDF4
+        LIBS += $(NCLIBF)
+endif # CHECK FOR NETCDF4
+LIBS += $(NCLIB)
+
+
+
+RM = rm -f
+
+##########################
+
+.SUFFIXES: .F .o
+
+
+OBJS = periodic_grid.o \
+       module_cell_indexing.o \
+       module_write_netcdf.o
+
+all: periodic_grid
+
+periodic_grid.o: module_cell_indexing.o module_write_netcdf.o 
+
+periodic_grid: $(OBJS)
+	$(FC) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
+
+clean:
+	$(RM) *.o *.mod periodic_grid
+
+.F.o:
+	$(RM) $@ $*.mod
+	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
+	$(FC) $(FFLAGS) -c $*.f90 $(INCLUDES)
+	$(RM) $*.f90

--- a/grid_gen/periodic_hex_minimal/README
+++ b/grid_gen/periodic_hex_minimal/README
@@ -1,0 +1,16 @@
+
+This dir contains a version of the orginal periodic hex code that creats a "minimal" grid.nc file
+to be then processed using the mesh convergion tool ("mpas_mesh_converter.cpp" in the 
+"grid_gen/mesh_conversion_tools/" subdir). E.g., invoking ...
+
+> mpas_mesh_converter ./grid.nc
+
+...will create a full mpas mesh called "mesh.nc".
+
+These alterations were made to greatly speed up the mesh generation process for large meshes. In 
+periodic_grid.F, only the necessary fields are constructed and written to netcdf, and these are 
+allocated, written, and deallocated in sequence to minimze the memory footprint. In 
+module_write_netcdf.F, the minimal number of fields are included and all fields are optional so
+that the netcdf write command can be called as many times as needed in periodic_grid.F.
+
+S. Price, 6-11-15 

--- a/grid_gen/periodic_hex_minimal/module_cell_indexing.F
+++ b/grid_gen/periodic_hex_minimal/module_cell_indexing.F
@@ -1,0 +1,170 @@
+module cell_indexing
+
+! this subroutine provide index mapping for hexagon meshes dimensioned (nx, ny)
+
+   integer, parameter :: maxEdges = 6
+
+   integer :: nx, ny, nVertLevels, nTracers, vertexDegree
+   real (kind=8) :: dc
+   integer, dimension(20) :: nproc
+
+
+   contains
+
+
+   subroutine cell_indexing_read_nl()
+
+      implicit none
+
+      namelist /periodic_grid/ nx, ny, dc, nVertLevels, nTracers, nproc, vertexDegree
+
+      nx = 200
+      ny = 200
+      dc = 10000.
+      nVertLevels = 1
+      nTracers = 2
+      nproc(:) = -1
+      vertexDegree = 3
+
+      open(20,file='namelist.input',status='old')
+      read(20,periodic_grid)
+      close(20)
+
+      if (mod(ny, 2) /= 0) then
+         print *, "Error: ny must be divisible by 2 for the grid's periodicity to work properly."
+         print *, "Please adjust ny in your namelist file and rerun the program."
+         call exit()
+      endif
+
+   end subroutine cell_indexing_read_nl
+
+
+   subroutine cellColRow(idx, iCol, iRow)
+
+      implicit none
+
+      integer, intent(in) :: idx
+      integer, intent(out) :: iCol, iRow
+
+      iRow = ((idx-1) / nx) + 1
+      iCol = mod((idx-1), nx) + 1
+
+   end subroutine cellColRow
+
+
+   integer function cellIdx(iCol, iRow)
+
+      implicit none
+
+      integer, intent(in) :: iCol, iRow
+
+      cellIdx = (iRow-1)*nx + iCol
+
+   end function cellIdx
+
+
+   integer function cellOnCell(iCol, iRow, neighborNumber)
+
+      implicit none
+
+      integer, intent(in) :: iCol, iRow, neighborNumber
+
+      integer :: mx, px, my, py
+
+      mx = iCol - 1
+      if (mx == 0) mx = nx
+      my = iRow - 1
+      if (my == 0) my = ny
+      px = iCol + 1
+      if (px == nx + 1) px = 1
+      py = iRow + 1
+      if (py == ny + 1) py = 1
+
+      if (mod(iRow,2) == 1) then
+         if (neighborNumber == 1) then
+            cellOnCell = cellIdx(mx, iRow)
+         else if (neighborNumber == 2) then
+            cellOnCell = cellIdx(mx, my)
+         else if (neighborNumber == 3) then
+            cellOnCell = cellIdx(iCol, my)
+         else if (neighborNumber == 4) then
+            cellOnCell = cellIdx(px, iRow)
+         else if (neighborNumber == 5) then
+            cellOnCell = cellIdx(iCol, py)
+         else if (neighborNumber == 6) then
+            cellOnCell = cellIdx(mx, py)
+         end if
+      else
+         if (neighborNumber == 1) then
+            cellOnCell = cellIdx(mx, iRow)
+         else if (neighborNumber == 2) then
+            cellOnCell = cellIdx(iCol, my)
+         else if (neighborNumber == 3) then
+            cellOnCell = cellIdx(px, my)
+         else if (neighborNumber == 4) then
+            cellOnCell = cellIdx(px, iRow)
+         else if (neighborNumber == 5) then
+            cellOnCell = cellIdx(px, py)
+         else if (neighborNumber == 6) then
+            cellOnCell = cellIdx(iCol, py)
+         end if
+      end if
+
+   end function cellOnCell
+
+
+   integer function edgeOnCell(iCell, neighborNumber)
+
+      implicit none
+
+      integer, intent(in) :: iCell, neighborNumber
+
+      integer :: myRow, myCol
+
+      call cellColRow(iCell, myCol, myRow)
+      
+      if (neighborNumber == 1) then
+         edgeOnCell = 3*(iCell - 1) + 1
+      else if (neighborNumber == 2) then
+         edgeOnCell = 3*(iCell - 1) + 2
+      else if (neighborNumber == 3) then
+         edgeOnCell = 3*(iCell - 1) + 3
+      else if (neighborNumber == 4) then
+         edgeOnCell = 3*(cellOnCell(myCol, myRow, 4) - 1) + 1
+      else if (neighborNumber == 5) then
+         edgeOnCell = 3*(cellOnCell(myCol, myRow, 5) - 1) + 2
+      else if (neighborNumber == 6) then
+         edgeOnCell = 3*(cellOnCell(myCol, myRow, 6) - 1) + 3
+      end if
+
+   end function edgeOnCell
+
+
+   integer function vertexOnCell(iCell, neighborNumber)
+
+      implicit none
+
+      integer, intent(in) :: iCell, neighborNumber
+
+      integer :: myRow, myCol
+
+      call cellColRow(iCell, myCol, myRow)
+
+      if (neighborNumber == 1) then
+         vertexOnCell = 2*(iCell - 1) + 1
+      else if (neighborNumber == 2) then
+         vertexOnCell = 2*(iCell - 1) + 2
+      else if (neighborNumber == 3) then
+         vertexOnCell = 2*(cellOnCell(myCol, myRow, 3) - 1) + 1
+      else if (neighborNumber == 4) then
+         vertexOnCell = 2*(cellOnCell(myCol, myRow, 4) - 1) + 2
+      else if (neighborNumber == 5) then
+         vertexOnCell = 2*(cellOnCell(myCol, myRow, 4) - 1) + 1
+      else if (neighborNumber == 6) then
+         vertexOnCell = 2*(cellOnCell(myCol, myRow, 5) - 1) + 2
+      end if
+
+   end function vertexOnCell
+
+
+end module cell_indexing

--- a/grid_gen/periodic_hex_minimal/module_write_netcdf.F
+++ b/grid_gen/periodic_hex_minimal/module_write_netcdf.F
@@ -1,0 +1,211 @@
+module write_netcdf
+ 
+   integer :: wr_ncid
+   integer :: wrDimIDnCells
+   integer :: wrDimIDnEdges
+   integer :: wrDimIDnVertices
+   integer :: wrDimIDmaxEdges
+   integer :: wrDimIDmaxEdges2
+   integer :: wrDimIDTWO
+   integer :: wrDimIDvertexDegree
+   integer :: wrVarIDxCell
+   integer :: wrVarIDyCell
+   integer :: wrVarIDzCell
+   integer :: wrVarIDxVertex
+   integer :: wrVarIDyVertex
+   integer :: wrVarIDzVertex
+   integer :: wrVarIDcellsOnVertex
+ 
+   integer :: wrLocalnCells
+   integer :: wrLocalnVertices
+ 
+   contains
+ 
+   subroutine write_netcdf_init( &
+                               nCells, &
+                               nEdges, &
+                               nVertices, &
+                               maxEdges, &
+                               vertexDegree, &
+                               dc, &
+                               nx, &
+                               ny )
+ 
+      implicit none
+ 
+      include 'netcdf.inc'
+ 
+      integer, intent(in) :: nCells
+      integer, intent(in) :: nEdges
+      integer, intent(in) :: nVertices
+      integer, intent(in) :: maxEdges
+      integer, intent(in) :: vertexDegree
+      real (kind=8), intent(in) :: dc
+      integer, intent(in) :: nx
+      integer, intent(in) :: ny
+ 
+      integer :: nferr
+      integer, dimension(10) :: dimlist
+      character (len=16) :: on_a_sphere
+      character (len=16) :: is_periodic
+      real (kind=8) :: sphere_radius
+      real (kind=8) :: x_offset, y_offset
+ 
+ 
+      wrLocalnCells = nCells
+      wrLocalnVertices = nVertices
+
+      on_a_sphere = 'NO'
+      is_periodic = 'YES'
+      sphere_radius = 0.0
+      x_offset = (nx) * dc
+      y_offset = (ny) * (dc * sqrt(3.0)) / 2.0
+ 
+      nferr = nf_create('grid.nc', IOR(NF_CLOBBER,NF_64BIT_OFFSET), wr_ncid)
+ 
+      !
+      ! Define dimensions
+      !
+      nferr = nf_def_dim(wr_ncid, 'nCells', nCells, wrDimIDnCells)
+      nferr = nf_def_dim(wr_ncid, 'nEdges', nEdges, wrDimIDnEdges)
+      nferr = nf_def_dim(wr_ncid, 'nVertices', nVertices, wrDimIDnVertices)
+      nferr = nf_def_dim(wr_ncid, 'maxEdges', maxEdges, wrDimIDmaxEdges)
+      nferr = nf_def_dim(wr_ncid, 'maxEdges2', 2*maxEdges, wrDimIDmaxEdges2)
+      nferr = nf_def_dim(wr_ncid, 'TWO', 2, wrDimIDTWO)
+      nferr = nf_def_dim(wr_ncid, 'vertexDegree', vertexDegree, wrDimIDvertexDegree)
+
+
+      !
+      ! Define attributes
+      !
+      nferr = nf_put_att_text(wr_ncid, NF_GLOBAL, 'on_a_sphere', 16, on_a_sphere)
+      nferr = nf_put_att_text(wr_ncid, NF_GLOBAL, 'is_periodic', 16, is_periodic)
+      nferr = nf_put_att_double(wr_ncid, NF_GLOBAL, 'sphere_radius', NF_DOUBLE, 1, sphere_radius)
+      nferr = nf_put_att_double(wr_ncid, NF_GLOBAL, 'x_offset', NF_DOUBLE, 1, x_offset)
+      nferr = nf_put_att_double(wr_ncid, NF_GLOBAL, 'y_offset', NF_DOUBLE, 1, y_offset)
+
+ 
+      !
+      ! Define variables
+      !
+      dimlist( 1) = wrDimIDnCells
+      nferr = nf_def_var(wr_ncid, 'xCell', NF_DOUBLE,  1, dimlist, wrVarIDxCell)
+      dimlist( 1) = wrDimIDnCells
+      nferr = nf_def_var(wr_ncid, 'yCell', NF_DOUBLE,  1, dimlist, wrVarIDyCell)
+      dimlist( 1) = wrDimIDnCells
+      nferr = nf_def_var(wr_ncid, 'zCell', NF_DOUBLE,  1, dimlist, wrVarIDzCell)
+      dimlist( 1) = wrDimIDnVertices
+      nferr = nf_def_var(wr_ncid, 'xVertex', NF_DOUBLE,  1, dimlist, wrVarIDxVertex)
+      dimlist( 1) = wrDimIDnVertices
+      nferr = nf_def_var(wr_ncid, 'yVertex', NF_DOUBLE,  1, dimlist, wrVarIDyVertex)
+      dimlist( 1) = wrDimIDnVertices
+      nferr = nf_def_var(wr_ncid, 'zVertex', NF_DOUBLE,  1, dimlist, wrVarIDzVertex)
+      dimlist( 1) = wrDimIDvertexDegree
+      dimlist( 2) = wrDimIDnVertices
+      nferr = nf_def_var(wr_ncid, 'cellsOnVertex', NF_INT,  2, dimlist, wrVarIDcellsOnVertex)
+ 
+      nferr = nf_enddef(wr_ncid)
+ 
+   end subroutine write_netcdf_init
+ 
+ 
+   subroutine write_netcdf_fields( &
+                                  xCell, &
+                                  yCell, &
+                                  zCell, &
+                                  xVertex, &
+                                  yVertex, &
+                                  zVertex, &
+                                  cellsOnVertex )
+ 
+      implicit none
+ 
+      include 'netcdf.inc'
+ 
+      real (kind=8), dimension(:), optional, intent(in) :: xCell
+      real (kind=8), dimension(:), optional, intent(in) :: yCell
+      real (kind=8), dimension(:), optional, intent(in) :: zCell
+      real (kind=8), dimension(:), optional, intent(in) :: xVertex
+      real (kind=8), dimension(:), optional, intent(in) :: yVertex
+      real (kind=8), dimension(:), optional, intent(in) :: zVertex
+      integer, dimension(:,:), optional, intent(in) :: cellsOnVertex
+
+      integer :: nferr
+      integer, dimension(1) :: start1, count1
+      integer, dimension(2) :: start2, count2
+      integer, dimension(3) :: start3, count3
+      integer, dimension(4) :: start4, count4
+ 
+      start1(1) = 1
+ 
+      start2(1) = 1
+      start2(2) = 1
+ 
+      start3(1) = 1
+      start3(2) = 1
+      start3(3) = 1
+ 
+      start4(1) = 1
+      start4(2) = 1
+      start4(3) = 1
+      start4(4) = 1
+ 
+      if(present(xCell))then      
+      start1(1) = 1
+      count1( 1) = wrLocalnCells
+      nferr = nf_put_vara_double(wr_ncid, wrVarIDxCell, start1, count1, xCell)
+      endif
+ 
+      if(present(yCell))then      
+      start1(1) = 1
+      count1( 1) = wrLocalnCells
+      nferr = nf_put_vara_double(wr_ncid, wrVarIDyCell, start1, count1, yCell)
+      endif
+ 
+      if(present(zCell))then      
+      start1(1) = 1
+      count1( 1) = wrLocalnCells
+      nferr = nf_put_vara_double(wr_ncid, wrVarIDzCell, start1, count1, zCell)
+      endif
+ 
+      if(present(xVertex))then  
+      start1(1) = 1
+      count1( 1) = wrLocalnVertices
+      nferr = nf_put_vara_double(wr_ncid, wrVarIDxVertex, start1, count1, xVertex)
+      endif
+ 
+      if(present(yVertex))then      
+      start1(1) = 1
+      count1( 1) = wrLocalnVertices
+      nferr = nf_put_vara_double(wr_ncid, wrVarIDyVertex, start1, count1, yVertex)
+      endif
+ 
+      if(present(zVertex))then      
+      start1(1) = 1
+      count1( 1) = wrLocalnVertices
+      nferr = nf_put_vara_double(wr_ncid, wrVarIDzVertex, start1, count1, zVertex)
+      endif
+ 
+      if(present(cellsOnVertex))then
+      start2(2) = 1
+      count2( 1) = 3
+      count2( 2) = wrLocalnVertices
+      nferr = nf_put_vara_int(wr_ncid, wrVarIDcellsOnVertex, start2, count2, cellsOnVertex)
+      endif
+ 
+   end subroutine write_netcdf_fields
+ 
+ 
+   subroutine write_netcdf_finalize()
+ 
+      implicit none
+ 
+      include 'netcdf.inc'
+ 
+      integer :: nferr
+ 
+      nferr = nf_close(wr_ncid)
+ 
+   end subroutine write_netcdf_finalize
+ 
+end module write_netcdf

--- a/grid_gen/periodic_hex_minimal/namelist.input
+++ b/grid_gen/periodic_hex_minimal/namelist.input
@@ -1,0 +1,5 @@
+&periodic_grid
+   nx = 500,
+   ny = 500,
+   dc = 10000.,
+/

--- a/grid_gen/periodic_hex_minimal/periodic_grid.F
+++ b/grid_gen/periodic_hex_minimal/periodic_grid.F
@@ -1,0 +1,103 @@
+program hexagonal_periodic_grid
+
+   use cell_indexing
+   use write_netcdf
+
+   implicit none
+
+   real (kind=8), parameter :: pi = 3.141592653589793
+   real (kind=8), parameter :: ONE = 1.0_8
+   real (kind=8), parameter :: TWO = 2.0_8
+   real (kind=8), parameter :: THREE = 3.0_8
+   real (kind=8), parameter :: FOUR = 4.0_8
+   real (kind=8), parameter :: SIX = 6.0_8
+
+   integer, allocatable, dimension(:,:) :: verticesOnCell, cellsOnVertex
+   real (kind=8), allocatable, dimension(:) :: xCell, yCell, zCell
+   real (kind=8), allocatable, dimension(:) :: xVertex, yVertex, zVertex
+
+   integer :: i, j, np, iCell
+   integer :: nCells, nEdges, nVertices
+   integer :: iRow, iCol, ii, jj
+   integer :: nprocx, nprocy
+   real (kind=8) :: r
+   character (len=32) :: decomp_fname
+
+   call cell_indexing_read_nl()
+
+   nCells = nx*ny
+   nEdges = 3*nCells
+   nVertices = 2*nCells
+
+   call write_netcdf_init( nCells, nEdges, nVertices, maxEdges, vertexDegree, dc, nx, ny )
+
+   allocate(verticesOnCell(maxEdges, nCells))
+
+   do iRow = 1, ny
+   do iCol = 1, nx
+      iCell = cellIdx(iCol,iRow)
+      do j=1,maxEdges
+         verticesOnCell(j,iCell) = vertexOnCell(iCell,j)
+      end do
+    end do
+    end do
+
+   allocate(cellsOnVertex(3,nVertices))
+
+   do iRow = 1, ny
+   do iCol = 1, nx
+      iCell = cellIdx(iCol,iRow)
+      cellsOnVertex(3,verticesOnCell(2,iCell)) = iCell
+      cellsOnVertex(1,verticesOnCell(4,iCell)) = iCell
+      cellsOnVertex(2,verticesOnCell(6,iCell)) = iCell
+      cellsOnVertex(1,verticesOnCell(1,iCell)) = iCell
+      cellsOnVertex(2,verticesOnCell(3,iCell)) = iCell
+      cellsOnVertex(3,verticesOnCell(5,iCell)) = iCell
+   end do
+   end do
+
+   call write_netcdf_fields( cellsOnVertex=cellsOnVertex )
+
+   allocate(xCell(nCells))
+   allocate(yCell(nCells))
+   allocate(zCell(nCells))
+   allocate(xVertex(nVertices))
+   allocate(yVertex(nVertices))
+   allocate(zVertex(nVertices))
+
+   do iRow = 1, ny
+   do iCol = 1, nx
+      iCell = cellIdx(iCol, iRow)
+      if (mod(iRow,2) == 1) then
+         xCell(iCell) = dc*real(iCol) - 0.5*dc
+         yCell(iCell) = dc*real(iRow)*sqrt(THREE) / TWO
+         zCell(iCell) = 0.0
+      else
+         xCell(iCell) = dc*real(iCol)
+         yCell(iCell) = dc*real(iRow)*sqrt(THREE) / TWO
+         zCell(iCell) = 0.0
+      end if
+      xVertex(verticesOnCell(1,iCell)) = xCell(iCell) - 0.5*dc
+      yVertex(verticesOnCell(1,iCell)) = yCell(iCell) + dc * sqrt(THREE) / SIX
+      zVertex(verticesOnCell(1,iCell)) = 0.0
+      xVertex(verticesOnCell(2,iCell)) = xCell(iCell) - 0.5*dc
+      yVertex(verticesOnCell(2,iCell)) = yCell(iCell) - dc * sqrt(THREE) / SIX
+      zVertex(verticesOnCell(2,iCell)) = 0.0
+   end do
+   end do
+
+   deallocate(verticesOnCell)
+
+   call write_netcdf_fields( xCell=xCell, yCell=yCell, zCell=zCell )
+   deallocate(xCell)
+   deallocate(yCell)
+   deallocate(zCell)
+
+   call write_netcdf_fields( xVertex=xVertex, yVertex=yVertex, zVertex=zVertex ) 
+   deallocate(xVertex)
+   deallocate(yVertex)
+   deallocate(zVertex)
+
+   call write_netcdf_finalize()
+
+end program hexagonal_periodic_grid


### PR DESCRIPTION
This PR adds a new, minimal version of the periodic_grid creation code to "./grid_gen/". It is much faster for moderate to large meshes. The output, "grid.nc" is then input to "mpas_mesh_converter" in "./grid_gen/mesh_conversion_tools/" in order to make a full, MPAS-compliant mesh (as explained in more detail in the README file).  
