### PR TITLE
Support adding all variables on cells, edges or verts

### DIFF
--- a/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
+++ b/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
@@ -96,6 +96,9 @@ def setup_time_indices(fn_pattern):#{{{
 #}}}
 
 def parse_extra_dim(dimName, indexString, time_series_file, mesh_file):#{{{
+    if indexString == '':
+        return np.zeros(0,int)
+        
     if (mesh_file is not None) and (dimName in mesh_file.dimensions):
         nc_file = mesh_file
     else:


### PR DESCRIPTION
This merge adds support for variable placeholders 'allOnCells', 'allOnEdges' and 'allOnVertices', similar to 'all'.  These placeholders can be used to extract all fields on cells, edges or vertices. They can be used in combination with a list of variables: `-v allOnCells,latVertex,lonEdge`

This merge also adds functionality to ignore any fields with a given dimension if the range of that dimension is left blank (either on the command line via the `-d` flag or via stdin).  Example:

```
-d maxEdges2= nVertLevels=:
```

This ignores any fields with dimension maxEdges2 and extracts all vertical levels.
