### PR TITLE
Remove remaining mentions of evtk

### DIFF
--- a/conda_package/mpas_tools/viz.py
+++ b/conda_package/mpas_tools/viz.py
@@ -10,10 +10,7 @@ files on MPAS grids.
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-try:
-    from evtk.vtk import VtkFile, VtkPolyData
-except ImportError:
-    from pyevtk.vtk import VtkFile, VtkPolyData
+from pyevtk.vtk import VtkFile, VtkPolyData
 
 import sys
 import glob

--- a/visualization/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
+++ b/visualization/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py
@@ -73,7 +73,7 @@ points of edge polygons (a "water-tight" surface).
 
 Requirements:
 This script requires access to the following non standard modules:
-evtk (available from e3sm channel)
+pyevtk
 netcdf4
 numpy
 


### PR DESCRIPTION
The package on conda-forge is pyevtk and evtk should not be used
going forward.

closes #251