### PR TITLE
Fix mpas_draw Makefile changes accidentally committed

### DIFF
--- a/visualization/mpas_draw/Makefile
+++ b/visualization/mpas_draw/Makefile
@@ -15,7 +15,7 @@ else
 endif
 
 ifeq ($(PLATFORM),_LINUX)
-	CXXLIBS = -I$(NETCDF)/include -L$(NETCDF)/lib -lGL -lglut -lnetcdf_c++ -lnetcdf -lGLU -lstdc++ -I/usr/common/graphics/netcdf-cxx/4.2/include -L/global/homes/h/hoffman2/software/glut-3.6/lib/glut -I/global/homes/h/hoffman2/software/glut-3.6/include/GL -L/usr/common/graphics/netcdf-cxx/4.2/lib
+	CXXLIBS = -I$(NETCDF)/include -L$(NETCDF)/lib -lGL -lglut -lnetcdf_c++ -lnetcdf -lGLU -lstdc++
 endif
 
 ifeq ($(PLATFORM),_MACOS)

--- a/visualization/mpas_draw/mpas_draw.cpp
+++ b/visualization/mpas_draw/mpas_draw.cpp
@@ -17,7 +17,7 @@ using namespace std;
 #ifdef _MACOS
 	#include <GLUT/glut.h>
 #elif _LINUX
-	#include <glut.h>
+	#include <GL/glut.h>
 #endif
 
 int main ( int argc, char *argv[] );


### PR DESCRIPTION
I accidentally committed some changes to the MpasDraw Makefile in commit
157bed988cf0294e73ac9f3544a050ecf773afb2.
This commit changes them back.