### PR TITLE
Fixes landice mesh tool interpolate_to_mpasli_grid.py when source and destination grids are both mpas format.

### DIFF
--- a/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
+++ b/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
@@ -366,7 +366,7 @@ def interpolate_field_with_layers(MPASfieldName):
 def vertical_interp_MPAS_grid(mpas_grid_input_layers, input_layers):
     destinationField = np.zeros((nCells, nVertLevels))
     for i in range(nCells):
-        destinationField[i,:] = np.interp(mpasLayerCenters, input_layers, mpas_grid_input_layers[:,i])
+        destinationField[i,:] = np.interp(mpasLayerCenters,input_layers, mpas_grid_input_layers[:,i])
     return destinationField
 
 
@@ -478,7 +478,7 @@ if filetype=='cism':
 elif filetype == 'mpas':
     # Get the MPAS vertical dimensions if they exist
     try:
-      nVertLevels = len(inputFile.dimensions['nVertLevels'])
+      input_nVertLevels = len(inputFile.dimensions['nVertLevels'])
     except:
       print('  Input file is missing the dimension nVertLevels.  Might not be a problem.')
 

--- a/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
+++ b/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
@@ -476,11 +476,6 @@ if filetype=='cism':
 
 
 elif filetype == 'mpas':
-    # Get the MPAS vertical dimensions if they exist
-    try:
-      input_nVertLevels = len(inputFile.dimensions['nVertLevels'])
-    except:
-      print('  Input file is missing the dimension nVertLevels.  Might not be a problem.')
 
     #try:
     #  nVertInterfaces = len(inputFile.dimensions['nVertInterfaces'])


### PR DESCRIPTION
Used input file for vertical dimensions, when should have used output file.