### PR TITLE
Updating mesh conversion tools for global attributes

### DIFF
--- a/grid_gen/mesh_conversion_tools/mpas_cell_culler.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_cell_culler.cpp
@@ -19,7 +19,7 @@ int nCells, nVertices, nEdges, vertexDegree, maxEdges;
 bool spherical, periodic;
 double sphere_radius, xPeriod, yPeriod;
 string in_history = "";
-string in_mesh_id = "";
+string in_file_id = "";
 string in_parent_id = "";
 double in_mesh_spec = 1.0;
 
@@ -190,9 +190,9 @@ int readGridInput(const string inputFilename){/*{{{*/
 #endif
 	in_history = netcdf_mpas_read_history(inputFilename);
 #ifdef _DEBUG
-	cout << "   Reading mesh_id" << endl;
+	cout << "   Reading file_id" << endl;
 #endif
-	in_mesh_id = netcdf_mpas_read_meshid(inputFilename);
+	in_file_id = netcdf_mpas_read_fileid(inputFilename);
 #ifdef _DEBUG
 	cout << "   Reading parent_id" << endl;
 #endif
@@ -440,7 +440,7 @@ int outputGridDimensions( const string outputFilename ){/*{{{*/
 	NcDim *TWODim;
 	NcDim *THREEDim;
 	NcDim *vertexDegreeDim;
-	NcDim *nVertLevelsDim;
+//	NcDim *nVertLevelsDim;
 	NcDim *timeDim;
 
 	nCellsNew = 0;
@@ -464,7 +464,7 @@ int outputGridDimensions( const string outputFilename ){/*{{{*/
 	if (!(nVerticesDim =	grid.add_dim(	"nVertices",	nVerticesNew)	)) return NC_ERR;
 	if (!(TWODim =			grid.add_dim(	"TWO",			2)				)) return NC_ERR;
 	if (!(vertexDegreeDim = grid.add_dim(   "vertexDegree", vertexDegree)	)) return NC_ERR;
-	if (!(nVertLevelsDim =  grid.add_dim(   "nVertLevels", 1)				)) return NC_ERR;
+//	if (!(nVertLevelsDim =  grid.add_dim(   "nVertLevels", 1)				)) return NC_ERR;
 	if (!(timeDim = 		grid.add_dim(   "Time")							)) return NC_ERR;
 
 	grid.close();
@@ -522,8 +522,8 @@ int outputGridAttributes( const string inputFilename, const string outputFilenam
 		history_str += in_history;
 	}
 
-	if(in_mesh_id != "" ){
-		parent_str = in_mesh_id;
+	if(in_file_id != "" ){
+		parent_str = in_file_id;
 		if(in_parent_id != ""){
 			parent_str += "\n";
 			parent_str += in_parent_id;
@@ -537,7 +537,7 @@ int outputGridAttributes( const string inputFilename, const string outputFilenam
 	if (!(spec = grid.add_att(   "mesh_spec", in_mesh_spec ))) return NC_ERR;
 	if (!(conventions = grid.add_att(   "Conventions", "MPAS" ))) return NC_ERR;
 	if (!(source = grid.add_att(   "source", "MpasCellCuller.x" ))) return NC_ERR;
-	if (!(id = grid.add_att(   "mesh_id", id_str.c_str() ))) return NC_ERR;
+	if (!(id = grid.add_att(   "file_id", id_str.c_str() ))) return NC_ERR;
 
 	grid.close();
 	

--- a/grid_gen/mesh_conversion_tools/mpas_mesh_converter.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_mesh_converter.cpp
@@ -37,7 +37,7 @@ double xCellDistance, yCellDistance, zCellDistance;
 double xVertexDistance, yVertexDistance, zVertexDistance;
 double xPeriodicFix, yPeriodicFix;
 string in_history = "";
-string in_mesh_id = "";
+string in_file_id = "";
 string in_parent_id = "";
 
 // Connectivity and location information {{{
@@ -324,9 +324,9 @@ int readGridInput(const string inputFilename){/*{{{*/
 #endif
 	in_history = netcdf_mpas_read_history(inputFilename);
 #ifdef _DEBUG
-	cout << "   Reading mesh_id" << endl;
+	cout << "   Reading file_id" << endl;
 #endif
-	in_mesh_id = netcdf_mpas_read_meshid(inputFilename);
+	in_file_id = netcdf_mpas_read_fileid(inputFilename);
 
 #ifdef _DEBUG
 	cout << "   Reading parent_id" << endl;
@@ -2373,7 +2373,7 @@ int outputGridDimensions( const string outputFilename ){/*{{{*/
 	NcDim *THREEDim;
 	NcDim *vertexDegreeDim;
 	NcDim *timeDim;
-	NcDim *nVertLevelsDim;
+//	NcDim *nVertLevelsDim;
 	
 	// write dimensions
 	if (!(nCellsDim =		grid.add_dim(	"nCells",		cells.size())		)) return NC_ERR;
@@ -2383,7 +2383,7 @@ int outputGridDimensions( const string outputFilename ){/*{{{*/
 	if (!(maxEdges2Dim =	grid.add_dim(	"maxEdges2",	maxEdges*2)			)) return NC_ERR;
 	if (!(TWODim =			grid.add_dim(	"TWO",			2)					)) return NC_ERR;
 	if (!(vertexDegreeDim = grid.add_dim(   "vertexDegree", vertex_degree)		)) return NC_ERR;
-	if (!(nVertLevelsDim =  grid.add_dim(   "nVertLevels", 1)					)) return NC_ERR;
+//	if (!(nVertLevelsDim =  grid.add_dim(   "nVertLevels", 1)					)) return NC_ERR;
 	if (!(timeDim = 		grid.add_dim(   "Time")								)) return NC_ERR;
 
 	grid.close();
@@ -2434,8 +2434,8 @@ int outputGridAttributes( const string outputFilename, const string inputFilenam
 		history_str += in_history;
 	}
 
-	if(in_mesh_id != "" ){
-		parent_str = in_mesh_id;
+	if(in_file_id != "" ){
+		parent_str = in_file_id;
 		if(in_parent_id != ""){
 			parent_str += "\n";
 			parent_str += in_parent_id;
@@ -2450,7 +2450,7 @@ int outputGridAttributes( const string outputFilename, const string inputFilenam
 	if (!(spec = grid.add_att(   "mesh_spec", mesh_spec_str ))) return NC_ERR;
 	if (!(conventions = grid.add_att(   "Conventions", "MPAS" ))) return NC_ERR;
 	if (!(source = grid.add_att(   "source", "MpasMeshConverter.x" ))) return NC_ERR;
-	if (!(id = grid.add_att(   "mesh_id", id_str.c_str() ))) return NC_ERR;
+	if (!(id = grid.add_att(   "file_id", id_str.c_str() ))) return NC_ERR;
 
 	grid.close();
 	

--- a/grid_gen/mesh_conversion_tools/netcdf_utils.cpp
+++ b/grid_gen/mesh_conversion_tools/netcdf_utils.cpp
@@ -544,12 +544,12 @@ string netcdf_mpas_read_history(string filename){/*{{{*/
 
 }/*}}}*/
 //****************************************************************************80
-string netcdf_mpas_read_meshid(string filename){/*{{{*/
+string netcdf_mpas_read_fileid(string filename){/*{{{*/
 	//****************************************************************************80
 	//
 	//  Purpose:
 	//
-	//    NETCDF_MPAS_READ_MESHID reads the mesh_id attribute from a file.
+	//    NETCDF_MPAS_READ_FILEID reads the file_id attribute from a file.
 	//
 	//  Licensing:
 	//
@@ -573,13 +573,13 @@ string netcdf_mpas_read_meshid(string filename){/*{{{*/
 	//
 	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
 	//
-	//    Output, string NETCDF_MPAS_READ_MESHID, the value of the mesh_id attribute
+	//    Output, string NETCDF_MPAS_READ_FILEID, the value of the file_id attribute
 	//
 	NcAtt *att_id;
 	NcValues *vals;
 	bool valid;
 	string tmp_name;
-	string sph_name = "mesh_id";
+	string sph_name = "file_id";
 	string id_str = "";
 	//
 	//  Open the file.

--- a/grid_gen/mesh_conversion_tools/netcdf_utils.h
+++ b/grid_gen/mesh_conversion_tools/netcdf_utils.h
@@ -12,7 +12,7 @@ bool netcdf_mpas_read_isperiodic(string filename);
 double netcdf_mpas_read_xperiod(string filename);
 double netcdf_mpas_read_yperiod(string filename);
 string netcdf_mpas_read_history(string filename);
-string netcdf_mpas_read_meshid(string filename);
+string netcdf_mpas_read_fileid(string filename);
 string netcdf_mpas_read_parentid(string filename);
 double netcdf_mpas_read_meshspec(string filename);
 /*}}}*/


### PR DESCRIPTION
This merge updates the mesh conversion tools to use file_id instead of
mesh_id for processing provenance information through the front_end tool
chain.
