### PR TITLE
Fixup create li grid script

### DIFF
--- a/grid_gen/landice_grid_tools/create_landice_grid_from_generic_MPAS_grid.py
+++ b/grid_gen/landice_grid_tools/create_landice_grid_from_generic_MPAS_grid.py
@@ -136,14 +136,14 @@ newvar = fileout.createVariable('temperature', datatype, ('Time', 'nCells', 'nVe
 newvar[0,:,:] = numpy.zeros( newvar.shape[1:] )
 # These landice variables are stored in the mesh currently, and therefore do not have a time dimension.
 #    It may make sense to eventually move them to state.
-newvar = fileout.createVariable('bedTopography', datatype, ('nCells',))
+newvar = fileout.createVariable('bedTopography', datatype, ('Time', 'nCells',))
 newvar[:] = numpy.zeros(newvar.shape)
-newvar = fileout.createVariable('sfcMassBal', datatype, ('nCells',))
+newvar = fileout.createVariable('sfcMassBal', datatype, ('Time', 'nCells',))
 newvar[:] = numpy.zeros(newvar.shape)
 print 'Added default variables: thickness, temperature, bedTopography, sfcMassBal'
 
 if options.beta:
-   newvar = fileout.createVariable('beta', datatype, ('nCells',))
+   newvar = fileout.createVariable('beta', datatype, ('Time', 'nCells',))
    newvar[:] = 1.0e8  # Give a default beta that won't have much sliding.
    print 'Added optional variable: beta'
 


### PR DESCRIPTION
This branch cleans up the script used to create land ice grids (create_landice_grid_from_generic_MPAS_grid.py).
1. It make the script more efficient and prints additional information to stdout, both of which improve the usage for large grids substantially.
2. Fixes an error in how the history attribute is written (bug was introduced when that feature was added recently)
3. Makes bedtopo, smb, and beta fields have a time dimension.  They have a time dimension in Registry.xml now.  (this breaks some existing test case scripts that will need cleanup.)
