### PR TITLE
Update version of pyremap in compass metapackage

### DIFF
--- a/compass/meta.yaml
+++ b/compass/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compass" %}
-{% set version = "0.1.5" %}
+{% set version = "0.1.6" %}
 {% set build = 0 %}
 
 {% if mpi == "nompi" %}
@@ -45,7 +45,7 @@ requirements:
     - esmf * {{ mpi_prefix }}_*
     - netcdf4 * nompi_*
     - nco
-    - pyremap >=0.0.6,<0.1.0
+    - pyremap >=0.0.7,<0.1.0
     - rasterio
     - affine
     - ipython


### PR DESCRIPTION
The new `pyremap` will detect if `esmf` was installed with MPI or not and will either call `ESMF_RegridWeightGen` with `mpirun` or not as appropriate.  See https://github.com/MPAS-Dev/pyremap/pull/16

Update conda package to v0.1.6