### PR TITLE
Removing nVertLevels from mesh conversion tools

### DIFF
--- a/grid_gen/mesh_conversion_tools/mpas_cell_culler.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_cell_culler.cpp
@@ -440,7 +440,6 @@ int outputGridDimensions( const string outputFilename ){/*{{{*/
 	NcDim *TWODim;
 	NcDim *THREEDim;
 	NcDim *vertexDegreeDim;
-//	NcDim *nVertLevelsDim;
 	NcDim *timeDim;
 
 	nCellsNew = 0;
@@ -464,7 +463,6 @@ int outputGridDimensions( const string outputFilename ){/*{{{*/
 	if (!(nVerticesDim =	grid.add_dim(	"nVertices",	nVerticesNew)	)) return NC_ERR;
 	if (!(TWODim =			grid.add_dim(	"TWO",			2)				)) return NC_ERR;
 	if (!(vertexDegreeDim = grid.add_dim(   "vertexDegree", vertexDegree)	)) return NC_ERR;
-//	if (!(nVertLevelsDim =  grid.add_dim(   "nVertLevels", 1)				)) return NC_ERR;
 	if (!(timeDim = 		grid.add_dim(   "Time")							)) return NC_ERR;
 
 	grid.close();

--- a/grid_gen/mesh_conversion_tools/mpas_mesh_converter.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_mesh_converter.cpp
@@ -2373,7 +2373,6 @@ int outputGridDimensions( const string outputFilename ){/*{{{*/
 	NcDim *THREEDim;
 	NcDim *vertexDegreeDim;
 	NcDim *timeDim;
-//	NcDim *nVertLevelsDim;
 	
 	// write dimensions
 	if (!(nCellsDim =		grid.add_dim(	"nCells",		cells.size())		)) return NC_ERR;
@@ -2383,7 +2382,6 @@ int outputGridDimensions( const string outputFilename ){/*{{{*/
 	if (!(maxEdges2Dim =	grid.add_dim(	"maxEdges2",	maxEdges*2)			)) return NC_ERR;
 	if (!(TWODim =			grid.add_dim(	"TWO",			2)					)) return NC_ERR;
 	if (!(vertexDegreeDim = grid.add_dim(   "vertexDegree", vertex_degree)		)) return NC_ERR;
-//	if (!(nVertLevelsDim =  grid.add_dim(   "nVertLevels", 1)					)) return NC_ERR;
 	if (!(timeDim = 		grid.add_dim(   "Time")								)) return NC_ERR;
 
 	grid.close();


### PR DESCRIPTION
This merge removes nVertLevels from the mesh conversion tools to allow front end workflows to work correctly, when nVertLevels is set during an init step.
