### PR TITLE
Add bare-bones docs with Read The Docs

### DIFF
--- a/conda_package/docs/environment.yml
+++ b/conda_package/docs/environment.yml
@@ -1,7 +1,6 @@
 name: mpas_tools_docs
 channels:
   - conda-forge
-  - xylar
 dependencies:
   - python=3.7
   - pytest

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,31 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the conda_package/docs/ directory with Sphinx
+sphinx:
+  configuration: conda_package/docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# Build PDF
+formats:
+    - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+      - method: setuptools
+        path: conda_package/
+   system_packages: true
+
+conda:
+    environment: conda_package/docs/environment.yml
+
+build:
+   image: latest
+
+


### PR DESCRIPTION
This will just create some minimal documentation with (part of) the API of the conda package.  It is intended to get the ball rolling for future work on building out the documentation.