### PR TITLE
Fix writing of string properties in mask creator

### DIFF
--- a/grid_gen/mesh_conversion_tools/mpas_mask_creator.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_mask_creator.cpp
@@ -1968,8 +1968,8 @@ int outputMaskFields( const string outputFilename) {/*{{{*/
 			} else if ( get<2>( regionProperties[0][i] ) == text ) {
 				char_vals = new char[nRegions * StrLen];
 
-				for ( j = 0; j < nRegions; j++ ) {
-					char_vals[j * StrLen] = '\0';
+				for ( j = 0; j < nRegions * StrLen; j++ ) {
+					char_vals[j] = '\0';
 				}
 
 				for ( j = 0; j < regionProperties.size(); j++ ) {


### PR DESCRIPTION
The array used to write strings is now initialized to all null
(string-terminating) characters so unset properties are handled
correctly.