### PR TITLE
Added option in cellCuller to output cellMap variable

### DIFF
--- a/grid_gen/mesh_conversion_tools/mpas_cell_culler.cpp
+++ b/grid_gen/mesh_conversion_tools/mpas_cell_culler.cpp
@@ -96,21 +96,21 @@ int main ( int argc, char *argv[] ) {
 	// default for input
 	if (in_name == "")
 	{
-		in_name = "grid.nc";
-
 		cout << "\n";
 		cout << "MPAS_CELL_CULLER:\n";
-		cout << "  Input name not specified. Using default of grid.nc\n";
+		cout << "  Please enter the NetCDF input filename.\n";
+
+		cin >> in_name;
 	}
 
 	// default for output
 	if (out_name == "")
 	{
-		out_name = "culled.nc";
-
 		cout << "\n";
 		cout << "MPAS_CELL_CULLER:\n";
-		cout << "  Output name not specified. Using default of culled.nc\n";
+		cout << "  Please enter the output NetCDF MPAS Mesh filename.\n";
+
+		cin >> out_name;
 	}
 
 


### PR DESCRIPTION
In my work to improve load balancing in the sea ice model I've been using the cell culler to create sub regions of grids to perform partitioning on with metis. Its very useful to be able to know the mapping from cells in the old grid to the new culled one (variable cellMap). This modification changes the way the cell culler takes command line options by using getopt. The usage is now:
MpasCellCuller.x -i [input grid filename] -o [output culled grid filename] -m [output mapping filename]
The -m is optional and if -i or -o are missing the code asks for the names as input with cin.