### PR TITLE
Updating the minimal periodic_hex with periodic attributes

### DIFF
--- a/grid_gen/periodic_hex_minimal/module_write_netcdf.F
+++ b/grid_gen/periodic_hex_minimal/module_write_netcdf.F
@@ -49,7 +49,7 @@ module write_netcdf
       character (len=16) :: on_a_sphere
       character (len=16) :: is_periodic
       real (kind=8) :: sphere_radius
-      real (kind=8) :: x_offset, y_offset
+      real (kind=8) :: x_period, y_period
  
  
       wrLocalnCells = nCells
@@ -58,8 +58,8 @@ module write_netcdf
       on_a_sphere = 'NO'
       is_periodic = 'YES'
       sphere_radius = 0.0
-      x_offset = (nx) * dc
-      y_offset = (ny) * (dc * sqrt(3.0)) / 2.0
+      x_period = (nx) * dc
+      y_period = (ny) * (dc * sqrt(3.0)) / 2.0
  
       nferr = nf_create('grid.nc', IOR(NF_CLOBBER,NF_64BIT_OFFSET), wr_ncid)
  
@@ -81,8 +81,8 @@ module write_netcdf
       nferr = nf_put_att_text(wr_ncid, NF_GLOBAL, 'on_a_sphere', 16, on_a_sphere)
       nferr = nf_put_att_text(wr_ncid, NF_GLOBAL, 'is_periodic', 16, is_periodic)
       nferr = nf_put_att_double(wr_ncid, NF_GLOBAL, 'sphere_radius', NF_DOUBLE, 1, sphere_radius)
-      nferr = nf_put_att_double(wr_ncid, NF_GLOBAL, 'x_offset', NF_DOUBLE, 1, x_offset)
-      nferr = nf_put_att_double(wr_ncid, NF_GLOBAL, 'y_offset', NF_DOUBLE, 1, y_offset)
+      nferr = nf_put_att_double(wr_ncid, NF_GLOBAL, 'x_period', NF_DOUBLE, 1, x_period)
+      nferr = nf_put_att_double(wr_ncid, NF_GLOBAL, 'y_period', NF_DOUBLE, 1, y_period)
 
  
       !


### PR DESCRIPTION
This merge fixes the global attributes of the periodic_hex_minimal tool to be correct for periodic meshes.
