### PR TITLE
Grid rotate double precision only / add write attribute to output file

### DIFF
--- a/grid_gen/grid_rotate/grid_rotate.f90
+++ b/grid_gen/grid_rotate/grid_rotate.f90
@@ -96,13 +96,17 @@ contains
          return
       end if
 
+      ! Copy original file to output file
       copyCmd = "cp " // trim(filename) // " " // trim(newFilename)
+      call system(copyCmd)
 
+      ! Make sure the output file is writeable
+      copyCmd = "chmod u+w " // trim(newFilename)
       call system(copyCmd)
 
       ierr = nf_open(newFilename, NF_WRITE, ncid)
       if(ierr /= 0) then
-         write(0,*) "Error: could not find file: ", filename
+         write(0,*) "Error: could not open file " // trim(filename) // " for writing"
          return
       end if
 


### PR DESCRIPTION
We found in a painful and long debugging process that the grid_rotate tool only works correctly if operating in double precision. In single precision, the calculation of angle_sphere fails, since small angles get truncated to zero. For this and other reasons, we suggest to perform grid operations (grid rotation etc) always on the double precision files and leave it up to the users to create single precision files using the mpas cores.

This PR addresses this issue by making sure that the input mesh file to grid_rotate is in double precision. Further, it enforces double precision for all calculations in the program. Lastly, it also addresses a problem that when copying a read-only input file to an output file, the output file would be read-only, too, and the subsequent open statement would fail.