### PR TITLE
Add an external script to conda-package planar_hex

### DIFF
--- a/mesh_tools/planar_hex/mpas_tools
+++ b/mesh_tools/planar_hex/mpas_tools
@@ -1,0 +1,1 @@
+../../conda_package/mpas_tools/

--- a/mesh_tools/planar_hex/planar_hex
+++ b/mesh_tools/planar_hex/planar_hex
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+# -*- coding: utf-8 -*-
+import re
+import sys
+
+from mpas_tools.planar_hex import main
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())


### PR DESCRIPTION
In #248, `planar_hex` was moved into the conda-package for MPAS-Tools.  However there is also a need for an external version of the tool.  This PR adds a stub script called planar_hex that calls the code in the conda package.  (The stub script is copied from a conda environment and is the same approach used to access entry points into python packages used elsewhere.)
