### PR TITLE
Fix conda package setup.py when called with a path

### DIFF
--- a/conda_package/setup.py
+++ b/conda_package/setup.py
@@ -11,6 +11,9 @@ with open(os.path.join(here, 'mpas_tools', '__init__.py')) as f:
 version = re.search(r'{}\s*=\s*[(]([^)]*)[)]'.format('__version_info__'),
                     init_file).group(1).replace(', ', '.')
 
+
+os.chdir(here)
+
 setup(name='mpas_tools',
       version=version,
       description='A set of tools for creating and manipulating meshes for the'


### PR DESCRIPTION
In such cases, we need to cd to the location of `setup.py` before finding package modules and scripts.

This appears to be needed to build in Read The Docs.