### PR TITLE
Update version of geometric_features to include offline data

### DIFF
--- a/compass/meta.yaml
+++ b/compass/meta.yaml
@@ -7,14 +7,14 @@ package:
 
 build:
   noarch: python
-  number: 0
+  number: 1
 
 requirements:
   host:
     - python
   run:
     - python
-    - geometric_features 0.1.6
+    - geometric_features 0.1.6 with_data*
     - mpas_tools 0.0.8
     - jigsaw 0.9.12
     - jigsawpy 0.2.1


### PR DESCRIPTION
This makes it much easier to use `geoemtric_features` on LANL IC and other machines where the geometric data cannot be downloaded on the fly.