### PR TITLE
Switch compass env to use nompi variant of netcdf4

### DIFF
--- a/compass/meta.yaml
+++ b/compass/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compass" %}
-{% set version = "0.1.4" %}
+{% set version = "0.1.5" %}
 {% set build = 0 %}
 
 {% if mpi == "nompi" %}
@@ -43,6 +43,7 @@ requirements:
     - ffmpeg
     - {{ mpi }}  # [mpi != 'nompi']
     - esmf * {{ mpi_prefix }}_*
+    - netcdf4 * nompi_*
     - nco
     - pyremap >=0.0.6,<0.1.0
     - rasterio


### PR DESCRIPTION
This seems so prevent us from having to use `mpirun` for any python code that uses netcdf4 while still allowing us to use MPI for ESMF.