### PR TITLE
Fix vtk extractor bug

### DIFF
--- a/visualization/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
+++ b/visualization/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
@@ -164,8 +164,6 @@ def build_field_time_series(local_time_indices, file_names, mesh_file,
         else:
             nHyperSlabs += len(extra_dim_vals)
 
-    time_series_file.close()
-
     any_var_has_time_dim = np.any(var_has_time_dim)
 
     if topo_dim is not None:
@@ -175,6 +173,8 @@ def build_field_time_series(local_time_indices, file_names, mesh_file,
             nTopoLevels = len(time_series_file.dimensions[topo_dim])
     else:
         nTopoLevels = None
+
+    time_series_file.close()
 
     try:
         os.makedirs(out_dir)


### PR DESCRIPTION
Quick fix on a bug @pwolfram and I found in `paraview_vtk_field_extractor.py`. 

Note that `time_series_file` is closed, and then called in the else block in L175. This breaks the extractor if one just uses the `-f` flag (and not the `-m` flag), e.g. when the mesh and desired variables are contained in the same file.

https://github.com/MPAS-Dev/MPAS-Tools/blob/e2202ecb0a98562a9221971f8dd01dd4c5fc08c8/visualization/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py#L167-L177

Although note that `time_series_file.close()` is called again towards the end of this block:
https://github.com/MPAS-Dev/MPAS-Tools/blob/e2202ecb0a98562a9221971f8dd01dd4c5fc08c8/visualization/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py#L373

So perhaps this is a merge bug and it should just remain at L373 and be removed around the region I implemented the fix.