### PR TITLE
Fix incorrect property vector name

### DIFF
--- a/grid_gen/mesh_conversion_tools/mpas_mask_creator.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_mask_creator.cpp
@@ -1241,7 +1241,7 @@ int getFeatureInfo(const string featureFilename){/*{{{*/
 
 				properties.clear();
 				properties = extractFeatureProperties( feature["properties"] );
-				regionProperties.push_back(properties);
+				pointProperties.push_back(properties);
 
 				pointLocations.push_back(point);
 				pointNames.push_back(featureName);


### PR DESCRIPTION
This merge fixes an issue when adding properties to points. Previously
point properties were incorrectly added to region properties, causing a
segfault when creating point files.
