### PR TITLE
Remove shallow-water IC fields from periodic hex meshes

### DIFF
--- a/mesh_tools/periodic_hex/module_write_netcdf.F
+++ b/mesh_tools/periodic_hex/module_write_netcdf.F
@@ -9,8 +9,6 @@ module write_netcdf
    integer :: wrDimIDmaxEdges2
    integer :: wrDimIDTWO
    integer :: wrDimIDvertexDegree
-   integer :: wrDimIDnVertLevels
-   integer :: wrDimIDnTracers
    integer :: wrVarIDlatCell
    integer :: wrVarIDlonCell
    integer :: wrVarIDxCell
@@ -47,25 +45,11 @@ module write_netcdf
    integer :: wrVarIDcellsOnVertex
    integer :: wrVarIDkiteAreasOnVertex
    integer :: wrVarIDmeshDensity
-   integer :: wrVarIDfEdge
-   integer :: wrVarIDfVertex
-   integer :: wrVarIDh_s
-   integer :: wrVarIDu
-   integer :: wrVarIDuBC
-   integer :: wrVarIDv
-   integer :: wrVarIDh
-   integer :: wrVarIDvh
-   integer :: wrVarIDcirculation
-   integer :: wrVarIDvorticity
-   integer :: wrVarIDke
-   integer :: wrVarIDtracers
  
    integer :: wrLocalnCells
    integer :: wrLocalnEdges
    integer :: wrLocalnVertices
    integer :: wrLocalmaxEdges
-   integer :: wrLocalnVertLevels
-   integer :: wrLocalnTracers
  
    contains
  
@@ -74,8 +58,6 @@ module write_netcdf
                                nEdges, &
                                nVertices, &
                                maxEdges, &
-                               nVertLevels, &
-                               nTracers, &
                                vertexDegree, &
                                dc, &
                                nx, &
@@ -90,8 +72,6 @@ module write_netcdf
       integer, intent(in) :: nEdges
       integer, intent(in) :: nVertices
       integer, intent(in) :: maxEdges
-      integer, intent(in) :: nVertLevels
-      integer, intent(in) :: nTracers
       integer, intent(in) :: vertexDegree
       real (kind=8), intent(in) :: dc
       integer, intent(in) :: nx
@@ -109,8 +89,6 @@ module write_netcdf
       wrLocalnEdges = nEdges
       wrLocalnVertices = nVertices
       wrLocalmaxEdges = maxEdges
-      wrLocalnVertLevels = nVertLevels
-      wrLocalnTracers = nTracers
 
       on_a_sphere = 'NO'
       is_periodic = 'YES'
@@ -130,8 +108,6 @@ module write_netcdf
       nferr = nf_def_dim(wr_ncid, 'maxEdges2', 2*maxEdges, wrDimIDmaxEdges2)
       nferr = nf_def_dim(wr_ncid, 'TWO', 2, wrDimIDTWO)
       nferr = nf_def_dim(wr_ncid, 'vertexDegree', vertexDegree, wrDimIDvertexDegree)
-      nferr = nf_def_dim(wr_ncid, 'nVertLevels', nVertLevels, wrDimIDnVertLevels)
-      nferr = nf_def_dim(wr_ncid, 'nTracers', nTracers, wrDimIDnTracers)
       nferr = nf_def_dim(wr_ncid, 'Time', NF_UNLIMITED, wrDimIDTime)
 
 
@@ -230,48 +206,6 @@ module write_netcdf
       nferr = nf_def_var(wr_ncid, 'kiteAreasOnVertex', NF_DOUBLE,  2, dimlist, wrVarIDkiteAreasOnVertex)
       dimlist( 1) = wrDimIDnCells
       nferr = nf_def_var(wr_ncid, 'meshDensity', NF_DOUBLE,  1, dimlist, wrVarIDmeshDensity)
