### PR TITLE
Correct history attribute in some grid_gen scripts

### DIFF
--- a/grid_gen/create_SCRIP_files/create_SCRIP_file_from_MPAS_mesh.py
+++ b/grid_gen/create_SCRIP_files/create_SCRIP_file_from_MPAS_mesh.py
@@ -113,12 +113,6 @@ grid_corner_lon[:] = grid_corner_lon_local[:]
 #plt.plot(grid_corner_lon[i, 5], grid_corner_lat[i, 5], 'rx')
 #plt.show()
 
-# Update history attribute of netCDF file
-if hasattr(fin, 'history'):
-   newhist = '\n'.join([getattr(fin, 'history'), ' '.join(sys.argv[:]) ] )
-else:
-   newhist = sys.argv[:]
-setattr(fout, 'history', newhist )
 
 print "Input latCell min/max values (radians):", latCell[:].min(), latCell[:].max()
 print "Input lonCell min/max values (radians):", lonCell[:].min(), lonCell[:].max()

--- a/grid_gen/planar_grid_transformations/scale_planar_grid.py
+++ b/grid_gen/planar_grid_transformations/scale_planar_grid.py
@@ -2,6 +2,7 @@
 import numpy, math
 from netCDF4 import Dataset as NetCDFFile
 from optparse import OptionParser
+from datetime import datetime
 
 parser = OptionParser()
 parser.add_option("-f", "--file", dest="filename", help="Path to grid file", metavar="FILE")
@@ -35,5 +36,14 @@ grid.variables['dvEdge'][:] = grid.variables['dvEdge'][:] * scale
 grid.variables['areaCell'][:] = grid.variables['areaCell'][:] * scale**2
 grid.variables['areaTriangle'][:] = grid.variables['areaTriangle'][:] * scale**2
 grid.variables['kiteAreasOnVertex'][:] = grid.variables['kiteAreasOnVertex'][:] * scale**2
+
+# Update history attribute of netCDF file
+thiscommand = datetime.now().strftime("%a %b %d %H:%M:%S %Y") + ": " + " ".join(sys.argv[:])
+if hasattr(grid, 'history'):
+   newhist = '\n'.join([thiscommand, getattr(grid, 'history')])
+else:
+   newhist = thiscommand
+setattr(grid, 'history', newhist )
+
 
 grid.close()

--- a/grid_gen/planar_grid_transformations/set_lat_lon_fields_in_planar_grid.py
+++ b/grid_gen/planar_grid_transformations/set_lat_lon_fields_in_planar_grid.py
@@ -7,8 +7,8 @@ import sys
 import netCDF4
 import pyproj
 #import numpy as np
-
 from optparse import OptionParser
+from datetime import datetime
 
 
 # ======== DEFINE PROJECTIONS =============
@@ -87,11 +87,13 @@ print "Calculated latCell min/max values (radians):", latCell[:].min(), latCell[
 print "Calculated lonCell min/max values (radians):", lonCell[:].min(), lonCell[:].max()
 
 # Update history attribute of netCDF file
+thiscommand = datetime.now().strftime("%a %b %d %H:%M:%S %Y") + ": " + " ".join(sys.argv[:])
 if hasattr(f, 'history'):
-   newhist = '\n'.join([getattr(f, 'history'), ' '.join(sys.argv[:]) ] )
+   newhist = '\n'.join([thiscommand, getattr(f, 'history')])
 else:
-   newhist = sys.argv[:]
+   newhist = thiscommand
 setattr(f, 'history', newhist )
+
 
 f.close()
 

--- a/grid_gen/planar_grid_transformations/translate_planar_grid.py
+++ b/grid_gen/planar_grid_transformations/translate_planar_grid.py
@@ -7,6 +7,7 @@ import sys
 import netCDF4
 #import numpy as np
 from optparse import OptionParser
+from datetime import datetime
 
 
 print "== Gathering information.  (Invoke with --help for more details. All arguments are optional)"
@@ -103,11 +104,13 @@ xEdge[:] += xOffset
 yEdge[:] += yOffset
 
 # Update history attribute of netCDF file
+thiscommand = datetime.now().strftime("%a %b %d %H:%M:%S %Y") + ": " + " ".join(sys.argv[:])
 if hasattr(f, 'history'):
-   newhist = '\n'.join([getattr(f, 'history'), ' '.join(sys.argv[:]) ] )
+   newhist = '\n'.join([thiscommand, getattr(f, 'history')])
 else:
-   newhist = sys.argv[:]
+   newhist = thiscommand
 setattr(f, 'history', newhist )
+
 
 f.close()
 


### PR DESCRIPTION
This merge fixes the history attribute as applied to the
landice grid tools.  NCO adds newest history to the beginning, and it
includes the date/time the command was executed.  I've made the
scripts in planar_grid_transformations conform to that convention.

I've also deleted appending the history attribute in
create_SCRIP_files/create_SCRIP_file_from_MPAS_mesh.py because the
source MPAS file is not actually modified by the script.