### PR TITLE
Add flag to ignore Time dimension in input

### DIFF
--- a/python_scripts/paraview_vtk_field_extractor/utils.py
+++ b/python_scripts/paraview_vtk_field_extractor/utils.py
@@ -75,7 +75,7 @@ def setup_time_indices(fn_pattern, xtimeName):  # {{{
             print "Warning: could not open {}".format(file_name)
             continue
 
-        if 'Time' not in nc_file.dimensions:
+        if 'Time' not in nc_file.dimensions or xtimeName is None:
             local_times = ['0']
         else:
             if xtimeName not in nc_file.variables:


### PR DESCRIPTION
This is useful for MPAS files with Time but without xtime or an equivalent.  The flag is `--ignore_time`.