### PR TITLE
Add CIME Earth radius

### DIFF
--- a/conda_package/mpas_tools/cime/constants.py
+++ b/conda_package/mpas_tools/cime/constants.py
@@ -1,0 +1,2 @@
+constants = \
+    {'SHR_CONST_REARTH': 6.37122e6}

--- a/conda_package/mpas_tools/tests/test_cime_constants.py
+++ b/conda_package/mpas_tools/tests/test_cime_constants.py
@@ -1,0 +1,47 @@
+from mpas_tools.cime.constants import constants
+import requests
+
+
+def test_cime_constants(e3sm_tag='master'):
+    """
+    Parse relevant constants from CIME
+
+    Parameters
+    ----------
+    e3sm_tag : str, optional
+        The E3SM tag to download CIME constants from
+    """
+
+    resp = requests.get(
+        'https://raw.githubusercontent.com/E3SM-Project/E3SM/{}/cime/src/share'
+        '/util/shr_const_mod.F90'.format(e3sm_tag))
+
+    text = resp.text
+
+    text = text.split('\n')
+
+    for line in text:
+        for constant in constants:
+            if constant in line:
+                print('verifying {}'.format(constant))
+                value = _parse_value(line, constant)
+                assert value == constants[constant]
+
+
+def _parse_value(line, key):
+    line, _ = line.split('!', 1)
+    _, line = line.split('=')
+    if '&' in line:
+        raise ValueError('This parser is too dumb to handle multi-line Fortran')
+
+    line, _ = line.split('_R8')
+
+    try:
+        value = float(line)
+    except ValueError:
+        value = line
+
+    return value
+
+if __name__ == '__main__':
+    test_cime_constants()

--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -45,6 +45,7 @@ requirements:
 test:
   requires:
     - pytest
+    - requests
   source_files:
     - mesh_tools/mesh_conversion_tools/test/Arctic_Ocean.geojson
     - mesh_tools/mesh_conversion_tools/test/mesh.QU.1920km.151026.nc


### PR DESCRIPTION
This is stored in a dictionary of potential CIME constants.

A test has also been added to verify each time the `mpas_tools` package is created (e.g. in Travis CI or on `conda-forge`) that the constants have the expected value by comparing them with the constants from CIME from `E3SM/master`.