### PR TITLE
Clarifies '--ignore_time' help for mesh-only case

### DIFF
--- a/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
+++ b/python_scripts/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
@@ -354,7 +354,9 @@ if __name__ == "__main__":
                         required=False)
     parser.add_argument("--ignore_time", dest="ignore_time",
                         action="store_true",
-                        help="ignore the Time dimension if it exists",
+                        help="ignore the Time dimension if it exists "
+                             "for files with a Time dimension but no xtime"
+                             "variable (e.g. mesh file)"
                         required=False)
     args = parser.parse_args()
 


### PR DESCRIPTION
Clarifies help message to specify that `--ignore_time` is needed to process a stand-alone mesh file.