### PR TITLE
transectGroupOutput

### DIFF
--- a/grid_gen/mesh_conversion_tools/mpas_mask_creator.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_mask_creator.cpp
@@ -1642,6 +1642,17 @@ int buildAllFeatureGroups(){/*{{{*/
 	regionGroupNames.push_back("all");
 	maxRegionsInGroup = max(maxRegionsInGroup, (int)groupIndices.size());
 
+	// 'all' transect group
+	groupIndices.clear();
+
+	for ( str_itr = transectNames.begin(), featureIdx = 0; str_itr != transectNames.end(); str_itr++, featureIdx++){
+		groupIndices.push_back(featureIdx);
+	}
+
+	transectsInGroup.push_back(groupIndices);
+	transectGroupNames.push_back("all");
+	maxTransectsInGroup = max(maxTransectsInGroup, (int)groupIndices.size());
+
 	// 'all' point group
 	groupIndices.clear();
 	


### PR DESCRIPTION
The MPAS mask creator now properly writes the transectNames, transectGroupNames, transectsInGroup and nTransectsInGroup properties to the resulting netCDF file.

Mostly copy-and-paste of the code that does this for the regions.
No 'all' group is created for transects (which I consider a feature, not a bug)

@mark-petersen please mark this as "enhancement"
