### PR TITLE
fix incorrect double equals in documentation parser

### DIFF
--- a/python_scripts/namelist_generation/parse_xml_registry.py
+++ b/python_scripts/namelist_generation/parse_xml_registry.py
@@ -489,7 +489,7 @@ for var_struct in registry.iter("var_struct"):
             try:
                 var_description = var.attrib['description']
             except KeyError:
-                var_description == latex_missing_string.replace('_', '\_')
+                var_description = latex_missing_string.replace('_', '\_')
 
             if var_description == "":
                 var_description = latex_missing_string.replace('_', '\_')


### PR DESCRIPTION
This merge fixes a double equals that should have been a single equals in the documentation parser.