### PR TITLE
Update to compass 0.1.7

### DIFF
--- a/compass/meta.yaml
+++ b/compass/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compass" %}
-{% set version = "0.1.6" %}
+{% set version = "0.1.7" %}
 {% set build = 0 %}
 
 {% if mpi == "nompi" %}
@@ -30,7 +30,7 @@ build:
 requirements:
   run:
     - python
-    - geometric_features 0.1.7 with_data*
+    - geometric_features 0.1.9
     - mpas_tools 0.0.10
     - jigsaw 0.9.12
     - jigsawpy 0.2.1


### PR DESCRIPTION
This merge updates the version of `geometric_features` in the `compass` conda metapackage to the latest version.  This is in anticipation of including v0.1.7 of the `compass` package in the next `e3sm-unified`.