### PR TITLE
Add --time flag to specify time indices in paraview extractor

### DIFF
--- a/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
+++ b/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
@@ -302,6 +302,9 @@ if __name__ == "__main__":
     parser.add_argument("-l", "--lonlat", dest="lonlat",
                         help="If set, the resulting points are in lon-lat "
                              "space, not Cartesian.", action="store_true")
+    parser.add_argument("-t", "--time", dest="time",
+                        help="Indices for the time dimension", metavar="TIME",
+                             required=False)
     args = parser.parse_args()
 
     if not args.output_32bit:
@@ -316,6 +319,10 @@ if __name__ == "__main__":
 
     (time_indices, time_file_names) = utils.setup_time_indices(
         args.filename_pattern, args.xtime)
+
+    if args.time:
+        time_indices, time_file_names = \
+            utils.parse_time_indices(args.time, time_indices, time_file_names)
 
     separate_mesh_file = True
     if not args.mesh_filename:


### PR DESCRIPTION
The format of the time index is the same as for "extra" dimensions
with the -d flag.  The time index can be formatted as follows:
```
--time=      -- no indices are to be extracted
--time=n     -- the index n is to be extracted
--time=m,n,p -- the list of indices is to be extracted
--time=m:n   -- all indices from m to n are to be extracted (including m but
                excluding n, in the typical python indexing convention)
--time=m:n:s -- all indices from m to n are to be extracted (including m but
                excluding n, in the typical python indexing convention) with
                stride s between indices
```