### PR TITLE
Allows paraview vtk extractor extraction of single dimension time coord

### DIFF
--- a/visualization/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
+++ b/visualization/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
@@ -196,12 +196,17 @@ def build_field_time_series(local_time_indices, file_names, mesh_file,
                     raise ValueError("xtime variable name {} not found in "
                                      "{}".format(xtimeName, time_series_file))
                 var = time_series_file.variables[xtimeName]
-                xtime = ''.join(var[local_time_indices[time_index], :]).strip()
-                date = datetime(int(xtime[0:4]), int(xtime[5:7]),
-                                int(xtime[8:10]), int(xtime[11:13]),
-                                int(xtime[14:16]), int(xtime[17:19]))
-                years = date2num(date, units='days since 0000-01-01',
-                                 calendar='noleap')/365.
+                if len(var.shape) == 2:
+                    xtime = ''.join(var[local_time_indices[time_index], :]).strip()
+                    date = datetime(int(xtime[0:4]), int(xtime[5:7]),
+                                    int(xtime[8:10]), int(xtime[11:13]),
+                                    int(xtime[14:16]), int(xtime[17:19]))
+                    years = date2num(date, units='days since 0000-01-01',
+                                     calendar='noleap')/365.
+                else:
+                    xtime = var[local_time_indices[time_index]]
+                    years = xtime/365.
+                    xtime = str(xtime)
 
             # write the header for the vtp file
             vtp_file_prefix = "time_series/{}.{:d}".format(out_prefix,

--- a/visualization/paraview_vtk_field_extractor/utils.py
+++ b/visualization/paraview_vtk_field_extractor/utils.py
@@ -96,9 +96,13 @@ def setup_time_indices(fn_pattern, xtimeName):  # {{{
                 raise ValueError("xtime variable name {} not found in "
                                  "{}".format(xtimeName, file_name))
             local_times = []
-            xtime = nc_file.variables[xtimeName][:, :]
-            for index in range(xtime.shape[0]):
-                local_times.append(''.join(xtime[index, :]))
+            xtime = nc_file.variables[xtimeName]
+            if len(xtime.shape) == 2:
+                xtime = xtime[:, :]
+                for index in range(xtime.shape[0]):
+                    local_times.append(''.join(xtime[index, :]))
+            else:
+                local_times = xtime[:]
 
             if(len(local_times) == 0):
                 local_times = ['0']

--- a/visualization/paraview_vtk_field_extractor/utils.py
+++ b/visualization/paraview_vtk_field_extractor/utils.py
@@ -615,7 +615,7 @@ def build_cell_geom_lists(nc_file, output_32bit, lonlat):  # {{{
                                                          validVertices,
                                                          lonCell)
 
-    if nc_file.is_periodic == 'YES':
+    if nc_file.on_a_sphere == 'NO' and nc_file.is_periodic == 'YES':
         if lonlat:
             xcoord = lonCell
             ycoord = latCell
@@ -661,7 +661,7 @@ def build_vertex_geom_lists(nc_file, output_32bit, lonlat):  # {{{
                                                         validVertices,
                                                         lonVertex[valid_mask])
 
-    if nc_file.is_periodic == 'YES':
+    if nc_file.on_a_sphere == 'NO' and nc_file.is_periodic == 'YES':
         # all remaining entries in cellsOnVertex are valid
         validVertices = numpy.ones(cellsOnVertex.shape, bool)
         if lonlat:
@@ -727,7 +727,7 @@ def build_edge_geom_lists(nc_file, output_32bit, lonlat):  # {{{
                                                         vertsOnCell,
                                                         validVerts,
                                                         lonEdge[valid_mask])
-    if nc_file.is_periodic == 'YES':
+    if nc_file.on_a_sphere == 'NO' and nc_file.is_periodic == 'YES':
         if lonlat:
             xcoord = lonEdge[valid_mask]
             ycoord = latEdge[valid_mask]


### PR DESCRIPTION
`xtime` is typically a 2D string.
`timeMonthly_avg_daysSinceStartOfSim` in contrast
is a float corresponding to days of simulation.

This PR allows extraction of fields with
`timeMonthly_avg_daysSinceStartOfSim` within
`paraview_vtk_field_extractor.py`.

