### PR TITLE
Add error handling for sphereRadius=0

### DIFF
--- a/mesh_tools/create_SCRIP_files/create_SCRIP_file_from_MPAS_mesh.py
+++ b/mesh_tools/create_SCRIP_files/create_SCRIP_file_from_MPAS_mesh.py
@@ -53,6 +53,10 @@ maxVertices = len(fin.dimensions['maxEdges'])
 areaCell = fin.variables['areaCell'][:]
 sphereRadius = float(fin.sphere_radius)
 
+if sphereRadius <= 0:
+    print " -- field 'sphereRadius' = 0 (using planar mesh?); setting = 1 "
+    sphereRadius = 1.0
+
 if options.landiceMasks:
     landIceMask = fin.variables['landIceMask'][:]
 

--- a/mesh_tools/create_SCRIP_files/create_SCRIP_file_from_MPAS_mesh.py
+++ b/mesh_tools/create_SCRIP_files/create_SCRIP_file_from_MPAS_mesh.py
@@ -52,10 +52,14 @@ nCells = len(fin.dimensions['nCells'])
 maxVertices = len(fin.dimensions['maxEdges'])
 areaCell = fin.variables['areaCell'][:]
 sphereRadius = float(fin.sphere_radius)
+on_a_sphere = str(fin.on_a_sphere)
+
 
 if sphereRadius <= 0:
-    print " -- field 'sphereRadius' = 0 (using planar mesh?); setting = 1 "
-    sphereRadius = 1.0
+    print " -- WARNING: conservative remapping is NOT possible when 'sphereRadius' <= 0 because 'grid_area' field will be infinite (from division by 0)"
+
+if on_a_sphere == "NO":
+    print " -- WARNING: 'on_a_sphere' attribute is 'NO', which means that there may be some disagreement regarding area between the planar (source) and spherical (target) mesh"
 
 if options.landiceMasks:
     landIceMask = fin.variables['landIceMask'][:]


### PR DESCRIPTION
Add simple error handling to avoid division by zero when sphereRadius field is set to 0,
which is commonly the case for planar meshes. Setting to 1 in this case ensures that the
grid_area values in the output SCRIP file take on the same values as the areaCell field
in the input MPAS input mesh file.

closes #132