### PR TITLE
Add icpc flags and fix string conversion for icpc

### DIFF
--- a/grid_gen/mesh_conversion_tools/Makefile
+++ b/grid_gen/mesh_conversion_tools/Makefile
@@ -1,8 +1,15 @@
 #Assumes ${NETCDF} is defined to the root of the netcdf library
 
+# gfortran
 CC=g++
 CFLAGS= -O3 -std=c++0x -fopenmp
 DFLAGS= -g -std=c++0x -D_DEBUG -fopenmp
+
+# intel
+# CC=icpc
+# CFLAGS= -O3 -std=c++0x -openmp
+# DFLAGS= -g -std=c++0x -D_DEBUG -openmp
+
 CONV_EXECUTABLE= MpasMeshConverter.x
 CULL_EXECUTABLE= MpasCellCuller.x
 MASK_EXECUTABLE= MpasMaskCreator.x
@@ -23,5 +30,5 @@ debug:
 clean:
 	rm -f grid.nc
 	rm -f graph.info
-	rm -f ${CONV_EXECUTABLE} ${CULL_EXECUTABLE}
+	rm -f ${CONV_EXECUTABLE} ${CULL_EXECUTABLE} ${MASK_EXECUTABLE}
 

--- a/grid_gen/mesh_conversion_tools/mpas_mask_creator.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_mask_creator.cpp
@@ -1100,7 +1100,9 @@ int getFeatureInfo(const string featureFilename){/*{{{*/
 				if ( addGroupToRegList ) {
 					addGroupToRegList = false;
 					if ( groupName == "enterNameHere" ){
-						tempGroupName = "regionGroup" + to_string( regionGroupNames.size() + 1 );
+						ostringstream convert;
+						convert << regionGroupNames.size() + 1;
+						tempGroupName = "regionGroup" + convert.str();
 						regionGroupNames.push_back(tempGroupName);
 					} else {
 						regionGroupNames.push_back(groupName);
@@ -1202,7 +1204,9 @@ int getFeatureInfo(const string featureFilename){/*{{{*/
 				if ( addGroupToTrnList ) {
 					addGroupToTrnList = false;
 					if ( groupName == "enterNameHere" ){
-						tempGroupName = "transectGroup" + to_string( transectGroupNames.size() + 1 );
+						ostringstream convert;
+						convert << transectGroupNames.size() + 1;
+						tempGroupName = "transectGroup" + convert.str();
 						transectGroupNames.push_back(tempGroupName);
 					} else {
 						transectGroupNames.push_back(groupName);
@@ -1259,7 +1263,9 @@ int getFeatureInfo(const string featureFilename){/*{{{*/
 				if ( addGroupToPntList ) {
 					addGroupToPntList = false;
 					if ( groupName == "enterNameHere" ){
-						tempGroupName = "pointGroup" + to_string( pointGroupNames.size() + 1 );
+						ostringstream convert;
+						convert << pointGroupNames.size() + 1;
+						tempGroupName = "pointGroup" + convert.str();
 						pointGroupNames.push_back(tempGroupName);
 					} else {
 						pointGroupNames.push_back(groupName);


### PR DESCRIPTION
This merge fixes support for icpc as a compiler. First it adds example
compiler / flags to the makefile for easy building with icpc, and second
it changes to_string calls which are not supported by intel currently to
an older method of converting integers to string.