-      dimlist( 1) = wrDimIDnEdges
-      nferr = nf_def_var(wr_ncid, 'fEdge', NF_DOUBLE,  1, dimlist, wrVarIDfEdge)
-      dimlist( 1) = wrDimIDnVertices
-      nferr = nf_def_var(wr_ncid, 'fVertex', NF_DOUBLE,  1, dimlist, wrVarIDfVertex)
-      dimlist( 1) = wrDimIDnCells
-      nferr = nf_def_var(wr_ncid, 'h_s', NF_DOUBLE,  1, dimlist, wrVarIDh_s)
-      dimlist( 1) = wrDimIDnVertLevels
-      dimlist( 2) = wrDimIDnEdges
-      dimlist( 3) = wrDimIDTime
-      nferr = nf_def_var(wr_ncid, 'u', NF_DOUBLE,  3, dimlist, wrVarIDu)
-      dimlist( 1) = wrDimIDnVertLevels
-      dimlist( 2) = wrDimIDnEdges
-      nferr = nf_def_var(wr_ncid, 'uBC', NF_INT,  2, dimlist, wrVarIDuBC)
-      dimlist( 1) = wrDimIDnVertLevels
-      dimlist( 2) = wrDimIDnEdges
-      dimlist( 3) = wrDimIDTime
-      nferr = nf_def_var(wr_ncid, 'v', NF_DOUBLE,  3, dimlist, wrVarIDv)
-      dimlist( 1) = wrDimIDnVertLevels
-      dimlist( 2) = wrDimIDnCells
-      dimlist( 3) = wrDimIDTime
-      nferr = nf_def_var(wr_ncid, 'h', NF_DOUBLE,  3, dimlist, wrVarIDh)
-      dimlist( 1) = wrDimIDnVertLevels
-      dimlist( 2) = wrDimIDnEdges
-      dimlist( 3) = wrDimIDTime
-      nferr = nf_def_var(wr_ncid, 'vh', NF_DOUBLE,  3, dimlist, wrVarIDvh)
-      dimlist( 1) = wrDimIDnVertLevels
-      dimlist( 2) = wrDimIDnVertices
-      dimlist( 3) = wrDimIDTime
-      nferr = nf_def_var(wr_ncid, 'circulation', NF_DOUBLE,  3, dimlist, wrVarIDcirculation)
-      dimlist( 1) = wrDimIDnVertLevels
-      dimlist( 2) = wrDimIDnVertices
-      dimlist( 3) = wrDimIDTime
-      nferr = nf_def_var(wr_ncid, 'vorticity', NF_DOUBLE,  3, dimlist, wrVarIDvorticity)
-      dimlist( 1) = wrDimIDnVertLevels
-      dimlist( 2) = wrDimIDnCells
-      dimlist( 3) = wrDimIDTime
-      nferr = nf_def_var(wr_ncid, 'ke', NF_DOUBLE,  3, dimlist, wrVarIDke)
-      dimlist( 1) = wrDimIDnTracers
-      dimlist( 2) = wrDimIDnVertLevels
-      dimlist( 3) = wrDimIDnCells
-      dimlist( 4) = wrDimIDTime
-      nferr = nf_def_var(wr_ncid, 'tracers', NF_DOUBLE,  4, dimlist, wrVarIDtracers)
  
       nferr = nf_enddef(wr_ncid)
  
@@ -279,7 +213,6 @@ module write_netcdf
  
  
    subroutine write_netcdf_fields( &
-                                  time, &
                                   latCell, &
                                   lonCell, &
                                   xCell, &
@@ -315,26 +248,13 @@ module write_netcdf
                                   edgesOnVertex, &
                                   cellsOnVertex, &
                                   kiteAreasOnVertex, &
-                                  meshDensity, &
-                                  fEdge, &
-                                  fVertex, &
-                                  h_s, &
-                                  uBC, &
-                                  u, &
-                                  v, &
-                                  h, &
-                                  vh, &
-                                  circulation, &
-                                  vorticity, &
-                                  ke, &
-                                  tracers &
+                                  meshDensity &
                                  )
  
       implicit none
  
       include 'netcdf.inc'
  
