### PR TITLE
Disable writing point cell mask

### DIFF
--- a/grid_gen/mesh_conversion_tools/mpas_mask_creator.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_mask_creator.cpp
@@ -20,7 +20,7 @@
 #define MESH_SPEC 1.0
 #define ID_LEN 10
 
-#define _WRITE_POINT_MASK
+//#define _WRITE_POINT_MASK
 
 using namespace std;
 


### PR DESCRIPTION
This merge turns off writing the point cell mask, since it's only useful for debugging.
