### PR TITLE
Print xtime in MpasDraw

### DIFF
--- a/visualization/mpas_draw/mpas_draw.cpp
+++ b/visualization/mpas_draw/mpas_draw.cpp
@@ -2015,6 +2015,8 @@ void keyPressed( unsigned char key, int x, int y ) {/*{{{*/
 	//    Geoff Womeldorff, Doug Jacobsen
 	//
 
+	char xtime[64];
+	int xtime_found;
 
 	usleep( 100 );
 
@@ -2047,15 +2049,29 @@ void keyPressed( unsigned char key, int x, int y ) {/*{{{*/
 			color_mesh();
 			break;
 		case KEY_t:
-			cur_time = (cur_time + 1) % ntime;
-			cout << "Current time level: " << cur_time+1 << " out of " << ntime << ".  xtime=" << netcdf_mpas_get_xtime(filename, cur_time) << endl;
+			if ( ntime > 0 ) {
+				cur_time = (cur_time + 1) % ntime;
+			}
+			xtime_found = netcdf_mpas_get_xtime(filename, cur_time, &xtime[0]);
+			if ( xtime_found ) {
+				cout << "Current time level: " << cur_time+1 << " out of " << ntime << ".  xtime=" << xtime << endl;
+			} else {
+				cout << "Current time level: " << cur_time+1 << " out of " << ntime << "." << endl;
+			}
 			color_mesh();
 			break;
 		case KEY_T:
-			cur_time = (cur_time - 1) % ntime;
-			if(cur_time < 0)
-				cur_time = ntime-1;
-			cout << "Current time level: " << cur_time+1 << " out of " << ntime << endl;
+			if ( ntime > 0 ) {
+				cur_time = (cur_time - 1) % ntime;
+				if(cur_time < 0)
+					cur_time = ntime-1;
+			}
+			xtime_found = netcdf_mpas_get_xtime(filename, cur_time, &xtime[0]);
+			if ( xtime_found ) {
+				cout << "Current time level: " << cur_time+1 << " out of " << ntime << ".  xtime=" << xtime << endl;
+			} else {
+				cout << "Current time level: " << cur_time+1 << " out of " << ntime << "." << endl;
+			}
 			color_mesh();
 			break;
 		case KEY_s:

--- a/visualization/mpas_draw/netcdf_utils.cpp
+++ b/visualization/mpas_draw/netcdf_utils.cpp
@@ -1772,7 +1772,7 @@ void  netcdf_mpas_get_vert_dim_info(string filename, int id, int& dim_size, stri
 }/*}}}*/
 
 //****************************************************************************
-string netcdf_mpas_get_xtime(string filename, int cur_time){/*{{{*/
+int netcdf_mpas_get_xtime(string filename, int cur_time, char *xtime){/*{{{*/
 	//**************************************************************************
 	//
 	//  Purpose:
@@ -1803,6 +1803,8 @@ string netcdf_mpas_get_xtime(string filename, int cur_time){/*{{{*/
 	//    Output, int dim_name, the name of the dimension
 
 	NcVar *var_id;
+	string name;
+	int num_vars;
 
 	//
 	//  Open the file.
@@ -1815,15 +1817,23 @@ string netcdf_mpas_get_xtime(string filename, int cur_time){/*{{{*/
 	//
 	//  Get the variable and its dimensions
 	//
-	var_id = ncid.get_var ("xtime");
-        char xtime[64];
-	(*var_id).get ( &xtime[0], cur_time, 64 );
+	
+	num_vars = ncid.num_vars();
 
-        cout << "DEBUG: xtime=" << xtime << endl;
+	for ( int i = 0; i < num_vars; i++ ) {
+		var_id = ncid.get_var(i);
+		name = var_id->name();
+		if ( name == "xtime" ) {
+			(*var_id).set_cur(cur_time);
+			(*var_id).get ( &xtime[0], 1, 64 );
+			ncid.close();
+			return 1;
+		}
+	}
+
 	//
 	//  Close the file.
 	//
-	ncid.close ( );
-        string xtimestr(xtime);
-	return xtimestr;
+	ncid.close();
+	return 0;
 }/*}}}*/

--- a/visualization/mpas_draw/netcdf_utils.h
+++ b/visualization/mpas_draw/netcdf_utils.h
@@ -22,4 +22,4 @@ void netcdf_mpas_print_field_info(string filename, int id);
 void netcdf_mpas_read_field(string filename, int id, double values[], int cur_time, int cur_level);
 void netcdf_mpas_read_full_field(string filename, int id, double values[]);
 int netcdf_mpas_get_vert_dim_info(string filename, int id, int& dim_size, string& dim_name);
-string netcdf_mpas_get_xtime(string filename, int cur_time);
+int netcdf_mpas_get_xtime(string filename, int cur_time, char *xtime);


### PR DESCRIPTION
This merge prints the xtime corresponding to the current time level to the screen when using MpasDraw.  Also, if xtime or the Time dimension do not exist, then MpasDraw handles these situations gracefully.