-      integer, intent(in) :: time
       real (kind=8), dimension(:), intent(in) :: latCell
       real (kind=8), dimension(:), intent(in) :: lonCell
       real (kind=8), dimension(:), intent(in) :: xCell
@@ -371,38 +291,15 @@ module write_netcdf
       integer, dimension(:,:), intent(in) :: cellsOnVertex
       real (kind=8), dimension(:,:), intent(in) :: kiteAreasOnVertex
       real (kind=8), dimension(:), intent(in) :: meshDensity
-      real (kind=8), dimension(:), intent(in) :: fEdge
-      real (kind=8), dimension(:), intent(in) :: fVertex
-      real (kind=8), dimension(:), intent(in) :: h_s
-      integer, dimension(:,:), intent(in) :: uBC
-      real (kind=8), dimension(:,:,:), intent(in) :: u
-      real (kind=8), dimension(:,:,:), intent(in) :: v
-      real (kind=8), dimension(:,:,:), intent(in) :: h
-      real (kind=8), dimension(:,:,:), intent(in) :: vh
-      real (kind=8), dimension(:,:,:), intent(in) :: circulation
-      real (kind=8), dimension(:,:,:), intent(in) :: vorticity
-      real (kind=8), dimension(:,:,:), intent(in) :: ke
-      real (kind=8), dimension(:,:,:,:), intent(in) :: tracers
  
       integer :: nferr
       integer, dimension(1) :: start1, count1
       integer, dimension(2) :: start2, count2
-      integer, dimension(3) :: start3, count3
-      integer, dimension(4) :: start4, count4
  
       start1(1) = 1
  
       start2(1) = 1
       start2(2) = 1
- 
-      start3(1) = 1
-      start3(2) = 1
-      start3(3) = 1
- 
-      start4(1) = 1
-      start4(2) = 1
-      start4(3) = 1
-      start4(4) = 1
  
       start1(1) = 1
       count1( 1) = wrLocalnCells
@@ -557,73 +454,6 @@ module write_netcdf
       start1(1) = 1
       count1( 1) = wrLocalnCells
       nferr = nf_put_vara_double(wr_ncid, wrVarIDmeshDensity, start1, count1, meshDensity)
- 
-      start1(1) = 1
-      count1( 1) = wrLocalnEdges
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDfEdge, start1, count1, fEdge)
- 
-      start1(1) = 1
-      count1( 1) = wrLocalnVertices
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDfVertex, start1, count1, fVertex)
- 
-      start1(1) = 1
-      count1( 1) = wrLocalnCells
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDh_s, start1, count1, h_s)
-
-      start2(2) = 1
-      count2( 1) = wrLocalnVertLevels
-      count2( 2) = wrLocalnEdges
-      nferr = nf_put_vara_int(wr_ncid, wrVarIDuBC, start2, count2, u)
- 
-      start3(3) = time
-      count3( 1) = wrLocalnVertLevels
-      count3( 2) = wrLocalnEdges
-      count3( 3) = 1
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDu, start3, count3, u)
- 
-      start3(3) = time
-      count3( 1) = wrLocalnVertLevels
-      count3( 2) = wrLocalnEdges
-      count3( 3) = 1
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDv, start3, count3, v)
- 
-      start3(3) = time
-      count3( 1) = wrLocalnVertLevels
-      count3( 2) = wrLocalnCells
-      count3( 3) = 1
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDh, start3, count3, h)
- 
-      start3(3) = time
-      count3( 1) = wrLocalnVertLevels
-      count3( 2) = wrLocalnEdges
-      count3( 3) = 1
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDvh, start3, count3, vh)
- 
-      start3(3) = time
-      count3( 1) = wrLocalnVertLevels
-      count3( 2) = wrLocalnVertices
-      count3( 3) = 1
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDcirculation, start3, count3, circulation)
- 
-      start3(3) = time
-      count3( 1) = wrLocalnVertLevels
-      count3( 2) = wrLocalnVertices
-      count3( 3) = 1
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDvorticity, start3, count3, vorticity)
- 
-      start3(3) = time
-      count3( 1) = wrLocalnVertLevels
-      count3( 2) = wrLocalnCells
-      count3( 3) = 1
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDke, start3, count3, ke)
- 
-      start4(4) = time
-      count4( 1) = wrLocalnTracers
-      count4( 2) = wrLocalnVertLevels
-      count4( 3) = wrLocalnCells
-      count4( 4) = 1
-      nferr = nf_put_vara_double(wr_ncid, wrVarIDtracers, start4, count4, tracers)
- 
  
    end subroutine write_netcdf_fields
  

