### PR TITLE
Fixes output of x_period and y_period

### DIFF
--- a/mesh_tools/mesh_conversion_tools/netcdf_utils.cpp
+++ b/mesh_tools/mesh_conversion_tools/netcdf_utils.cpp
@@ -449,9 +449,8 @@ double netcdf_mpas_read_yperiod(string filename){/*{{{*/
 		vals = att_id -> values();
 
 		for(int i = 0; i < vals -> num(); i++){
-			tmp_name = vals -> as_string(i);
 
-			return atof(vals -> as_string(i));
+			return vals -> as_double(i);
 		}
 	} else {
 		return -1.0;


### PR DESCRIPTION
For periodic grids, x and y_period where being read in as character
strings and then converted to doubles for output in the mesh.  The read
in as a string caused only the first two decimals to be read of y_period
and x_period, which breaks periodicity in MPAS.

This commit reads in x_period and y_period as doubles and skips the
conversions.