### PR TITLE
Fix vtk extraction for fields on vertices

### DIFF
--- a/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
+++ b/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
@@ -28,12 +28,11 @@ import vtk
 import sys, os, glob
 import numpy as np
 
-from netCDF4 import *
 from netCDF4 import Dataset as NetCDFFile
 import argparse
 
 try:
-    from progressbar import *
+    from progressbar import ProgressBar, Percentage, Bar, ETA
     use_progress_bar = True
 except:
     use_progress_bar = False
@@ -167,13 +166,11 @@ def summarize_extraction(all_dim_vals, time_global_indices, cellVarTime, cellVar
             print "      name: %s"%(var)
 
     if len(edgeVarTime) > 0:
-        print " Edge fields are currently not supported, any fields listed are ignored."
         print "   Variables with 'Time' and 'nEdges' as dimensions:"
         for var in edgeVarTime:
             print "      name: %s"%(var)
 
     if len(edgeVarNoTime) > 0:
-        print " Edge fields are currently not supported, any fields listed are ignored."
         print "   Variables with 'nEdges' and without 'Time' as dimensions:"
         for var in edgeVarNoTime:
             print "      name: %s"%(var)
@@ -181,7 +178,7 @@ def summarize_extraction(all_dim_vals, time_global_indices, cellVarTime, cellVar
     print ""
 #}}}
 
-def build_cell_lists( nc_file, blocking, cell_list ):#{{{
+def build_cell_lists( nc_file, blocking, cell_list, valid_mask ):#{{{
     nCells = len(nc_file.dimensions['nCells'])
 
     nEdgesOnCell_var = nc_file.variables['nEdgesOnCell']
@@ -201,16 +198,17 @@ def build_cell_lists( nc_file, blocking, cell_list ):#{{{
         blockCount = blockEnd - blockStart
 
         nEdgesOnCell = nEdgesOnCell_var[blockStart:blockEnd]
-        verticesOnCell = verticesOnCell_var[blockStart:blockEnd][:]
+        verticesOnCell = verticesOnCell_var[blockStart:blockEnd,:] - 1
 
         for idx in np.arange(0, blockCount):
             polygon = vtk.vtkPolygon()
             polygon.GetPointIds().SetNumberOfIds(nEdgesOnCell[idx])
             for iVertex in np.arange(0, nEdgesOnCell[idx]):
-                vert = verticesOnCell[idx][iVertex] - 1
+                vert = verticesOnCell[idx,iVertex]
                 polygon.GetPointIds().SetId(iVertex, vert)
 
             cell_list.InsertNextCell(polygon)
+            valid_mask[blockStart + idx] = True
 
         del nEdgesOnCell
         del verticesOnCell
@@ -222,7 +220,7 @@ def build_cell_lists( nc_file, blocking, cell_list ):#{{{
 
 #}}}
 
-def build_dual_cell_lists( nc_file, blocking, cell_list ):#{{{
+def build_dual_cell_lists( nc_file, blocking, cell_list, valid_mask ):#{{{
     nVertices = len(nc_file.dimensions['nVertices'])
     vertexDegree = len(nc_file.dimensions['vertexDegree'])
 
@@ -241,21 +239,23 @@ def build_dual_cell_lists( nc_file, blocking, cell_list ):#{{{
         blockEnd = min( (iBlock + 1) * blocking, nVertices )
         blockCount = blockEnd - blockStart
 
-        cellsOnVertex = cellsOnVertex_var[blockStart:blockEnd][:]
+        cellsOnVertex = cellsOnVertex_var[blockStart:blockEnd,:] - 1
 
-        keep_cell = True
+        valid = np.all(cellsOnVertex >= 0, axis=1)
+        valid_mask[blockStart:blockEnd] = valid
 
         for idx in np.arange(0, blockCount):
+            if not valid[idx]:
+                continue
+
             polygon = vtk.vtkPolygon()
             polygon.GetPointIds().SetNumberOfIds(vertexDegree)
 
             for iCell in np.arange(0, vertexDegree):
-                cell = cellsOnVertex[idx][iCell] - 1
-                polygon.GetPointIds().SetId(iVertex, cell)
-                keep_cell = keep_cell and ( cell >= 0 )
+                cell = cellsOnVertex[idx,iCell]
+                polygon.GetPointIds().SetId(iCell, cell)
 
-            if keep_cell:
-                cell_list.InsertNextCell(polygon)
+            cell_list.InsertNextCell(polygon)
 
         del cellsOnVertex
         if use_progress_bar:
@@ -265,10 +265,9 @@ def build_dual_cell_lists( nc_file, blocking, cell_list ):#{{{
         dual_bar.finish()
 #}}}
 
-def build_edge_cell_lists( nc_file, blocking, cell_list ):#{{{
+def build_edge_cell_lists( nc_file, blocking, cell_list, valid_mask ):#{{{
     nCells = len(nc_file.dimensions['nCells'])
     nEdges = len(nc_file.dimensions['nEdges'])
-    nVertices = len(nc_file.dimensions['nVertices'])
 
     cellsOnEdge_var = nc_file.variables['cellsOnEdge']
     verticesOnEdge_var = nc_file.variables['verticesOnEdge']
@@ -286,15 +285,15 @@ def build_edge_cell_lists( nc_file, blocking, cell_list ):#{{{
         blockEnd = min( (iBlock + 1) * blocking, nEdges )
         blockCount = blockEnd - blockStart
 
-        verticesOnEdge = verticesOnEdge_var[blockStart:blockEnd][:]
-        cellsOnEdge = cellsOnEdge_var[blockStart:blockEnd][:]
+        verticesOnEdge = verticesOnEdge_var[blockStart:blockEnd,:] - 1
+        cellsOnEdge = cellsOnEdge_var[blockStart:blockEnd,:] - 1
 
         for idx in np.arange(0, blockCount):
 
-            cell1 = cellsOnEdge[idx][0] - 1
-            vertex1 = verticesOnEdge[idx][0] - 1
-            cell2 = cellsOnEdge[idx][1] - 1
-            vertex2 = verticesOnEdge[idx][1] - 1
+            cell1 = cellsOnEdge[idx,0]
+            vertex1 = verticesOnEdge[idx,0]
+            cell2 = cellsOnEdge[idx,1]
+            vertex2 = verticesOnEdge[idx,1]
 
             valid_ids = 0
 
@@ -327,16 +326,9 @@ def build_edge_cell_lists( nc_file, blocking, cell_list ):#{{{
                 if ( vertex2 >= 0 ):
                     polygon.GetPointIds().SetId(index, vertex2 + nCells + 1) # nCells has an extra garbage cell at the end
                     index = index + 1
-            else:
-                polygon = vtk.vtkPolygon()
-                polygon.GetPointIds().SetNumberOfIds(2)
 
-                polygon.GetPointIds().SetId(0, nCells + 1)
-                polygon.GetPointIds().SetId(1, nCells + 1)
-                
-
-            cell_list.InsertNextCell(polygon)
-            del polygon
+                valid_mask[blockStart + idx] = True
+                cell_list.InsertNextCell(polygon)
 
         del cellsOnEdge
         del verticesOnEdge
@@ -367,14 +359,12 @@ def build_location_list_xyz( nc_file, blocking, dimName, xName, yName, zName, po
         blockEnd = min( (iBlock + 1) * blocking, nLocs )
         blockCount = blockEnd - blockStart
 
-        #print "  On vertex block %d out of %d (vertices %d through %d out of %d, contains %d vertices)"%(iBlock, nBlocks, blockStart, blockEnd, nVertices, blockCount)
-
         xLoc = xLoc_var[blockStart:blockEnd]
         yLoc = yLoc_var[blockStart:blockEnd]
         zLoc = zLoc_var[blockStart:blockEnd]
 
         for idx in np.arange(0, blockCount):
-            id = point_list.InsertNextPoint(xLoc[idx], yLoc[idx], zLoc[idx])
+            point_list.InsertNextPoint(xLoc[idx], yLoc[idx], zLoc[idx])
         
         del xLoc
         del yLoc
@@ -382,13 +372,14 @@ def build_location_list_xyz( nc_file, blocking, dimName, xName, yName, zName, po
         if use_progress_bar:
             loc_bar.update(iBlock)
 
-    id = point_list.InsertNextPoint(0.0, 0.0, 0.0)
+    point_list.InsertNextPoint(0.0, 0.0, 0.0)
 
     if use_progress_bar:
         loc_bar.finish()
 #}}}
 
-def build_field_time_series( local_indices, global_indices, file_names, blocking, all_dim_vals, blockDimName, variable_list, point_list, cell_list, output_32bit ):#{{{
+def build_field_time_series( local_indices, global_indices, file_names, blocking, all_dim_vals,
+                             blockDimName, variable_list, point_list, cell_list, valid_mask, output_32bit ):#{{{
     if len(variable_list) > 0:
         polydata = vtk.vtkPolyData()
         polydata.SetPoints(point_list)
@@ -420,12 +411,13 @@ def build_field_time_series( local_indices, global_indices, file_names, blocking
         # Output time series
         if use_progress_bar:
             widgets = ['Writing time series: ', Percentage(), ' ', Bar(), ' ', ETA()]
-            field_bar = ProgressBar(widgets=widgets, maxval=len(global_indices) ).start()
+            field_bar = ProgressBar(widgets=widgets, maxval=len(global_indices)*len(variable_list)*nBlocks ).start()
         else:
             print "Writing time series...."
 
         prev_file = ""
-        for time_index in global_indices:
+        for iTime in range(len(global_indices)):
+            time_index = global_indices[iTime]
 
             if prev_file != file_names[time_index]:
                 if prev_file != "":
@@ -433,12 +425,12 @@ def build_field_time_series( local_indices, global_indices, file_names, blocking
                 nc_file = NetCDFFile(file_names[time_index], 'r')
                 prev_file = file_names[time_index]
 
-            for var_name in variable_list:
+            for iVar in range(len(variable_list)):
+                var_name = variable_list[iVar]
                 Colors.SetName(var_name);
                 dim_vals = all_dim_vals[var_name]
                 field_var = nc_file.variables[var_name]
                 field_ndims = len(dim_vals)
-                field_dims = field_var.dimensions
 
                 try:
                     missing_val = field_var.missing_value
@@ -446,6 +438,7 @@ def build_field_time_series( local_indices, global_indices, file_names, blocking
                     missing_val = -9999999790214767953607394487959552.000000
 
                 # Build data
+                outIndex = 0
                 for iBlock in np.arange(0, nBlocks):
                     blockStart = iBlock * blocking
                     blockEnd = min( (iBlock + 1) * blocking, blockDim )
@@ -464,10 +457,15 @@ def build_field_time_series( local_indices, global_indices, file_names, blocking
                         field = field_var[local_indices[time_index], blockStart:blockEnd, dim_vals[2], dim_vals[3], dim_vals[4]]
 
                     for idx in np.arange(0, blockCount):
+                        if not valid_mask[blockStart + idx]:
+                            continue
                         if (field[idx] == missing_val):
-                            Colors.SetTuple1(blockStart + idx, float('nan'));
+                            Colors.SetTuple1(outIndex, float('nan'));
                         else:
-                            Colors.SetTuple1(blockStart + idx, field[idx]);
+                            Colors.SetTuple1(outIndex, field[idx]);
+                        outIndex += 1
+                    if use_progress_bar:
+                        field_bar.update((iTime*len(variable_list) + iVar)*nBlocks + iBlock)
 
                 polydata.GetCellData().SetScalars(Colors)
                 polydata.Modified()
@@ -488,8 +486,6 @@ def build_field_time_series( local_indices, global_indices, file_names, blocking
                 del field_var
                 del dim_vals
 
-            if use_progress_bar:
-                field_bar.update(time_index)
 
         del Colors
         nc_file.close()
@@ -511,24 +507,29 @@ def build_field_time_series( local_indices, global_indices, file_names, blocking
             pvd_file.write('</VTKFile>\n')
 #}}}
 
-def build_field_single_time_field( local_indices, global_indices, file_names, blocking, all_dim_vals, blockDimName, variable_list, point_list, cell_list, output_32bit ):#{{{
+def build_field_single_time_field( local_indices, global_indices, file_names, blocking, all_dim_vals, blockDimName,
+                                   variable_list, point_list, cell_list, valid_mask, output_32bit ):#{{{
     if len(variable_list) > 0:
         polydata = vtk.vtkPolyData()
         polydata.SetPoints(point_list)
         polydata.SetPolys(cell_list)
 
-        # Output time series
-        if use_progress_bar:
-            widgets = ['Writing single fields: ', Percentage(), ' ', Bar(), ' ', ETA()]
-            field_bar = ProgressBar(widgets=widgets, maxval=len(variable_list) ).start()
-        else:
-            print "Writing single fields...."
-
-        prev_file = ""
+        # Get dimension info to allocate the size of Colors
         nc_file = NetCDFFile( file_names[0], 'r' )
 
         blockDim = len(nc_file.dimensions[blockDimName])
         nBlocks = 1 + blockDim / blocking
+
+        nc_file = NetCDFFile(file_names[0], 'r')
+
+        nc_file.close
+
+        # Output time series
+        if use_progress_bar:
+            widgets = ['Writing single fields: ', Percentage(), ' ', Bar(), ' ', ETA()]
+            field_bar = ProgressBar(widgets=widgets, maxval=len(variable_list)*nBlocks ).start()
+        else:
+            print "Writing single fields...."
 
         if output_32bit:
             Colors = vtk.vtkTypeFloat32Array()
@@ -536,16 +537,6 @@ def build_field_single_time_field( local_indices, global_indices, file_names, bl
             Colors = vtk.vtkTypeFloat64Array()
 
         Colors.SetNumberOfComponents(1);
-
-        # Get dimension info to allocate the size of Colors
-        nc_file = NetCDFFile(file_names[0], 'r')
-
-        blockDim = len(nc_file.dimensions[blockDimName])
-
-        # Pre-compute the number of blocks
-        nBlocks = 1 + blockDim / blocking
-
-        nc_file.close
 
         # Allocate the correct number of elements for the colors array
         Colors.Allocate( blockDim )
@@ -567,6 +558,7 @@ def build_field_single_time_field( local_indices, global_indices, file_names, bl
                 missing_val = -9999999790214767953607394487959552.000000
 
             # Build data
+            outIndex = 0
             for iBlock in np.arange(0, nBlocks):
                 blockStart = iBlock * blocking
                 blockEnd = min( (iBlock + 1) * blocking, blockDim )
@@ -584,10 +576,18 @@ def build_field_single_time_field( local_indices, global_indices, file_names, bl
                     field = field_var[blockStart:blockEnd, dim_vals[1], dim_vals[2], dim_vals[3]]
 
                 for idx in np.arange(0, blockCount):
+                    if not valid_mask[blockStart + idx]:
+                        continue
+
                     if ( field[idx] == missing_val  ):
-                        Colors.SetTuple1(blockStart + idx, float('nan'))
+                        Colors.SetTuple1(outIndex, float('nan'))
                     else:
-                        Colors.SetTuple1(blockStart + idx, field[idx])
+                        Colors.SetTuple1(outIndex, field[idx])
+                    outIndex += 1
+
+                if use_progress_bar:
+                    field_bar.update(var_index*nBlocks + iBlock)
+
 
             polydata.GetCellData().SetScalars(Colors)
             polydata.Modified()
@@ -609,8 +609,6 @@ def build_field_single_time_field( local_indices, global_indices, file_names, bl
             del dim_vals
 
             var_index = var_index + 1
-            if use_progress_bar:
-                field_bar.update(var_index)
 
         del Colors
         nc_file.close()
@@ -674,14 +672,15 @@ if __name__ == "__main__":
         build_location_list_xyz( nc_file, args.blocking, 'nVertices', 'xVertex', 'yVertex', 'zVertex', CellVertices )
 
         # Build cell list
-        build_cell_lists( nc_file, args.blocking, Cells )
+        valid_mask = np.zeros(len(nc_file.dimensions['nCells']),bool)
+        build_cell_lists( nc_file, args.blocking, Cells, valid_mask )
 
         nc_file.close()
 
         build_field_single_time_field( time_indices, time_global_indices, time_file_names, args.blocking,
-                                       all_dim_vals, 'nCells', cellVarNoTime, CellVertices, Cells, use_32bit )
+                                       all_dim_vals, 'nCells', cellVarNoTime, CellVertices, Cells, valid_mask, use_32bit )
         build_field_time_series( time_indices, time_global_indices, time_file_names, args.blocking,
-                                 all_dim_vals, 'nCells', cellVarTime, CellVertices, Cells, use_32bit )
+                                 all_dim_vals, 'nCells', cellVarTime, CellVertices, Cells, valid_mask, use_32bit )
 
         print ""
         del Cells
@@ -697,14 +696,15 @@ if __name__ == "__main__":
         build_location_list_xyz( nc_file, args.blocking, 'nCells', 'xCell', 'yCell', 'zCell', VertexVertices )
 
         # Build cell list
-        build_dual_cell_lists( nc_file, args.blocking, Vertices )
+        valid_mask = np.zeros(len(nc_file.dimensions['nVertices']),bool)
+        build_dual_cell_lists( nc_file, args.blocking, Vertices, valid_mask )
 
         nc_file.close()
 
         build_field_single_time_field( time_indices, time_global_indices, time_file_names, args.blocking,
-                                       all_dim_vals, 'nVertices', vertexVarNoTime, VertexVertices, Vertices, use_32bit )
+                                       all_dim_vals, 'nVertices', vertexVarNoTime, VertexVertices, Vertices, valid_mask, use_32bit )
         build_field_time_series( time_indices, time_global_indices, time_file_names, args.blocking,
-                                 all_dim_vals, 'nVertices', vertexVarTime, VertexVertices, Vertices, use_32bit )
+                                 all_dim_vals, 'nVertices', vertexVarTime, VertexVertices, Vertices, valid_mask, use_32bit )
 
         print ""
         del Vertices
@@ -722,14 +722,15 @@ if __name__ == "__main__":
         build_location_list_xyz( nc_file, args.blocking, 'nVertices', 'xVertex', 'yVertex', 'zVertex', EdgeVertices )
 
         # Build cell list
-        build_edge_cell_lists( nc_file, args.blocking, Edges )
+        valid_mask = np.zeros(len(nc_file.dimensions['nEdges']),bool)
+        build_edge_cell_lists( nc_file, args.blocking, Edges, valid_mask )
 
         nc_file.close()
 
         build_field_single_time_field( time_indices, time_global_indices, time_file_names, args.blocking,
-                                       all_dim_vals, 'nEdges', edgeVarNoTime, EdgeVertices, Edges, use_32bit )
+                                       all_dim_vals, 'nEdges', edgeVarNoTime, EdgeVertices, Edges, valid_mask, use_32bit )
         build_field_time_series( time_indices, time_global_indices, time_file_names, args.blocking,
-                                 all_dim_vals, 'nEdges', edgeVarTime, EdgeVertices, Edges, use_32bit )
+                                 all_dim_vals, 'nEdges', edgeVarTime, EdgeVertices, Edges, valid_mask, use_32bit )
 
 
 # vim: set expandtab:


### PR DESCRIPTION
Keeps track of which vertices (and cells and edges) are valid
when building connectivity.  Data values are taken only from
valid field locations, and output indexing is based on valid
field entries only.

Other cleanup:
- Switches from [:][:] to [:,:] style indexing, which behaves more
  as expected with NetCDF4 vars.
- Changes "import *" to specify what is imported
- Removes incorrect output claiming edges are not supported
  (they seem to be)
- Removes a few unreferenced variables
- Included blocks, variables and time (if applicable) in progress
  bar for writing files so there's more feedback on progress