--- a/mesh_tools/periodic_hex/periodic_grid.F
+++ b/mesh_tools/periodic_hex/periodic_grid.F
@@ -16,7 +16,7 @@ program hexagonal_periodic_grid
    integer, allocatable, dimension(:) :: nEdgesOnCell, nEdgesOnEdge
    integer, allocatable, dimension(:,:) :: cellsOnCell, edgesOnCell, verticesOnCell
    integer, allocatable, dimension(:,:) :: cellsOnEdge, edgesOnEdge, verticesOnEdge
-   integer, allocatable, dimension(:,:) :: edgesOnVertex, cellsOnVertex, uBC
+   integer, allocatable, dimension(:,:) :: edgesOnVertex, cellsOnVertex
    real (kind=8), allocatable, dimension(:) :: areaTriangle, areaCell, angleEdge
    real (kind=8), allocatable, dimension(:) :: dcEdge, dvEdge
    real (kind=8), allocatable, dimension(:) :: latCell, lonCell, xCell, yCell, zCell
@@ -24,15 +24,11 @@ program hexagonal_periodic_grid
    real (kind=8), allocatable, dimension(:) :: latVertex, lonVertex, xVertex, yVertex, zVertex
    real (kind=8), allocatable, dimension(:) :: meshDensity
    real (kind=8), allocatable, dimension(:,:) :: weightsOnEdge, kiteAreasOnVertex
-   real (kind=8), allocatable, dimension(:) :: fEdge, fVertex, h_s
-   real (kind=8), allocatable, dimension(:,:,:) :: u, v, h, vh, circulation, vorticity, ke
-   real (kind=8), allocatable, dimension(:,:,:,:) :: tracers
 
    integer :: i, j, np, iCell
    integer :: nCells, nEdges, nVertices
    integer :: iRow, iCol, ii, jj
    integer :: nprocx, nprocy
-   real (kind=8) :: r
    character (len=32) :: decomp_fname
 
    call cell_indexing_read_nl()
@@ -84,19 +80,6 @@ program hexagonal_periodic_grid
    allocate(zVertex(nVertices))
    allocate(meshDensity(nCells))
 
-   allocate(fEdge(nEdges))
-   allocate(fVertex(nVertices))
-   allocate(h_s(nCells))
-   allocate(uBC(nVertLevels, nEdges))
-
-   allocate(u(nVertLevels,nEdges,1))
-   allocate(v(nVertLevels,nEdges,1))
-   allocate(vh(nVertLevels,nEdges,1))
-   allocate(h(nVertLevels,nCells,1))
-   allocate(circulation(nVertLevels,nVertices,1))
-   allocate(vorticity(nVertLevels,nVertices,1))
-   allocate(ke(nVertLevels,nCells,1))
-   allocate(tracers(nTracers,nVertLevels,nCells,1))
 
    do iRow = 1, ny
    do iCol = 1, nx
@@ -276,43 +259,11 @@ program hexagonal_periodic_grid
    meshDensity(:) = 1.0
 
    !
