### PR TITLE
Add support for various xtime variable names in paraview extractor

### DIFF
--- a/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
+++ b/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
@@ -274,6 +274,7 @@ if __name__ == "__main__":
     parser.add_argument("-a", "--append", dest="append", help="If set, only vtp files that do not already exist are written out.", action="store_true")
     parser.add_argument("-d", "--dim_list", dest="dimension_list", nargs="+", help="A list of dimensions and associated indices.")
     parser.add_argument("-o", "--out_dir", dest="out_dir", help="the output directory.", default='vtk_files', metavar="DIR")
+    parser.add_argument("-x", "--xtime", dest="xtime", help="the name of the xtime variable", default='xtime', metavar="XTIME")
     args = parser.parse_args()
 
     if not args.output_32bit:
@@ -286,7 +287,8 @@ if __name__ == "__main__":
     else:
         args.blocking = int(args.blocking)
 
-    (time_indices, time_file_names) = utils.setup_time_indices(args.filename_pattern)
+    (time_indices, time_file_names) = utils.setup_time_indices(
+        args.filename_pattern, args.xtime)
 
     separate_mesh_file = True
     if not args.mesh_filename:

--- a/python_scripts/paraview_vtk_field_extractor/utils.py
+++ b/python_scripts/paraview_vtk_field_extractor/utils.py
@@ -39,7 +39,7 @@ def get_var(variable_name, mesh_file, time_series_file):
 # This function finds a list of NetCDF files containing time-dependent
 # MPAS data and extracts the time indices in each file.  The routine
 # insures that each time is unique.
-def setup_time_indices(fn_pattern):#{{{
+def setup_time_indices(fn_pattern, xtimeName):#{{{
     # Build file list and time indices
     if ';' in fn_pattern:
         file_list = []
@@ -69,17 +69,17 @@ def setup_time_indices(fn_pattern):#{{{
         try: 
             nc_file = NetCDFFile(file_name, 'r')
         except IOError:
+            print "Warning: could not open {}".format(file_name)
             continue
 
 
-        try:
-            xtime = nc_file.variables['xtime'][:,:]
-            local_times = []
+        local_times = []
+        if xtimeName in nc_file.variables:
+            xtime = nc_file.variables[xtimeName][:,:]
             for index in range(xtime.shape[0]):
-              local_times.append(''.join(xtime[index,:]))
-
-        except:
-            local_times = ['0']
+                local_times.append(''.join(xtime[index,:]))
+        else:
+            print "Warning: {} not found in {}".format(xtimeName, file_name)
 
         if(len(local_times) == 0):
             local_times = ['0']


### PR DESCRIPTION
The -x command-line option has been added to the paraveiw extractor so alternative `xtime`-like variables can be specified (e.g. `xtime_start`).

Also, a try/except has been added to gracefully handle cases where file permissions aren't right for some of the files in a time sequence.  A warning is printed rather than an exception being raised.