### PR TITLE
Land ice mesh tools to python 3

### DIFF
--- a/landice/mesh_tools_li/define_cullMask.py
+++ b/landice/mesh_tools_li/define_cullMask.py
@@ -2,6 +2,9 @@
 # Script for adding a field named cullMask to an MPAS land ice grid for use with the MpasCellCuller tool that actually culls the unwanted cells.
 # Matt Hoffman, February 28, 2013
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import sys
 import numpy as np
 from optparse import OptionParser
@@ -9,7 +12,7 @@ from netCDF4 import Dataset as NetCDFFile
 from datetime import datetime
 
 
-print "** Gathering information."
+print("** Gathering information.")
 parser = OptionParser()
 parser.add_option("-f", "--file", dest="file", help="grid file to modify; default: landice_grid.nc", metavar="FILE")
 parser.add_option("-m", "--method", dest="method", help="method to use for marking cells to cull.  Supported methods: 'noIce', 'numCells', 'distance', 'radius', 'edgeFraction'", metavar="METHOD")
@@ -19,7 +22,7 @@ parser.add_option("-p", "--plot", dest="makePlot", help="Include to have the scr
 options, args = parser.parse_args()
 
 if not options.file:
-	print "No grid filename provided. Using landice_grid.nc."
+	print("No grid filename provided. Using landice_grid.nc.")
         options.file = "landice_grid.nc"
 
 if not options.method:
@@ -46,10 +49,10 @@ cullCell = np.zeros((nCells, ), dtype=np.int8)  # Initialize to cull no cells
 thicknessMissing = True
 try:
   thickness = f.variables['thickness'][0,:]
-  print 'Using thickness field at time 0'
+  print('Using thickness field at time 0')
   thicknessMissing = False
 except:
-  print "The field 'thickness' is not available.  Some culling methods will not work."
+  print("The field 'thickness' is not available.  Some culling methods will not work.")
 
 
 # =====  Various methods for defining the mask ====
@@ -57,7 +60,7 @@ except:
 # =========
 #  only keep cells with ice
 if maskmethod == 'noIce':
-  print "Method: remove cells without ice"
+  print("Method: remove cells without ice")
   if thicknessMissing:
      sys.exit("Unable to perform 'numCells' method because thickness field was missing.")
 
@@ -66,13 +69,13 @@ if maskmethod == 'noIce':
 # =========
 #  add a buffer of X cells around the ice
 elif maskmethod == 'numCells':
-  print "Method: remove cells beyond a certain number of cells from existing ice"
+  print("Method: remove cells beyond a certain number of cells from existing ice")
 
   if thicknessMissing:
      sys.exit("Unable to perform 'numCells' method because thickness field was missing.")
 
   buffersize=int(options.numCells)  # number of cells to expand
-  print "Using a buffer of {} cells".format(buffersize)
+  print("Using a buffer of {} cells".format(buffersize))
 
   keepCellMask = np.copy(cullCell[:])
   keepCellMask[:] = 0
@@ -81,17 +84,17 @@ elif maskmethod == 'numCells':
 
   # mark the cells with ice first
   keepCellMask[thickness > 0.0] = 1
-  print 'Num of cells with ice:', sum(keepCellMask)
+  print('Num of cells with ice: {}'.format(sum(keepCellMask)))
 
   for i in range(buffersize):
-    print 'Starting buffer loop ', i+1
+    print('Starting buffer loop {}'.format(i+1))
     keepCellMaskNew = np.copy(keepCellMask)  # make a copy to edit that can be edited without changing the original
     ind = np.nonzero(keepCellMask == 0)[0]
     for i in range(len(ind)):
        iCell = ind[i]
        keepCellMaskNew[iCell] = keepCellMask[cellsOnCell[iCell,:nEdgesOnCell[iCell]]-1].max() # if any neighbor has a value of 1, then 1 will get assigned to iCell.
     keepCellMask = np.copy(keepCellMaskNew)  # after we've looped over all cells assign the new mask to the variable we need (either for another loop around the domain or to write out)
-    print '  Num of cells to keep:', sum(keepCellMask)
+    print('  Num of cells to keep: {}'.format(sum(keepCellMask)))
 
   # Now convert the keepCellMask to the cullMask
   cullCell[:] = np.absolute(keepCellMask[:]-1)  # Flip the mask for which ones to cull
@@ -100,13 +103,13 @@ elif maskmethod == 'numCells':
 #  remove cells beyond a certain distance of ice extent
 elif maskmethod == 'distance':
 
-  print "Method: remove cells beyond a certain distance from existing ice"
+  print("Method: remove cells beyond a certain distance from existing ice")
 
   if thicknessMissing:
      sys.exit("Unable to perform 'numCells' method because thickness field was missing.")
 
   dist=float(options.distance)
-  print "Using a buffer distance of {} km".format(dist)
+  print("Using a buffer distance of {} km".format(dist))
   dist = dist * 1000.0 # convert to m
 
   keepCellMask = np.copy(cullCell[:])
@@ -118,7 +121,7 @@ elif maskmethod == 'distance':
 
   # mark the cells with ice first
   keepCellMask[thickness > 0.0] = 1
-  print 'Num of cells with ice:', sum(keepCellMask)
+  print('Num of cells with ice: {}'.format(sum(keepCellMask)))
 
   # find list of margin cells
   iceCells = np.nonzero(keepCellMask == 1)[0]
@@ -138,7 +141,7 @@ elif maskmethod == 'distance':
       ind = np.nonzero(((xCell-xCell[iCell])**2 + (yCell-yCell[iCell])**2)**0.5 < dist)[0]
       keepCellMask[ind] = 1
 
-  print '  Num of cells to keep:', sum(keepCellMask)
+  print('  Num of cells to keep:'.format(sum(keepCellMask)))
 
   # Now convert the keepCellMask to the cullMask
   cullCell[:] = np.absolute(keepCellMask[:]-1)  # Flip the mask for which ones to cull
@@ -147,14 +150,14 @@ elif maskmethod == 'distance':
 # =========
 #  cut out beyond some radius (good for the dome)
 elif maskmethod == 'radius':
-  print "Method: remove cells beyond a radius"
+  print("Method: remove cells beyond a radius")
   ind = np.nonzero( (xCell[:]**2 + yCell[:]**2)**0.5 > 26000.0 )
   cullCell[ind] = 1
 
 # =========
 #  cut off some fraction of the height/width on all 4 sides - useful for cleaning up a mesh from periodic_general
 elif maskmethod == 'edgeFraction':
-  print "Method: remove a fraction from all 4 edges"
+  print("Method: remove a fraction from all 4 edges")
   frac=0.025
 
   cullCell[:] = 0
@@ -175,7 +178,7 @@ else:
 # =========
 
 
-print 'Num of cells to cull:', sum(cullCell[:])
+print('Num of cells to cull: {}'.format(sum(cullCell[:])))
 
 # =========
 # Try to add the new variable
@@ -205,6 +208,6 @@ if options.makePlot:
   plt.show()
 
 f.close()
-print "cullMask generation complete."
+print("cullMask generation complete.")
 
 

--- a/landice/mesh_tools_li/define_cullMask.py
+++ b/landice/mesh_tools_li/define_cullMask.py
@@ -22,7 +22,7 @@ parser.add_option("-p", "--plot", dest="makePlot", help="Include to have the scr
 options, args = parser.parse_args()
 
 if not options.file:
-	print("No grid filename provided. Using landice_grid.nc.")
+        print("No grid filename provided. Using landice_grid.nc.")
         options.file = "landice_grid.nc"
 
 if not options.method:

--- a/landice/mesh_tools_li/mark_domain_boundaries_dirichlet.py
+++ b/landice/mesh_tools_li/mark_domain_boundaries_dirichlet.py
@@ -3,13 +3,16 @@
 This script marks all of the boundary cells in a domain as Dirichlet velocity boundaries.
 '''
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import netCDF4
 import numpy as np
 from optparse import OptionParser
 from datetime import datetime
 import sys
 
-print "== Gathering information.  (Invoke with --help for more details. All arguments are optional)\n"
+print("== Gathering information.  (Invoke with --help for more details. All arguments are optional)\n")
 parser = OptionParser()
 parser.description = __doc__
 parser.add_option("-f", "--file", dest="inputFile", help="name of file to be modified.", default="landice_grid.nc", metavar="FILENAME")
@@ -20,8 +23,8 @@ for option in parser.option_list:
 options, args = parser.parse_args()
 
 
-print "  Input file: " + options.inputFile
-print "  Time level: {}".format(options.time)
+print("  Input file: {}".format(options.inputFile))
+print("  Time level: {}".format(options.time))
 
 f=netCDF4.Dataset(options.inputFile, 'r+')
 nCells = len(f.dimensions['nCells'])
@@ -47,4 +50,4 @@ setattr(f, 'history', newhist )
 
 f.close()
 
-print '\nMarking boundary cells completed.'
+print('\nMarking boundary cells completed.')

--- a/mesh_tools/mesh_conversion_tools/mark_horns_for_culling.py
+++ b/mesh_tools/mesh_conversion_tools/mark_horns_for_culling.py
@@ -9,6 +9,9 @@ It adds the new masked cell to an existing 'cullCell' field if it exists,
 otherwise it creates a new field.
 '''
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import sys
 import numpy as np
 import netCDF4
@@ -16,7 +19,7 @@ from optparse import OptionParser
 from datetime import datetime
 
 
-print "== Gathering information.  (Invoke with --help for more details. All arguments are optional)\n"
+print("== Gathering information.  (Invoke with --help for more details. All arguments are optional)\n")
 parser = OptionParser()
 parser.description = __doc__
 parser.add_option("-f", "--file", dest="inputFile", help="Name of file to be processed.", default="grid.nc", metavar="FILENAME")
@@ -25,7 +28,7 @@ for option in parser.option_list:
         option.help += (" " if option.help else "") + "[default: %default]"
 options, args = parser.parse_args()
 
-print "  File to be modified:  " + options.inputFile
+print("  File to be modified:  " + options.inputFile)
 
 
 # Open file and get needed fields.
@@ -63,5 +66,5 @@ setattr(inputFile, 'history', newhist )
 
 inputFile.close()
 
-print '\n{} "horn" locations have been marked in the field cullCell.'.format(nHorns)
-print "Remember to use MpasCellCuller.x to actually remove them!"
+print('\n{} "horn" locations have been marked in the field cullCell.'.format(nHorns))
+print("Remember to use MpasCellCuller.x to actually remove them!")


### PR DESCRIPTION
Make a few minor formatting changes to the land ice mesh tools so they work in python 3 as well as python 2.

I also include `mark_horns_for_culling.py` because I think this script might be used primarily by the land-ice model and because I'm pretty sure that @matthewhoffman is the author of all 5 scripts.