### PR TITLE
generalize mpas_draw makefile for OS X and linux

### DIFF
--- a/visualization/mpas_draw/Makefile
+++ b/visualization/mpas_draw/Makefile
@@ -7,8 +7,12 @@ DBGFLAGS= -g -m64
 
 #OFFSETFLAG=-D_64BITOFFSET
 
-PLATFORM=_MACOS
-PLATFORM=_LINUX
+platform=$(shell uname)
+ifeq ($(platform),Darwin)
+	PLATFORM=_MACOS
+else
+	PLATFORM=_LINUX
+endif
 
 ifeq ($(PLATFORM),_LINUX)
 	CXXLIBS = -I$(NETCDF)/include -L$(NETCDF)/lib -lGL -lglut -lnetcdf_c++ -lnetcdf -lGLU -lstdc++


### PR DESCRIPTION
This automatically differentiates between OS X and linux for the mpas_draw makefile to set platform dependent preferences for user convenience.
