### PR TITLE
Add subglacial hydro fields to MPASLI grid creation script

### DIFF
--- a/grid_gen/landice_grid_tools/create_landice_grid_from_generic_MPAS_grid.py
+++ b/grid_gen/landice_grid_tools/create_landice_grid_from_generic_MPAS_grid.py
@@ -18,7 +18,7 @@ parser.add_option("-l", "--level", dest="levels", help="Number of vertical level
 parser.add_option("--beta", dest="beta", action="store_true", help="Use this flag to include the field 'beta' in the resulting file.")
 parser.add_option("--diri", dest="dirichlet", action="store_true", help="Use this flag to include the fields 'dirichletVelocityMask', 'uReconstructX', 'uReconstructY' needed for specifying Dirichlet velocity boundary conditions in the resulting file.")
 parser.add_option("--thermal", dest="thermal", action="store_true", help="Use this flag to include the fields 'temperature', 'surfaceAirTemperature', 'basalHeatFlux' needed for specifying thermal initial conditions in the resulting file.")
-parser.add_option("--hydro", dest="hydro", action="store_true", help="Use this flag to include the fields 'waterThickness', 'tillWaterThickness', 'basalMeltInput', 'externalWaterInput', 'frictionAngle', 'waterPressure' needed for specifying hydro initial conditions in the resulting file.")
+parser.add_option("--hydro", dest="hydro", action="store_true", help="Use this flag to include the fields 'waterThickness', 'tillWaterThickness', 'basalMeltInput', 'externalWaterInput', 'frictionAngle', 'waterPressure', 'waterFluxMask' needed for specifying hydro initial conditions in the resulting file.")
 options, args = parser.parse_args()
 
 if not options.fileinName:
@@ -214,7 +214,9 @@ if options.hydro:
    newvar[:] = 0.0
    newvar = fileout.createVariable('waterPressure', datatype, ('Time', 'nCells'))
    newvar[:] = 0.0
-   print 'Added optional hydro variables: waterThickness, tillWaterThickness, meltInput, frictionAngle, waterPressure'
+   newvar = fileout.createVariable('waterFluxMask', 'i', ('Time', 'nEdges'))
+   newvar[:] = 0.0
+   print 'Added optional hydro variables: waterThickness, tillWaterThickness, meltInput, frictionAngle, waterPressure, waterFluxMask'
 
 fileout.sync()
 print "Completed creating land ice variables in new file. Now syncing to file."


### PR DESCRIPTION
This merge adds a handful of input fields related to subglacial hydrology to the script that creates a land ice grid from any ol' mpas grid.  The hydro fields are only created if the `--hydro` command line option is used. 
