### PR TITLE
Change conversions from rad->degrees and m^2->rad^2

### DIFF
--- a/grid_gen/create_SCRIP_files/create_SCRIP_file_from_MPAS_mesh.py
+++ b/grid_gen/create_SCRIP_files/create_SCRIP_file_from_MPAS_mesh.py
@@ -42,6 +42,7 @@ nEdgesOnCell = fin.variables['nEdgesOnCell'][:]
 nCells = len(fin.dimensions['nCells'])
 maxVertices = len(fin.dimensions['maxEdges'])
 areaCell = fin.variables['areaCell'][:]
+sphereRadius = float(fin.sphere_radius)
 
 # Write to output file
 # Dimensions
@@ -51,22 +52,22 @@ fout.createDimension("grid_rank", 1)
 
 # Variables
 grid_center_lat = fout.createVariable('grid_center_lat', 'f8', ('grid_size',))
-grid_center_lat.units = 'degrees'
+grid_center_lat.units = 'radians'
 grid_center_lon = fout.createVariable('grid_center_lon', 'f8', ('grid_size',))
-grid_center_lon.units = 'degrees'
+grid_center_lon.units = 'radians'
 grid_corner_lat = fout.createVariable('grid_corner_lat', 'f8', ('grid_size', 'grid_corners'))
-grid_corner_lat.units = 'degrees'
+grid_corner_lat.units = 'radians'
 grid_corner_lon = fout.createVariable('grid_corner_lon', 'f8', ('grid_size', 'grid_corners'))
-grid_corner_lon.units = 'degrees'
+grid_corner_lon.units = 'radians'
 grid_area = fout.createVariable('grid_area', 'f8', ('grid_size',))
 grid_area.units = 'radian^2'
 grid_imask = fout.createVariable('grid_imask', 'i4', ('grid_size',))
 grid_imask.units = 'unitless'
 grid_dims = fout.createVariable('grid_dims', 'i4', ('grid_rank',))
 
-grid_center_lat[:] = latCell[:]*57.29577951308
-grid_center_lon[:] = lonCell[:]*57.29577951308
-grid_area[:] = areaCell[:]*0.24635127E-13 # SCRIP uses square radians
+grid_center_lat[:] = latCell[:]
+grid_center_lon[:] = lonCell[:]
+grid_area[:] = areaCell[:]/ ( sphereRadius**2 ) # SCRIP uses square radians
 grid_imask[:] = 1  # For now, assume we don't want to mask anything out - but eventually may want to exclude certain cells from the input mesh during interpolation
 grid_dims[:] = nCells
 
@@ -81,8 +82,8 @@ for iCell in range(nCells):
     # repeat the last vertex location for any remaining, unused vertex indices
 		grid_corner_lat_local[iCell, vertexMax:] = latVertex[verticesOnCell[iCell, vertexMax-1] - 1]
 		grid_corner_lon_local[iCell, vertexMax:] = lonVertex[verticesOnCell[iCell, vertexMax-1] - 1]
-grid_corner_lat[:] = grid_corner_lat_local[:]*57.29577951308
-grid_corner_lon[:] = grid_corner_lon_local[:]*57.29577951308
+grid_corner_lat[:] = grid_corner_lat_local[:]
+grid_corner_lon[:] = grid_corner_lon_local[:]
 
 #import matplotlib.pyplot as plt
 #i=-1
@@ -104,8 +105,8 @@ setattr(fout, 'history', newhist )
 
 print "Input latCell min/max values (radians):", latCell[:].min(), latCell[:].max()
 print "Input lonCell min/max values (radians):", lonCell[:].min(), lonCell[:].max()
-print "Calculated grid_center_lat min/max values (degrees):", grid_center_lat[:].min(), grid_center_lat[:].max()
-print "Calculated grid_center_lon min/max values (degrees):", grid_center_lon[:].min(), grid_center_lon[:].max()
+print "Calculated grid_center_lat min/max values (radians):", grid_center_lat[:].min(), grid_center_lat[:].max()
+print "Calculated grid_center_lon min/max values (radians):", grid_center_lon[:].min(), grid_center_lon[:].max()
 print "Calculated grid_area min/max values (sq radians):", grid_area[:].min(), grid_area[:].max()
 
 fin.close()


### PR DESCRIPTION
This merge changes conversions for SCRIP files to leave cell centers
and corners as radians, but also more accurately uses the radius of the
sphere defined in the MPAS mesh file to convert from m^2 -> radians^2
