### PR TITLE
Specify extra dims on command line and as list/range

### DIFF
--- a/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
+++ b/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
@@ -604,7 +604,7 @@ def build_field_time_series( local_time_indices, file_names, mesh_file, blocking
         iHyperSlabProgress = 0
         for iVar in varIndices:
             has_time = var_has_time_dim[iVar]
-            if has_time and time_index > 0:
+            if not has_time and time_index > 0:
                 continue
 
             var_name = variable_list[iVar]


### PR DESCRIPTION
Either on the command line or via stdin, the user can now supply values for extra dimensions (e.g. nVertLevels).  These values can be single entries, comma-separated lists of indices, or colon-separated ranges of indices (using python's syntax first:last+1:step, where all are optional, and defaults are first=0, last+1=<dim_size> and step=1).

If supplied at the command line, the dimension name is supplied as an "optional" argument (e.g. `--nVertLevels`), followed by the index, index list or index range.

If a range of 0:0 is supplied for a dimension, all variables with that dimension will be ignored.

Also, adds the flag `--append`.  If the flag is used, existing `vtp` files are not overwritten.  This makes it easier to perform progressive conversion to vtk format to monitor a run that is in progress.
