### PR TITLE
Corrected ordering of hline for icepack_name for seaice docs

### DIFF
--- a/python_scripts/namelist_generation/parse_xml_registry.py
+++ b/python_scripts/namelist_generation/parse_xml_registry.py
@@ -467,9 +467,9 @@ def write_namelist_section_documentation():
             latex.write('    Possible Values: & %s \\\\\n' % possible_values)
             latex.write('    \hline\n')
             if (opt_icepack_name is not None):
-                latex.write('    \hline\n')
                 latex.write('    Icepack name: & \\verb+%s+ \\\\\n' %
                             opt_icepack_name)
+                latex.write('    \hline\n')
             latex.write('    \caption{%s: %s}\n' % (name_escaped, description))
             latex.write('\end{longtable}\n')
             latex.write('\end{center}\n')


### PR DESCRIPTION
Currently namelist tables with the icepack_name entry are not formatted correctly because of a misplaced \hline. This corrects that bug.