### PR TITLE
Switch units in docs. generator to use the siunitx package

### DIFF
--- a/python_scripts/namelist_generation/README
+++ b/python_scripts/namelist_generation/README
@@ -8,7 +8,7 @@ users or developers guide.
 Typical usage is as follows:
 
     # set the core, one of ocean, landice, cice, etc.
-    exoprt CORE=<core>
+    export CORE=<core>
     # Set your repo directories:
     export MPAS_REPO=~/repos/MPAS
     export MPAS_TOOLS_REPO=~/repos/MPAS-Tools

--- a/python_scripts/namelist_generation/parse_xml_registry.py
+++ b/python_scripts/namelist_generation/parse_xml_registry.py
@@ -7,7 +7,7 @@ users or developers guide.
 Typical usage is as follows::
 
     # set the core, one of ocean, landice, cice, etc.
-    exoprt CORE=<core>
+    export CORE=<core>
     # Set your repo directories:
     export MPAS_REPO=~/repos/MPAS
     export MPAS_TOOLS_REPO=~/repos/MPAS-Tools
@@ -161,7 +161,8 @@ def get_attrib(element, attributeName, missingValue=None):
 def get_units(element):
     units = get_attrib(element, 'units')
     if units != latex_missing_string:
-        units = "${}$".format(units.replace(' ', '$ $'))
+        # units with the siunitx package
+        units = "\si{{{}}}".format(units.replace(' ', '.'))
     units = escape_underscore(units)
     return units
 


### PR DESCRIPTION
Units are inside a `\si` tag rather than `$ $`, leading to better formatting (text is not in italics but exponents and subscripts work as expected).