-   ! fill in initial conditions below
-   ! NOTE: these initial conditions will likely be removed
-   !   from the grid.nc files at some point (soon).
-   ! Initialize fields in grid
-   !
-
-   fEdge(:) = 1.0e-4
-   fVertex(:) = 1.0e-4
-
-   h_s(:) = 0.0
-   u(:,:,:) = 0.0
-   v(:,:,:) = 0.0
-   vh(:,:,:) = 0.0
-   circulation(:,:,:) = 0.0
-   vorticity(:,:,:) = 0.0
-   ke(:,:,:) = 0.0
-   tracers(:,:,:,:) = 0.0
-   h(:,:,:) = 1.0
-
-   do i=1,nCells
-      r = sqrt((xCell(i) - (nx/2)*(10.0*dc))**2.0 + (yCell(i) - (ny/2)*(10.0*dc))**2.0)
-      if (r < 10.0*10.0*dc) then
-         tracers(1,1,i,1) = (20.0 / 2.0) * (1.0 + cos(pi*r/(10.0*10.0*dc))) + 0.0
-         h(1,i,1) = 1.0 + 0.1*cos(pi*r/(20.0*10.0*dc))
-      else
-         tracers(1,1,i,1) = 0.0
-         h(1,i,1) = 1.0
-      end if
-   end do
-
-   !
    ! Write grid to grid.nc file
    !
-   call write_netcdf_init( nCells, nEdges, nVertices, maxEdges, nVertLevels, nTracers, vertexDegree, dc, nx, ny )
+   call write_netcdf_init( nCells, nEdges, nVertices, maxEdges, vertexDegree, dc, nx, ny )
  
-   call write_netcdf_fields( 1, &
-                             latCell, lonCell, xCell, yCell, zCell, indexToCellID, &
+   call write_netcdf_fields( latCell, lonCell, xCell, yCell, zCell, indexToCellID, &
                              latEdge, lonEdge, xEdge, yEdge, zEdge, indexToEdgeID, &
                              latVertex, lonVertex, xVertex, yVertex, zVertex, indexToVertexID, &
                              cellsOnEdge, &
@@ -332,19 +283,7 @@ program hexagonal_periodic_grid
                              edgesOnVertex, &
                              cellsOnVertex, &
                              kiteAreasOnVertex, &
-                             meshDensity, &
-                             fEdge, &
-                             fVertex, &
-                             h_s, &
-                             uBC, &
-                             u, &
-                             v, &
-                             h, &
-                             vh, &
-                             circulation, &
-                             vorticity, &
-                             ke, &
-                             tracers &
+                             meshDensity &
                             )
 
    call write_netcdf_finalize()
@@ -382,21 +321,6 @@ program hexagonal_periodic_grid
    end do
 
 end program hexagonal_periodic_grid
-
-
-subroutine enforce_uBC(u, uBC, xCell, yCell, zCell, nCells, nEdges, nVertLevels, dc)
-! this suboutine provides a hook into uBC. the uBC field is read into the ocean
-! model and used to enforce boundary conditions on the velocity field.
-! uBC is written to the grid.nc file, even if the forward model does not use it.
-
-real (kind=8), intent(in) :: dc
-real (kind=8), intent(inout), dimension(nVertLevels, nEdges, 1) :: u
-real (kind=8), intent(in), dimension(nCells) :: xCell, yCell, zCell
-integer, intent(inout), dimension(nVertLevels, nEdges) :: uBC
-
-uBC = -10
-
-end subroutine enforce_uBC
 
 
 subroutine decompose_nproc(nproc, nprocx, nprocy)


### PR DESCRIPTION
This merge removes shallow-water initial conditions from periodic hex meshes.

The periodic_hex mesh generator previously added fields to the grid.nc
file to serve as placeholders for ICs for the shallow-water model.
However, these fields are not part of the MPAS mesh specification, and
have been removed. Specifically, the following fields are deleted in
this commit:
```
  fEdge
  fVertex
  h_s
  u
  uBC
  v
  h
  vh
  circulation
  vorticity
  ke
  tracers
```
Additionally, the dimensions nVertLevels and nTracers have also been
removed.