### PR TITLE
Add modules for computing transect geometry

### DIFF
--- a/conda_package/docs/api.rst
+++ b/conda_package/docs/api.rst
@@ -178,6 +178,17 @@ Ocean Tools
    inject_preserve_floodplain
 
 
+.. currentmodule:: mpas_tools.ocean.transects
+
+.. autosummary::
+   :toctree: generated/
+
+   find_transect_levels_and_weights
+   interp_mpas_to_transect_triangles
+   interp_mpas_to_transect_triangle_nodes
+   interp_transect_grid_to_transect_triangle_nodes
+   get_outline_segments
+
 Visualization
 =============
 
@@ -194,6 +205,16 @@ Visualization
    :toctree: generated/
 
    mesh_to_triangles
+
+.. currentmodule:: mpas_tools.viz.transects
+
+.. autosummary::
+   :toctree: generated/
+
+   make_triangle_tree
+   find_transect_cells_and_weights
+   subdivide_great_circle
+   cartesian_to_great_circle_distance
 
 
 .. currentmodule:: mpas_tools.viz.colormaps

--- a/conda_package/docs/conf.py
+++ b/conda_package/docs/conf.py
@@ -38,6 +38,8 @@ napoleon_use_rtype = False
 # Otherwise, the Attributes parameter list looks different from the Parameters
 # list
 napoleon_use_ivar = True
+# Make sure multiple variable on the same line show up right
+napoleon_use_param = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/conda_package/mpas_tools/ocean/transects.py
+++ b/conda_package/mpas_tools/ocean/transects.py
@@ -1,0 +1,571 @@
+import xarray
+import numpy
+
+
+def find_transect_levels_and_weights(dsTransect, layerThickness, bottomDepth,
+                                     maxLevelCell, zTransect=None):
+    """
+    Construct a vertical coordinate for a transect produced by
+    ``mpas_tools.viz.transects.find_transect_cells_and_weights()``, then break
+     each resulting quadrilateral into 2 triangles that can later be visualized
+     with functions like ``tripcolor`` and ``tricontourf``.  Also, compute
+     interpolation weights such that observations at points on the original
+     transect and with vertical cooridinate ``transectZ`` can be bilinearly
+     interpolated to the nodes of the transect.
+    Parameters
+    ----------
+    dsTransect : xarray.Dataset
+        A dataset that defines nodes of the transect, the results of calling
+        ``find_transect_cells_and_weights()``
+
+    layerThickness : xarray.DataArray
+        layer thicknesses on the MPAS mesh
+
+    bottomDepth : xarray.DataArray
+        the (positive down) depth of the seafloor on the MPAS mesh
+
+    maxLevelCell : xarray.DataArray
+        the vertical zero-based index of the bathymetry on the MPAS mesh
+
+    zTransect : xarray.DataArray, optional
+        the z coordinate of the transect (1D or 2D).  If 2D, it must have the
+        same along-transect dimension as the lon and lat passed to
+        ``find_transect_cells_and_weights()``
+
+    Returns
+    -------
+    dsTransectTriangles : xarray.Dataset
+        A dataset that contains nodes and triangles that make up a 2D transect.
+        For convenience in visualization, the quadrilaterals of each cell making
+        up the transect have been divided into an upper and lower triangle.  The
+        nodes of the triangles are completely independent of one another,
+        allowing for potential jumps in fields values between nodes of different
+        triangles that are at the same location.  This is convenient, for
+        example, when visualizing data with constant values within each MPAS
+        cell.
+
+        There are ``nTransectTriangles = 2*nTransectCells`` triangles, each with
+        ``nTriangleNodes = 3`` nodes, where ``nTransectCells`` is the number of
+        valid transect cells (quadrilaterals) that are above the MPAS-Ocean
+        bathymetry.
+
+        In addition to the variables and coordinates in ``dsTransect``, the
+        output dataset contains:
+
+            - nodeHorizBoundsIndices: which of the ``nHorizBounds = 2``
+              bounds of a horizontal transect segment a given node is on
+            - segmentIndices: the transect segment of a given triangle
+            - cellIndices: the MPAS-Ocean cell of a given triangle
+            - levelIndices: the MPAS-Ocean vertical level of a given triangle
+
+            - zTransectNode: the vertical height of each triangle node
+            - ssh, zSeaFloor: the sea-surface height and sea-floor height at
+              each node of each transect segment
+
+            - interpCellIndices, interpLevelIndices: the MPAS-Ocean cells and
+              levels from which the value at a given triangle node are
+              interpolated.  This can involve up to `nWeights = 12` different
+              cells and levels.
+            - interpCellWeights: the weight to multiply each field value by
+              to perform interpolation to a triangle node.
+
+            - transectInterpVertIndices, transectInterpVertWeights - if
+              ``zTransect`` is not ``None``, vertical indices and weights for
+              interpolating from the original transect grid to MPAS-Ocean
+              transect nodes.
+
+        Interpolation of a DataArray from MPAS cells and levels to transect
+        triangle nodes can be performed with
+        ``interp_mpas_to_transect_triangle_nodes()``.  Similarly, interpolation of a
+        DataArray (e.g. an observation) from the original transect grid to
+        transect triangle nodes can be performed with
+        ``interp_transect_grid_to_transect_triangle_nodes()``
+
+        To visualize constant values on MPAS cells, a field can be sampled
+        at indices ``nCells=cellIndices`` and ``nVertLevels=levelIndices``.
+        If a smoother visualization is desired, bilinear interpolation can be
+        performed by first sampling the field at indices
+        ``nCells=interpCellIndices`` and ``nVertLevels=interpLevelIndices`` and
+        then multiplying by ``interpCellWeights`` and summing over
+        ``nWeights``.
+    """
+
+    dsTransectCells = _get_transect_cells_and_nodes(
+        dsTransect, layerThickness, bottomDepth, maxLevelCell)
+
+    dsTransectTriangles = _transect_cells_to_triangles(dsTransectCells)
+
+    if zTransect is not None:
+        dsTransectTriangles = _add_vertical_interpolation_of_transect_points(
+            dsTransectTriangles, zTransect)
+
+    return dsTransectTriangles
+
+
+def interp_mpas_to_transect_triangles(dsTransectTriangles, da):
+    """
+    Interpolate a 3D (``nCells`` by ``nVertLevels``) MPAS-Ocean DataArray
+    to transect nodes with constant values in each MPAS cell
+
+    Parameters
+    ----------
+    dsTransectTriangles : xarray.Dataset
+        A dataset that defines triangles making up an MPAS-Ocean transect, the
+        results of calling ``find_transect_levels_and_weights()``
+
+    da : xarray.DataArray
+        An MPAS-Ocean 3D field with dimensions `nCells`` and ``nVertLevels``
+        (possibly among others)
+
+    Returns
+    -------
+    daNodes : xarray.DataArray
+        The data array interpolated to transect nodes with dimensions
+        ``nTransectTriangles`` and ``nTriangleNodes`` (in addition to whatever
+        dimensions were in ``da`` besides ``nCells`` and ``nVertLevels``)
+    """
+
+    cellIndices = dsTransectTriangles.cellIndices
+    levelIndices = dsTransectTriangles.levelIndices
+
+    daNodes = da.isel(nCells=cellIndices, nVertLevels=levelIndices)
+
+    return daNodes
+
+
+def interp_mpas_to_transect_triangle_nodes(dsTransectTriangles, da):
+    """
+    Interpolate a 3D (``nCells`` by ``nVertLevels``) MPAS-Ocean DataArray
+    to transect nodes, linearly interpolating fields between the closest
+    neighboring cells
+
+    Parameters
+    ----------
+    dsTransectTriangles : xarray.Dataset
+        A dataset that defines triangles making up an MPAS-Ocean transect, the
+        results of calling ``find_transect_levels_and_weights()``
+
+    da : xarray.DataArray
+        An MPAS-Ocean 3D field with dimensions `nCells`` and ``nVertLevels``
+        (possibly among others)
+
+    Returns
+    -------
+    daNodes : xarray.DataArray
+        The data array interpolated to transect nodes with dimensions
+        ``nTransectTriangles`` and ``nTriangleNodes`` (in addition to whatever
+        dimensions were in ``da`` besides ``nCells`` and ``nVertLevels``)
+    """
+
+    interpCellIndices = dsTransectTriangles.interpCellIndices
+    interpLevelIndices = dsTransectTriangles.interpLevelIndices
+    interpCellWeights = dsTransectTriangles.interpCellWeights
+
+    da = da.isel(nCells=interpCellIndices, nVertLevels=interpLevelIndices)
+
+    daNodes = (da*interpCellWeights).sum(dim='nWeights')
+
+    return daNodes
+
+
+def interp_transect_grid_to_transect_triangle_nodes(dsTransectTriangles, da):
+    """
+    Interpolate a DataArray on the original transect grid to triangle nodes on
+    the MPAS-Ocean transect.
+
+    Parameters
+    ----------
+    dsTransectTriangles : xarray.Dataset
+        A dataset that defines triangles making up an MPAS-Ocean transect, the
+        results of calling ``find_transect_levels_and_weights()``
+
+    da : xarray.DataArray
+        An field on the original triangle mesh
+
+    Returns
+    -------
+    daNodes : xarray.DataArray
+        The data array interpolated to transect nodes with dimensions
+        ``nTransectTriangles`` and ``nTriangleNodes``
+    """
+
+    horizDim = dsTransectTriangles.dTransect.dims[0]
+    zTransect = dsTransectTriangles.zTransect
+    vertDim = None
+    for dim in zTransect.dims:
+        if dim != horizDim:
+            vertDim = dim
+
+    horizIndices = dsTransectTriangles.transectIndicesOnHorizNode
+    horizWeights = dsTransectTriangles.transectWeightsOnHorizNode
+
+    segmentIndices = dsTransectTriangles.segmentIndices
+    nodeHorizBoundsIndices = dsTransectTriangles.nodeHorizBoundsIndices
+
+    horizIndices = horizIndices.isel(nSegments=segmentIndices,
+                                     nHorizBounds=nodeHorizBoundsIndices)
+    horizWeights = horizWeights.isel(nSegments=segmentIndices,
+                                     nHorizBounds=nodeHorizBoundsIndices)
+
+    vertIndices = dsTransectTriangles.transectInterpVertIndices
+    vertWeights = dsTransectTriangles.transectInterpVertWeights
+
+    kwargs00 = {horizDim: horizIndices, vertDim: vertIndices}
+    kwargs01 = {horizDim: horizIndices, vertDim: vertIndices+1}
+    kwargs10 = {horizDim: horizIndices+1, vertDim: vertIndices}
+    kwargs11 = {horizDim: horizIndices+1, vertDim: vertIndices+1}
+
+    daNodes = (horizWeights * vertWeights * da.isel(**kwargs00) +
+               horizWeights * (1.0 - vertWeights) * da.isel(**kwargs01) +
+               (1.0 - horizWeights) * vertWeights * da.isel(**kwargs10) +
+               (1.0 - horizWeights) * (1.0 - vertWeights) * da.isel(**kwargs11))
+
+
+    mask = numpy.logical_and(horizIndices != -1, vertIndices != -1)
+
+    daNodes = daNodes.where(mask)
+
+    return daNodes
+
+
+def get_outline_segments(dsTransectTriangles):
+    """Get a set of line segments that outline the given transect"""
+
+    dSeaFloor = dsTransectTriangles.dNode.values
+    zSeaFloor = dsTransectTriangles.zSeaFloor.values
+    ssh = dsTransectTriangles.ssh.values
+
+    dJump = numpy.zeros((dSeaFloor.shape[0]-1, 2))
+    zJump = numpy.zeros(dJump.shape)
+    dJump[:, 0] = dSeaFloor[0:-1, 1]
+    dJump[:, 1] = dSeaFloor[1:, 0]
+    zJump[:, 0] = zSeaFloor[0:-1, 1]
+    zJump[:, 1] = zSeaFloor[1:, 0]
+    mask = numpy.abs(dJump[:, 0] - dJump[:, 1]) < 1e-3
+    dJump = dJump[mask, :]
+    zJump = zJump[mask, :]
+
+    d = numpy.append(numpy.append(dSeaFloor, dSeaFloor, axis=0),
+                     dJump, axis=0).T
+    z = numpy.append(numpy.append(ssh, zSeaFloor, axis=0), zJump, axis=0).T
+
+    return d, z
+
+
+def _get_transect_cells_and_nodes(dsTransect, layerThickness, bottomDepth,
+                                  maxLevelCell):
+
+    if 'Time' in layerThickness.dims:
+        raise ValueError('Please select a single time level in layerThickness.')
+
+    dsTransect = dsTransect.rename({'nBounds': 'nHorizBounds'})
+
+    zTop, zMid, zBot, ssh, zSeaFloor, interpCellIndices, interpCellWeights = \
+        _get_vertical_coordinate(dsTransect, layerThickness, bottomDepth,
+                                 maxLevelCell)
+
+    nVertLevels = layerThickness.sizes['nVertLevels']
+
+    levelIndices = xarray.DataArray(data=numpy.arange(2*nVertLevels)//2,
+                                    dims='nHalfLevels')
+
+    cellMask = (levelIndices <= maxLevelCell).transpose('nCells', 'nHalfLevels')
+
+    dsTransectCells = _add_valid_cells_and_levels(
+        dsTransect, dsTransect.cellIndices.values, levelIndices.values,
+        cellMask.values)
+
+    # transect cells are made up of half-levels, and each half-level has a top
+    # and bottom interface, so we need 4 interfaces per MPAS level
+
+    interpCellIndices, interpLevelIndices, interpCellWeights = \
+        _get_interp_indices_and_weights(layerThickness, maxLevelCell,
+                                        interpCellIndices, interpCellWeights)
+
+    levelIndex, tempIndex = numpy.meshgrid(numpy.arange(nVertLevels),
+                                           numpy.arange(2), indexing='ij')
+    levelIndex = xarray.DataArray(data=levelIndex.ravel(), dims='nHalfLevels')
+    tempIndex = xarray.DataArray(data=tempIndex.ravel(), dims='nHalfLevels')
+    zTop = xarray.concat((zTop, zMid), dim='nTemp')
+    zTop = zTop.isel(nVertLevels=levelIndex, nTemp=tempIndex)
+    zBot = xarray.concat((zMid, zBot), dim='nTemp')
+    zBot = zBot.isel(nVertLevels=levelIndex, nTemp=tempIndex)
+
+    zInterface = xarray.concat((zTop, zBot), dim='nVertBounds')
+
+    segmentIndices = dsTransectCells.segmentIndices
+    halfLevelIndices = dsTransectCells.halfLevelIndices
+
+    dsTransectCells['interpCellIndices'] = interpCellIndices.isel(
+        nSegments=segmentIndices, nHalfLevels=halfLevelIndices)
+    dsTransectCells['interpLevelIndices'] = interpLevelIndices.isel(
+        nSegments=segmentIndices, nHalfLevels=halfLevelIndices)
+    dsTransectCells['interpCellWeights'] = interpCellWeights.isel(
+        nSegments=segmentIndices, nHalfLevels=halfLevelIndices)
+    dsTransectCells['zTransectNode'] = zInterface.isel(
+        nSegments=segmentIndices, nHalfLevels=halfLevelIndices)
+
+    dsTransectCells['ssh'] = ssh
+    dsTransectCells['zSeaFloor'] = zSeaFloor
+
+    dims = ['nSegments', 'nTransectCells', 'nHorizBounds', 'nVertBounds',
+            'nHorizWeights', 'nWeights']
+    for dim in dsTransectCells.dims:
+        if dim not in dims:
+            dims.insert(0, dim)
+    dsTransectCells = dsTransectCells.transpose(*dims)
+
+    return dsTransectCells
+
+
+def _get_vertical_coordinate(dsTransect, layerThickness, bottomDepth,
+                             maxLevelCell):
+    nVertLevels = layerThickness.sizes['nVertLevels']
+    levelIndices = xarray.DataArray(data=numpy.arange(nVertLevels),
+                                    dims='nVertLevels')
+    cellMask = (levelIndices <= maxLevelCell).transpose('nCells', 'nVertLevels')
+
+    ssh = -bottomDepth + layerThickness.sum(dim='nVertLevels')
+
+    interpCellIndices = dsTransect.interpHorizCellIndices
+    interpCellWeights = dsTransect.interpHorizCellWeights
+
+    interpMask = numpy.logical_and(interpCellIndices > 0,
+                                   cellMask.isel(nCells=interpCellIndices))
+
+    interpCellWeights = interpMask*interpCellWeights
+    weightSum = interpCellWeights.sum(dim='nHorizWeights')
+
+    cellIndices = dsTransect.cellIndices
+
+    validCells = cellMask.isel(nCells=cellIndices)
+
+    _, validWeights = xarray.broadcast(interpCellWeights, validCells)
+    interpCellWeights = (interpCellWeights/weightSum).where(validWeights)
+
+    layerThicknessTransect = layerThickness.isel(nCells=interpCellIndices)
+    layerThicknessTransect = (layerThicknessTransect*interpCellWeights).sum(
+        dim='nHorizWeights')
+
+    sshTransect = ssh.isel(nCells=interpCellIndices)
+    sshTransect = (sshTransect*dsTransect.interpHorizCellWeights).sum(
+        dim='nHorizWeights')
+
+    zBot = sshTransect - layerThicknessTransect.cumsum(dim='nVertLevels')
+    zTop = zBot + layerThicknessTransect
+    zMid = 0.5*(zTop + zBot)
+
+    zSeaFloor = sshTransect - layerThicknessTransect.sum(dim='nVertLevels')
+
+    return zTop, zMid, zBot, sshTransect, zSeaFloor, interpCellIndices, \
+        interpCellWeights
+
+
+def _add_valid_cells_and_levels(dsTransect, cellIndices, levelIndices,
+                                cellMask):
+
+    dims = ('nTransectCells',)
+    CellIndices, LevelIndices = numpy.meshgrid(cellIndices, levelIndices,
+                                               indexing='ij')
+    mask = numpy.logical_and(CellIndices >= 0, cellMask[cellIndices, :])
+
+    SegmentIndices, HalfLevelIndices = \
+        numpy.meshgrid(numpy.arange(len(cellIndices)),
+                       numpy.arange(len(levelIndices)), indexing='ij')
+
+    segmentIndices = xarray.DataArray(data=SegmentIndices[mask], dims=dims)
+
+    dsTransectCells = dsTransect
+    dsTransectCells['cellIndices'] = (dims, CellIndices[mask])
+    dsTransectCells['levelIndices'] = (dims, LevelIndices[mask])
+    dsTransectCells['segmentIndices'] = segmentIndices
+    dsTransectCells['halfLevelIndices'] = (dims, HalfLevelIndices[mask])
+
+    return dsTransectCells
+
+
+def _get_interp_indices_and_weights(layerThickness, maxLevelCell,
+                                    interpCellIndices, interpCellWeights):
+    interpCellIndices = interpCellIndices.rename({'nHorizWeights': 'nWeights'})
+    interpCellWeights = interpCellWeights.rename({'nHorizWeights': 'nWeights'})
+    nVertLevels = layerThickness.sizes['nVertLevels']
+    nHalfLevels = 2*nVertLevels
+    nVertBounds = 2
+
+    interpMaxLevelCell = maxLevelCell.isel(nCells=interpCellIndices)
+
+    levelIndices = xarray.DataArray(
+        data=numpy.arange(nHalfLevels)//2, dims='nHalfLevels')
+    valid = levelIndices <= interpMaxLevelCell
+
+    topLevelIndices = -1*numpy.ones((nHalfLevels, nVertBounds), int)
+    topLevelIndices[1:, 0] = numpy.arange(nHalfLevels-1)//2
+    topLevelIndices[:, 1] = numpy.arange(nHalfLevels)//2
+    topLevelIndices = xarray.DataArray(
+        data=topLevelIndices, dims=('nHalfLevels', 'nVertBounds'))
+    interpCellIndices, topLevelIndices = \
+        xarray.broadcast(interpCellIndices, topLevelIndices)
+    topLevelIndices = topLevelIndices.where(valid, -1)
+
+    botLevelIndices = numpy.zeros((nHalfLevels, nVertBounds), int)
+    botLevelIndices[:, 0] = numpy.arange(nHalfLevels)//2
+    botLevelIndices[:, 1] = numpy.arange(1, nHalfLevels+1)//2
+    botLevelIndices = xarray.DataArray(
+        data=botLevelIndices, dims=('nHalfLevels', 'nVertBounds'))
+    _, botLevelIndices = xarray.broadcast(interpCellIndices, botLevelIndices)
+    botLevelIndices = botLevelIndices.where(valid, -1)
+    botLevelIndices = numpy.minimum(botLevelIndices, interpMaxLevelCell)
+
+    interpLevelIndices = xarray.concat((topLevelIndices, botLevelIndices),
+                                       dim='nWeights')
+
+    topHalfLevelThickness = 0.5*layerThickness.isel(
+        nCells=interpCellIndices, nVertLevels=topLevelIndices)
+    botHalfLevelThickness = 0.5*layerThickness.isel(
+        nCells=interpCellIndices, nVertLevels=botLevelIndices)
+
+    # vertical weights are proportional to the half-level thickness
+    interpCellWeights = xarray.concat(
+        (topHalfLevelThickness*interpCellWeights.isel(nVertLevels=topLevelIndices),
+         botHalfLevelThickness*interpCellWeights.isel(nVertLevels=botLevelIndices)),
+        dim='nWeights')
+
+    weightSum = interpCellWeights.sum(dim='nWeights')
+    _, outMask = xarray.broadcast(interpCellWeights, weightSum > 0.)
+    interpCellWeights = (interpCellWeights/weightSum).where(outMask)
+
+    interpCellIndices = xarray.concat((interpCellIndices, interpCellIndices),
+                                      dim='nWeights')
+
+    return interpCellIndices, interpLevelIndices, interpCellWeights
+
+
+def _transect_cells_to_triangles(dsTransectCells):
+
+    nTransectCells = dsTransectCells.sizes['nTransectCells']
+    nTransectTriangles = 2*nTransectCells
+    triangleTransectCellIndices = numpy.arange(nTransectTriangles)//2
+    nodeTransectCellIndices = numpy.zeros((nTransectTriangles, 3), int)
+    nodeHorizBoundsIndices = numpy.zeros((nTransectTriangles, 3), int)
+    nodeVertBoundsIndices = numpy.zeros((nTransectTriangles, 3), int)
+
+    for index in range(3):
+        nodeTransectCellIndices[:, index] = triangleTransectCellIndices
+
+    # the upper triangle
+    nodeHorizBoundsIndices[0::2, 0] = 0
+    nodeVertBoundsIndices[0::2, 0] = 0
+    nodeHorizBoundsIndices[0::2, 1] = 1
+    nodeVertBoundsIndices[0::2, 1] = 0
+    nodeHorizBoundsIndices[0::2, 2] = 0
+    nodeVertBoundsIndices[0::2, 2] = 1
+
+    # the lower triangle
+    nodeHorizBoundsIndices[1::2, 0] = 0
+    nodeVertBoundsIndices[1::2, 0] = 1
+    nodeHorizBoundsIndices[1::2, 1] = 1
+    nodeVertBoundsIndices[1::2, 1] = 0
+    nodeHorizBoundsIndices[1::2, 2] = 1
+    nodeVertBoundsIndices[1::2, 2] = 1
+
+    triangleTransectCellIndices = xarray.DataArray(
+        data=triangleTransectCellIndices, dims='nTransectTriangles')
+    nodeTransectCellIndices = xarray.DataArray(
+        data=nodeTransectCellIndices,
+        dims=('nTransectTriangles', 'nTriangleNodes'))
+    nodeHorizBoundsIndices = xarray.DataArray(
+        data=nodeHorizBoundsIndices,
+        dims=('nTransectTriangles', 'nTriangleNodes'))
+    nodeVertBoundsIndices = xarray.DataArray(
+        data=nodeVertBoundsIndices,
+        dims=('nTransectTriangles', 'nTriangleNodes'))
+
+    dsTransectTriangles = xarray.Dataset()
+    dsTransectTriangles['nodeHorizBoundsIndices'] = \
+        nodeHorizBoundsIndices
+    for var_name in dsTransectCells.data_vars:
+        var = dsTransectCells[var_name]
+        if 'nTransectCells' in var.dims:
+            if 'nVertBounds' in var.dims:
+                assert 'nHorizBounds' in var.dims
+                dsTransectTriangles[var_name] = var.isel(
+                    nTransectCells=nodeTransectCellIndices,
+                    nHorizBounds=nodeHorizBoundsIndices,
+                    nVertBounds=nodeVertBoundsIndices)
+            elif 'nHorizBounds' in var.dims:
+                dsTransectTriangles[var_name] = var.isel(
+                    nTransectCells=nodeTransectCellIndices,
+                    nHorizBounds=nodeHorizBoundsIndices)
+            else:
+                dsTransectTriangles[var_name] = var.isel(
+                    nTransectCells=triangleTransectCellIndices)
+        else:
+            dsTransectTriangles[var_name] = var
+
+    dsTransectTriangles = dsTransectTriangles.drop_vars('halfLevelIndices')
+
+    return dsTransectTriangles
+
+
+def _add_vertical_interpolation_of_transect_points(dsTransectTriangles,
+                                                   zTransect):
+
+    dTransect = dsTransectTriangles.dTransect
+    # make sure zTransect is 2D
+    zTransect, _ = xarray.broadcast(zTransect, dTransect)
+
+    assert len(zTransect.dims) == 2
+
+    horizDim = dTransect.dims[0]
+    vertDim = None
+    for dim in zTransect.dims:
+        if dim != horizDim:
+            vertDim = dim
+
+    assert vertDim is not None
+
+    nzTransect = zTransect.sizes[vertDim]
+
+    horizIndices = dsTransectTriangles.transectIndicesOnHorizNode
+    horizWeights = dsTransectTriangles.transectWeightsOnHorizNode
+    kwargs0 = {horizDim: horizIndices}
+    kwargs1 = {horizDim: horizIndices+1}
+    zTransectAtHorizNodes = horizWeights*zTransect.isel(**kwargs0) + \
+                            (1.0 - horizWeights)*zTransect.isel(**kwargs1)
+
+    zTriangleNode = dsTransectTriangles.zTransectNode
+
+    segmentIndices = dsTransectTriangles.segmentIndices
+    nodeHorizBoundsIndices = dsTransectTriangles.nodeHorizBoundsIndices
+
+    nTransectTriangles = dsTransectTriangles.sizes['nTransectTriangles']
+    nTriangleNodes = dsTransectTriangles.sizes['nTriangleNodes']
+    transectInterpVertIndices = -1*numpy.ones(
+        (nTransectTriangles, nTriangleNodes), int)
+    transectInterpVertWeights = numpy.zeros(
+        (nTransectTriangles, nTriangleNodes))
+
+    kwargs = {vertDim: 0, 'nSegments': segmentIndices,
+              'nHorizBounds': nodeHorizBoundsIndices}
+    z0 = zTransectAtHorizNodes.isel(**kwargs)
+    for zIndex in range(nzTransect-1):
+        kwargs = {vertDim: zIndex+1, 'nSegments': segmentIndices,
+                  'nHorizBounds': nodeHorizBoundsIndices}
+        z1 = zTransectAtHorizNodes.isel(**kwargs)
+        mask = numpy.logical_and(zTriangleNode <= z0, zTriangleNode > z1)
+        mask = mask.values
+        weights = (z1 - zTriangleNode)/(z1 - z0)
+
+        transectInterpVertIndices[mask] = zIndex
+        transectInterpVertWeights[mask] = weights.values[mask]
+        z0 = z1
+
+    dsTransectTriangles['transectInterpVertIndices'] = (
+        ('nTransectTriangles', 'nTriangleNodes'), transectInterpVertIndices)
+
+    dsTransectTriangles['transectInterpVertWeights'] = (
+        ('nTransectTriangles', 'nTriangleNodes'), transectInterpVertWeights)
+
+    dsTransectTriangles['zTransect'] = zTransect
+
+    return dsTransectTriangles

--- a/conda_package/mpas_tools/ocean/transects.py
+++ b/conda_package/mpas_tools/ocean/transects.py
@@ -221,7 +221,6 @@ def interp_transect_grid_to_transect_triangle_nodes(dsTransectTriangles, da):
                (1.0 - horizWeights) * vertWeights * da.isel(**kwargs10) +
                (1.0 - horizWeights) * (1.0 - vertWeights) * da.isel(**kwargs11))
 
-
     mask = numpy.logical_and(horizIndices != -1, vertIndices != -1)
 
     daNodes = daNodes.where(mask)
@@ -304,7 +303,7 @@ def _get_transect_cells_and_nodes(dsTransect, layerThickness, bottomDepth,
     cellMask = (levelIndices <= maxLevelCell).transpose('nCells', 'nHalfLevels')
 
     dsTransectCells = _add_valid_cells_and_levels(
-        dsTransect, dsTransect.cellIndices.values, levelIndices.values,
+        dsTransect, dsTransect.horizCellIndices.values, levelIndices.values,
         cellMask.values)
 
     # transect cells are made up of half-levels, and each half-level has a top
@@ -368,7 +367,7 @@ def _get_vertical_coordinate(dsTransect, layerThickness, bottomDepth,
     interpCellWeights = interpMask*interpCellWeights
     weightSum = interpCellWeights.sum(dim='nHorizWeights')
 
-    cellIndices = dsTransect.cellIndices
+    cellIndices = dsTransect.horizCellIndices
 
     validCells = cellMask.isel(nCells=cellIndices)
 

--- a/conda_package/mpas_tools/ocean/transects.py
+++ b/conda_package/mpas_tools/ocean/transects.py
@@ -453,6 +453,8 @@ def _get_interp_indices_and_weights(layerThickness, maxLevelCell,
 
     topHalfLevelThickness = 0.5*layerThickness.isel(
         nCells=interpCellIndices, nVertLevels=topLevelIndices)
+    topHalfLevelThickness = topHalfLevelThickness.where(topLevelIndices >= 0,
+                                                        other=0.)
     botHalfLevelThickness = 0.5*layerThickness.isel(
         nCells=interpCellIndices, nVertLevels=botLevelIndices)
 

--- a/conda_package/mpas_tools/ocean/transects.py
+++ b/conda_package/mpas_tools/ocean/transects.py
@@ -7,11 +7,12 @@ def find_transect_levels_and_weights(dsTransect, layerThickness, bottomDepth,
     """
     Construct a vertical coordinate for a transect produced by
     ``mpas_tools.viz.transects.find_transect_cells_and_weights()``, then break
-     each resulting quadrilateral into 2 triangles that can later be visualized
-     with functions like ``tripcolor`` and ``tricontourf``.  Also, compute
-     interpolation weights such that observations at points on the original
-     transect and with vertical cooridinate ``transectZ`` can be bilinearly
-     interpolated to the nodes of the transect.
+    each resulting quadrilateral into 2 triangles that can later be visualized
+    with functions like ``tripcolor`` and ``tricontourf``.  Also, compute
+    interpolation weights such that observations at points on the original
+    transect and with vertical coordinate ``transectZ`` can be bilinearly
+    interpolated to the nodes of the transect.
+
     Parameters
     ----------
     dsTransect : xarray.Dataset
@@ -64,7 +65,7 @@ def find_transect_levels_and_weights(dsTransect, layerThickness, bottomDepth,
 
             - interpCellIndices, interpLevelIndices: the MPAS-Ocean cells and
               levels from which the value at a given triangle node are
-              interpolated.  This can involve up to `nWeights = 12` different
+              interpolated.  This can involve up to ``nWeights = 12`` different
               cells and levels.
             - interpCellWeights: the weight to multiply each field value by
               to perform interpolation to a triangle node.

--- a/conda_package/mpas_tools/viz/transects.py
+++ b/conda_package/mpas_tools/viz/transects.py
@@ -82,8 +82,8 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
         repeated twice, once for each triangle that node touches.  This allows
         for discontinuous fields between triangles (e.g. if one wishes to plot
         constant values on each MPAS cell).  The Cartesian and lon/lat
-        coordinates of these nodes are ``xCartNode``, ``yCartNode``, `
-        `zCartNode``, ``lonNode`` and ``latNode``.  The distance along the
+        coordinates of these nodes are ``xCartNode``, ``yCartNode``,
+        ``zCartNode``, ``lonNode`` and ``latNode``.  The distance along the
         transect of each intersection is ``dNode``. The index of the triangle
         and the first triangle node in ``dsTris`` associated with each
         intersection node are given by ``horizTriangleIndices`` and
@@ -91,13 +91,13 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
         triangle for the edge associated with the intersection is given by
         ``numpy.mod(horizTriangleNodeIndices + 1, 3)``.
 
-        The MPAS cell tha a given node belongs to is given by ``cellIndices``.
-        Each node also has an associated set of 6 ``interpHorizCellIndices`` and
-        ``interpHorizCellWeights`` that can be used to interpolate from MPAS
-        cell centers to nodes first with area-weighted averaging to MPAS
-        vertices and then linear interpolation along triangle edges.  Some of
-        the weights may be zero, in which case the associated
-        ``interpHorizCellIndices`` will be -1.
+        The MPAS cell that a given node belongs to is given by
+        ``horizCellIndices``. Each node also has an associated set of 6
+        ``interpHorizCellIndices`` and ``interpHorizCellWeights`` that can be
+        used to interpolate from MPAS cell centers to nodes first with
+        area-weighted averaging to MPAS vertices and then linear interpolation
+        along triangle edges.  Some of the weights may be zero, in which case
+        the associated ``interpHorizCellIndices`` will be -1.
 
         Finally, ``lonTransect`` and ``latTransect`` are included in the
         dataset, along with Cartesian coordinates ``xCartTransect``,
@@ -374,7 +374,7 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
                         latOut.reshape((nSegments, nBounds)))
 
     dsOut['horizTriangleIndices'] = ('nSegments', tris)
-    dsOut['cellIndices'] = ('nSegments', cellIndices)
+    dsOut['horizCellIndices'] = ('nSegments', cellIndices)
     dsOut['horizTriangleNodeIndices'] = (('nSegments', 'nBounds'), nodes)
     dsOut['interpHorizCellIndices'] = \
         (('nSegments', 'nBounds', 'nHorizWeights'),
@@ -410,7 +410,7 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
     return dsOut
 
 
-def subdivide_great_circle(x, y, z, maxRes, earthRadius):  # {{{
+def subdivide_great_circle(x, y, z, maxRes, earthRadius):
     """
     Subdivide each segment of the transect so the horizontal resolution
     approximately matches the requested resolution

--- a/conda_package/mpas_tools/viz/transects.py
+++ b/conda_package/mpas_tools/viz/transects.py
@@ -2,6 +2,7 @@ import numpy
 import xarray
 
 from scipy.spatial import cKDTree
+from shapely.geometry import LineString, Point
 
 
 def make_triangle_tree(dsTris):
@@ -255,100 +256,14 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
 
         dTransect[segIndex + 1] = dStart
 
-    # sort nodes by distance
-    sortIndices = numpy.argsort(dNode)
-    dSorted = dNode[sortIndices]
-    trisSorted = tris[sortIndices]
-
     epsilon = 1e-6*subdivisionRes
-    nodesAreSame = numpy.abs(dSorted[1:] - dSorted[:-1]) < epsilon
-    if nodesAreSame[0]:
-        # the first two nodes are the same, so the first transect point is in a
-        # triangle, and we need to figure out which
-        if trisSorted[1] == trisSorted[2] or trisSorted[1] == trisSorted[3]:
-            # the first transect point is in trisSorted[0], so the first two
-            # nodes are in the right order
-            indices = [0, 1]
-        elif trisSorted[0] == trisSorted[2] or trisSorted[0] == trisSorted[3]:
-            # the first transect point is in trisSorted[1], so the first two
-            # nodes need to be swapped
-            indices = [1, 0]
-        else:
-            raise ValueError('Couldn\'t find an order for the first two nodes')
-    else:
-        # the first transect point is outside of an MPAS cell
-        indices = [0]
+    dNode, xOut, yOut, zOut, tris, nodes, interpCells, cellWeights = \
+        _sort_intersections(dNode, tris, nodes, xOut, yOut, zOut, interpCells,
+                            cellWeights, epsilon)
 
-    while len(indices) < len(sortIndices):
-        index = len(indices)
-        currentTri = trisSorted[indices[-1]]
-        if index < len(nodesAreSame) and nodesAreSame[index]:
-            # the next two nodes are the same, so we need to know which
-            # corresponds to the current triangle
-            if trisSorted[index] == currentTri:
-                # the first node is in the current triangle, so add the next
-                # two nodes in the current order
-                indices.extend([index, index+1])
-            elif trisSorted[index+1] == currentTri:
-                # the second node is in the current triangle, so add the next
-                # two nodes in swapped order
-                indices.extend([index+1, index])
-            else:
-                raise ValueError('Couldn\'t find an order for nodes {} and '
-                                 '{}'.format(index, index+1))
-        else:
-            # the next node is a boundary of the MPAS domain, so there is no
-            # ambiguity about order and we just add it
-            indices.extend([index])
-
-    indices = sortIndices[indices]
-
-    dNode = dNode[indices]
-    xOut= xOut[indices]
-    yOut = yOut[indices]
-    zOut = zOut[indices]
-
-    tris = tris[indices]
-    nodes = nodes[indices]
-    interpCells = interpCells[indices, :]
-    cellWeights = cellWeights[indices, :]
-
-    # we need to figure out if the end points of the transect are in a triangle
-    # and add tris, nodes, interpCells and cellWeights if so
-
-    if len(tris) >= 2 and tris[0] != tris[1]:
-        # the starting point is in a triangle so we need to duplicate the first
-        # entry in several fields to handle this
-        tris = numpy.concatenate((tris[0:1], tris))
-        nodes = numpy.concatenate((nodes[0:1], nodes))
-        interpCells = numpy.concatenate((interpCells[0:1, :], interpCells),
-                                        axis=0)
-        cellWeights = numpy.concatenate((cellWeights[0:1, :], cellWeights),
-                                        axis=0)
-
-        dNode = numpy.append(numpy.array([0.]), dNode)
-        xOut = numpy.append(x[0].values, xOut)
-        yOut = numpy.append(y[0].values, yOut)
-        zOut = numpy.append(z[0].values, zOut)
-
-    if len(tris) >= 2 and tris[-1] != tris[-2]:
-        # the end point is in a triangle so we need to add final entries or
-        # duplicate the last entry in several fields to handle this
-        tris = numpy.concatenate((tris, tris[-1:]))
-        nodes = numpy.concatenate((nodes, nodes[-1:]))
-        interpCells = numpy.concatenate((interpCells, interpCells[-1:, :]),
-                                        axis=0)
-        cellWeights = numpy.concatenate((cellWeights, cellWeights[-1:, :]),
-                                        axis=0)
-
-        dNode = numpy.append(dNode, dStart)
-        xOut = numpy.append(xOut, x[-1].values)
-        yOut = numpy.append(yOut, y[-1].values)
-        zOut = numpy.append(zOut, z[-1].values)
-
-    assert(numpy.all(tris[0::2] == tris[1::2]))
-
-    tris = tris[0::2]
+    dNode, xOut, yOut, zOut, tris, nodes, interpCells, cellWeights = \
+        _update_start_end_triangles(tris, nodes, interpCells, cellWeights,
+                                    dNode, xOut, yOut, zOut, dStart, x, y, z)
 
     lonOut, latOut = _cartesian_to_lon_lat(xOut, yOut, zOut, earth_radius,
                                            degrees)
@@ -402,6 +317,287 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
     dsOut['yCartTransect'] = y
     dsOut['zCartTransect'] = z
     dsOut['dTransect'] = (lonTransect.dims, dTransect)
+    dsOut['transectIndicesOnHorizNode'] = (('nSegments', 'nBounds'),
+                                           transectIndicesOnHorizNode)
+    dsOut['transectWeightsOnHorizNode'] = (('nSegments', 'nBounds'),
+                                           transectWeightsOnHorizNode)
+
+    return dsOut
+
+
+def find_planar_transect_cells_and_weights(xTransect, yTransect, dsTris, dsMesh,
+                                           tree, subdivisionRes=10e3):
+    """
+    Find "nodes" where the transect intersects the edges of the triangles
+    that make up MPAS cells.
+
+    Parameters
+    ----------
+    xTransect, yTransect : xarray.DataArray
+        The x and y points defining segments making up the transect
+
+    dsTris : xarray.Dataset
+        A dataset that defines triangles, the results of calling
+        ``mesh_to_triangles()``
+
+    dsMesh : xarray.Dataset
+        A data set with the full MPAS mesh.
+
+    tree : scipy.spatial.cKDTree
+        A tree of edge centers from triangles making up an MPAS mesh, the return
+        value from ``make_triangle_tree()``
+
+    subdivisionRes : float, optional
+        Resolution in m to use to subdivide the transect when looking for
+        intersection candidates.  Should be small enough that curvature is
+        small.
+
+    Returns
+    -------
+    dsOut : xarray.Dataset
+        A dataset that contains "nodes" where the transect intersects the
+        edges of the triangles in ``dsTris``.  The nodes also include the two
+        end points of the transect, which typically lie within triangles. Each
+        internal node (that is, not including the end points) is purposefully
+        repeated twice, once for each triangle that node touches.  This allows
+        for discontinuous fields between triangles (e.g. if one wishes to plot
+        constant values on each MPAS cell).  The planar coordinates of these
+        nodes are ``xNode`` and ``yNode``.  The distance along the transect of
+        each intersection is ``dNode``. The index of the triangle and the first
+        triangle node in ``dsTris`` associated with each intersection node are
+        given by ``horizTriangleIndices`` and ``horizTriangleNodeIndices``,
+        respectively. The second node on the triangle for the edge associated
+        with the intersection is given by
+        ``numpy.mod(horizTriangleNodeIndices + 1, 3)``.
+
+        The MPAS cell that a given node belongs to is given by
+        ``horizCellIndices``. Each node also has an associated set of 6
+        ``interpHorizCellIndices`` and ``interpHorizCellWeights`` that can be
+        used to interpolate from MPAS cell centers to nodes first with
+        area-weighted averaging to MPAS vertices and then linear interpolation
+        along triangle edges.  Some of the weights may be zero, in which case
+        the associated ``interpHorizCellIndices`` will be -1.
+
+        Finally, ``xTransect`` and ``yTransect`` are included in the
+        dataset, along with ``dTransect``, the distance along the transect of
+        each original transect point.  In order to interpolate values (e.g.
+        observations) from the original transect points to the intersection
+        nodes, linear interpolation indices ``transectIndicesOnHorizNode`` and
+        weights ``transectWeightsOnHorizNode`` are provided.  The values at
+        nodes are found by::
+
+          nodeValues = ((transectValues[transectIndicesOnHorizNode] *
+                         transectWeightsOnHorizNode)
+                        + (transectValues[transectIndicesOnHorizNode+1] *
+                           (1.0 - transectWeightsOnHorizNode))
+    """
+    buffer = numpy.maximum(numpy.amax(dsMesh.dvEdge.values),
+                           numpy.amax(dsMesh.dcEdge.values))
+
+    nNodes = dsTris.sizes['nNodes']
+    nodeCellWeights = dsTris.nodeCellWeights.values
+    nodeCellIndices = dsTris.nodeCellIndices.values
+
+    x = xTransect
+    y = yTransect
+
+    xNode = dsTris.xNode.values.ravel()
+    yNode = dsTris.yNode.values.ravel()
+
+    coordNode = numpy.zeros((len(xNode), 2))
+    coordNode[:, 0] = xNode
+    coordNode[:, 1] = yNode
+
+    dTransect = numpy.zeros(xTransect.shape)
+
+    dNode = None
+    xOut = None
+    yOut = None
+    tris = None
+    nodes = None
+    interpCells = None
+    cellWeights = None
+
+    nHorizWeights = 6
+
+    first = True
+
+    dStart = 0.
+    for segIndex in range(len(x)-1):
+
+        subSlice = slice(segIndex, segIndex+2)
+        xSub, ySub, _, _ = subdivide_planar(
+            x[subSlice].values, y[subSlice].values, subdivisionRes)
+
+        startPoint = Point(xTransect[segIndex].values,
+                           yTransect[segIndex].values)
+        endPoint = Point(xTransect[segIndex+1].values,
+                         yTransect[segIndex+1].values)
+
+        segment = LineString([startPoint, endPoint])
+
+        coords = numpy.zeros((len(xSub), 3))
+        coords[:, 0] = xSub
+        coords[:, 1] = ySub
+        radius = buffer + subdivisionRes
+
+        indexList = tree.query_ball_point(x=coords, r=radius)
+
+        uniqueIndices = set()
+        for indices in indexList:
+            uniqueIndices.update(indices)
+
+        startIndices = numpy.array(list(uniqueIndices))
+
+        if len(startIndices) == 0:
+            continue
+
+        trisCand = startIndices//nNodes
+        nextNodeIndex = numpy.mod(startIndices + 1, nNodes)
+        endIndices = nNodes * trisCand + nextNodeIndex
+
+        intersectingNodes = list()
+        trisInter = list()
+        xIntersection = list()
+        yIntersection = list()
+        nodeWeights = list()
+        node0Inter = list()
+        node1Inter = list()
+        distances = list()
+
+        for index in range(len(startIndices)):
+            start = startIndices[index]
+            end = endIndices[index]
+
+            node0 = Point(coordNode[start, 0], coordNode[start, 1])
+            node1 = Point(coordNode[end, 0], coordNode[end, 1])
+
+            edge = LineString([node0, node1])
+            if segment.intersects(edge):
+                intersection = segment.intersection(edge)
+                intersectingNodes.append((node0, node1, start, end, edge))
+
+                if isinstance(intersection, LineString):
+                    raise ValueError('A triangle edge exactly coincides with a '
+                                     'transect segment and I can\'t handle '
+                                     'that case.  Try moving the transect a '
+                                     'tiny bit.')
+                elif not isinstance(intersection, Point):
+                    raise ValueError('Unexpected intersection type {}'.format(
+                        intersection))
+
+                xIntersection.append(intersection.x)
+                yIntersection.append(intersection.y)
+
+                startToIntersection = LineString([startPoint, intersection])
+
+                weight = (LineString([intersection, node1]).length /
+                          LineString([node0, node1]).length)
+
+                nodeWeights.append(weight)
+                node0Inter.append(numpy.mod(start, nNodes))
+                node1Inter.append(numpy.mod(end, nNodes))
+                distances.append(startToIntersection.length)
+                trisInter.append(trisCand[index])
+
+        distances = numpy.array(distances)
+        xIntersection = numpy.array(xIntersection)
+        yIntersection = numpy.array(yIntersection)
+        nodeWeights = numpy.array(nodeWeights)
+        node0Inter = numpy.array(node0Inter)
+        node1Inter = numpy.array(node1Inter)
+        trisInter = numpy.array(trisInter)
+
+        dNodeLocal = dStart + distances
+
+        dStart += segment.length
+
+        weights = numpy.zeros((len(trisInter), nHorizWeights))
+        cellIndices = numpy.zeros((len(trisInter), nHorizWeights), int)
+        for index in range(3):
+            weights[:, index] = (nodeWeights *
+                                 nodeCellWeights[trisInter, node0Inter, index])
+            cellIndices[:, index] = \
+                nodeCellIndices[trisInter, node0Inter, index]
+            weights[:, index+3] = ((1.0 - nodeWeights) *
+                                   nodeCellWeights[trisInter, node1Inter, index])
+            cellIndices[:, index+3] = \
+                nodeCellIndices[trisInter, node1Inter, index]
+
+        if first:
+            xOut = xIntersection
+            yOut = yIntersection
+            dNode = dNodeLocal
+
+            tris = trisInter
+            nodes = node0Inter
+            interpCells = cellIndices
+            cellWeights = weights
+            first = False
+        else:
+            xOut = numpy.append(xOut, xIntersection)
+            yOut = numpy.append(yOut, yIntersection)
+            dNode = numpy.append(dNode, dNodeLocal)
+
+            tris = numpy.concatenate((tris, trisInter))
+            nodes = numpy.concatenate((nodes, node0Inter))
+            interpCells = numpy.concatenate((interpCells, cellIndices), axis=0)
+            cellWeights = numpy.concatenate((cellWeights, weights), axis=0)
+
+        dTransect[segIndex + 1] = dStart
+
+    zOut = numpy.zeros(xOut.shape)
+    z = xarray.zeros_like(x)
+
+    epsilon = 1e-6*subdivisionRes
+    dNode, xOut, yOut, zOut, tris, nodes, interpCells, cellWeights = \
+        _sort_intersections(dNode, tris, nodes, xOut, yOut, zOut, interpCells,
+                            cellWeights, epsilon)
+
+    dNode, xOut, yOut, zOut, tris, nodes, interpCells, cellWeights = \
+        _update_start_end_triangles(tris, nodes, interpCells, cellWeights,
+                                    dNode, xOut, yOut, zOut, dStart, x, y, z)
+
+    nSegments = len(xOut)//2
+    nBounds = 2
+
+    cellIndices = dsTris.triCellIndices.values[tris]
+    nodes = nodes.reshape((nSegments, nBounds))
+    dNode = dNode.reshape((nSegments, nBounds))
+
+    dsOut = xarray.Dataset()
+    dsOut['xNode'] = (('nSegments', 'nBounds'),
+                      xOut.reshape((nSegments, nBounds)))
+    dsOut['yNode'] = (('nSegments', 'nBounds'),
+                      yOut.reshape((nSegments, nBounds)))
+    dsOut['dNode'] = (('nSegments', 'nBounds'), dNode)
+
+    dsOut['horizTriangleIndices'] = ('nSegments', tris)
+    dsOut['horizCellIndices'] = ('nSegments', cellIndices)
+    dsOut['horizTriangleNodeIndices'] = (('nSegments', 'nBounds'), nodes)
+    dsOut['interpHorizCellIndices'] = \
+        (('nSegments', 'nBounds', 'nHorizWeights'),
+         interpCells.reshape((nSegments, nBounds, nHorizWeights)))
+    dsOut['interpHorizCellWeights'] = \
+        (('nSegments', 'nBounds', 'nHorizWeights'),
+         cellWeights.reshape((nSegments, nBounds, nHorizWeights)))
+
+    transectIndicesOnHorizNode = numpy.zeros(dNode.shape, int)
+    transectWeightsOnHorizNode = numpy.zeros(dNode.shape)
+    for segIndex in range(len(dTransect)-1):
+        d0 = dTransect[segIndex]
+        d1 = dTransect[segIndex+1]
+        mask = numpy.logical_and(dNode >= d0, dNode < d1)
+        transectIndicesOnHorizNode[mask] = segIndex
+        transectWeightsOnHorizNode[mask] = (d1 - dNode[mask])/(d1 - d0)
+    # last index will get missed by the mask and needs to be handled as a
+    # special case
+    transectIndicesOnHorizNode[-1, 1] = len(dTransect)-2
+    transectWeightsOnHorizNode[-1, 1] = 0.0
+
+    dsOut['xTransect'] = x
+    dsOut['yTransect'] = y
+    dsOut['dTransect'] = (xTransect.dims, dTransect)
     dsOut['transectIndicesOnHorizNode'] = (('nSegments', 'nBounds'),
                                            transectIndicesOnHorizNode)
     dsOut['transectWeightsOnHorizNode'] = (('nSegments', 'nBounds'),
@@ -510,6 +706,178 @@ def cartesian_to_great_circle_distance(x, y, z, earth_radius):
             earth_radius*_angular_distance(first=transectv0, second=transectv1)
 
     return distance
+
+
+def subdivide_planar(x, y, maxRes):
+    """
+    Subdivide each segment of the transect so the horizontal resolution
+    approximately matches the requested resolution
+
+    Uses a formula for interpolating unit vectors on the sphere from
+    https://en.wikipedia.org/wiki/Slerp
+
+    Parameters
+    ----------
+    x, y: numpy.array
+        The planar coordinates of a transect, where the number of segments
+        is ``len(x) - 1``.  ``x`` and ``y`` are of the same length.
+
+    maxRes : float
+        The maximum allowed spacing in m after subdivision
+
+    Returns
+    -------
+    xOut, yOut : numpy.array
+        The transect subdivided into segments with segment length at most
+        ``maxRes``.  All the points in ``x`` and ``y`` are guaranteed to be
+        included.
+
+    dIn : numpy.array
+        The distance along the transect before subdivision
+
+    dOut : numpy.array
+        The distance along the transect after subdivision
+    """
+
+    dx = numpy.zeros(len(x)-1)
+    for index in range(len(x)-1):
+        start = Point(x[index], y[index])
+        end = Point(x[index+1], y[index+1])
+        segment = LineString([start, end])
+        dx[index] = segment.length
+
+    nSegments = numpy.maximum(
+        (dx / maxRes + 0.5).astype(int), 1)
+
+    dIn = numpy.zeros(x.shape)
+    dIn[1:] = numpy.cumsum(dx)
+
+    frac = []
+    outIndices = []
+    for index in range(len(dIn) - 1):
+        n = nSegments[index]
+        frac.extend(numpy.arange(0, n)/n)
+        outIndices.extend(index*numpy.ones(n, int))
+    frac.append(1.)
+    outIndices.append(len(dIn) - 2)
+
+    frac = numpy.array(frac)
+    outIndices = numpy.array(outIndices)
+
+    xOut = (-frac + 1.)*x[outIndices] + frac*x[outIndices+1]
+    yOut = (-frac + 1.)*y[outIndices] + frac*y[outIndices+1]
+    dOut = (-frac + 1.)*dIn[outIndices] + frac*dIn[outIndices+1]
+
+    return xOut, yOut, dIn, dOut
+
+
+def _sort_intersections(dNode, tris, nodes, xOut, yOut, zOut, interpCells,
+                        cellWeights, epsilon):
+    """ sort nodes by distance """
+
+    sortIndices = numpy.argsort(dNode)
+    dSorted = dNode[sortIndices]
+    trisSorted = tris[sortIndices]
+
+    nodesAreSame = numpy.abs(dSorted[1:] - dSorted[:-1]) < epsilon
+    if nodesAreSame[0]:
+        # the first two nodes are the same, so the first transect point is in a
+        # triangle, and we need to figure out which
+        if trisSorted[1] == trisSorted[2] or trisSorted[1] == trisSorted[3]:
+            # the first transect point is in trisSorted[0], so the first two
+            # nodes are in the right order
+            indices = [0, 1]
+        elif trisSorted[0] == trisSorted[2] or trisSorted[0] == trisSorted[3]:
+            # the first transect point is in trisSorted[1], so the first two
+            # nodes need to be swapped
+            indices = [1, 0]
+        else:
+            raise ValueError('Couldn\'t find an order for the first two nodes')
+    else:
+        # the first transect point is outside of an MPAS cell
+        indices = [0]
+
+    while len(indices) < len(sortIndices):
+        index = len(indices)
+        currentTri = trisSorted[indices[-1]]
+        if index < len(nodesAreSame) and nodesAreSame[index]:
+            # the next two nodes are the same, so we need to know which
+            # corresponds to the current triangle
+            if trisSorted[index] == currentTri:
+                # the first node is in the current triangle, so add the next
+                # two nodes in the current order
+                indices.extend([index, index+1])
+            elif trisSorted[index+1] == currentTri:
+                # the second node is in the current triangle, so add the next
+                # two nodes in swapped order
+                indices.extend([index+1, index])
+            else:
+                print(trisSorted[index:index+2], currentTri)
+                raise ValueError('Couldn\'t find an order for nodes {} and '
+                                 '{}'.format(index, index+1))
+        else:
+            # the next node is a boundary of the MPAS domain, so there is no
+            # ambiguity about order and we just add it
+            indices.extend([index])
+
+    indices = sortIndices[indices]
+
+    dNode = dNode[indices]
+    xOut= xOut[indices]
+    yOut = yOut[indices]
+    zOut = zOut[indices]
+
+    tris = tris[indices]
+    nodes = nodes[indices]
+    interpCells = interpCells[indices, :]
+    cellWeights = cellWeights[indices, :]
+
+    return dNode, xOut, yOut, zOut, tris, nodes, interpCells, cellWeights
+
+
+def _update_start_end_triangles(tris, nodes, interpCells, cellWeights, dNode,
+                                xOut, yOut, zOut, dStart, x, y, z):
+    """
+    figure out if the end points of the transect are in a triangle and add tris,
+    nodes, interpCells and cellWeights if so
+    """
+
+    if len(tris) >= 2 and tris[0] != tris[1]:
+        # the starting point is in a triangle so we need to duplicate the first
+        # entry in several fields to handle this
+        tris = numpy.concatenate((tris[0:1], tris))
+        nodes = numpy.concatenate((nodes[0:1], nodes))
+        interpCells = numpy.concatenate((interpCells[0:1, :], interpCells),
+                                        axis=0)
+        cellWeights = numpy.concatenate((cellWeights[0:1, :], cellWeights),
+                                        axis=0)
+
+        dNode = numpy.append(numpy.array([0.]), dNode)
+        xOut = numpy.append(x[0].values, xOut)
+        yOut = numpy.append(y[0].values, yOut)
+        zOut = numpy.append(z[0].values, zOut)
+
+    if len(tris) >= 2 and tris[-1] != tris[-2]:
+        # the end point is in a triangle so we need to add final entries or
+        # duplicate the last entry in several fields to handle this
+        tris = numpy.concatenate((tris, tris[-1:]))
+        nodes = numpy.concatenate((nodes, nodes[-1:]))
+        interpCells = numpy.concatenate((interpCells, interpCells[-1:, :]),
+                                        axis=0)
+        cellWeights = numpy.concatenate((cellWeights, cellWeights[-1:, :]),
+                                        axis=0)
+
+        dNode = numpy.append(dNode, dStart)
+        xOut = numpy.append(xOut, x[-1].values)
+        yOut = numpy.append(yOut, y[-1].values)
+        zOut = numpy.append(zOut, z[-1].values)
+
+    assert(numpy.all(tris[0::2] == tris[1::2]))
+
+    tris = tris[0::2]
+
+    return dNode, xOut, yOut, zOut, tris, nodes, interpCells, cellWeights
+
 
 
 def _lon_lat_to_cartesian(lon, lat, earth_radius, degrees):

--- a/conda_package/mpas_tools/viz/transects.py
+++ b/conda_package/mpas_tools/viz/transects.py
@@ -1,0 +1,629 @@
+import numpy
+import xarray
+
+from scipy.spatial import cKDTree
+
+
+def make_triangle_tree(dsTris):
+    """
+    Make a KD-Tree for finding triangle edges that are near enough to transect
+    segments that they might intersect
+
+    Parameters
+    ----------
+    dsTris : xarray.Dataset
+        A dataset that defines triangles, the results of calling
+        ``mesh_to_triangles()``
+
+    Returns
+    -------
+    tree : scipy.spatial.cKDTree
+        A tree of edge centers from triangles making up an MPAS mesh
+    """
+
+    nTriangles = dsTris.sizes['nTriangles']
+    nNodes = dsTris.sizes['nNodes']
+    nodeCoords = numpy.zeros((nTriangles*nNodes, 3))
+    nodeCoords[:, 0] = dsTris.xNode.values.ravel()
+    nodeCoords[:, 1] = dsTris.yNode.values.ravel()
+    nodeCoords[:, 2] = dsTris.zNode.values.ravel()
+
+    nextTri, nextNode = numpy.meshgrid(
+        numpy.arange(nTriangles), numpy.mod(numpy.arange(nNodes) + 1, 3),
+        indexing='ij')
+    nextIndices = nNodes*nextTri.ravel() + nextNode.ravel()
+
+    # edge centers are half way between adjacent nodes (ignoring great-circle
+    # distance)
+    edgeCoords = 0.5*(nodeCoords + nodeCoords[nextIndices, :])
+
+    tree = cKDTree(data=edgeCoords, copy_data=True)
+    return tree
+
+
+def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
+                                    tree, degrees=True, subdivisionRes=10e3):
+    """
+    Find edges from the MPAS mesh that intersect the given transect
+
+    Parameters
+    ----------
+    lonTransect, latTransect : xarray.DataArray
+        The latitude and longitude of segments making up the transect
+
+    dsTris : xarray.Dataset
+        A dataset that defines triangles, the results of calling
+        ``mesh_to_triangles()``
+
+    dsMesh : xarray.Dataset
+        A data set with the full MPAS mesh.
+
+    tree : scipy.spatial.cKDTree
+        A tree of edge centers from triangles making up an MPAS mesh, the return
+        value from ``make_triangle_tree()``
+
+    degrees : bool, optional
+        Whether ``lonTransect`` and ``latTransect`` are in degrees (as opposed
+        to radians).
+
+    subdivisionRes : float, optional
+        Resolution in m to use to subdivide the transect when looking for
+        intersection candidates.  Should be small enough that curvature is
+        small.
+
+    Returns
+    -------
+    dsOut : xarray.Dataset
+        A dataset that contains "nodes" where the transect intersects the
+        edges of the triangles in ``dsTris``.  The nodes also includes the two
+        end points of the transect, which typically lie within triangles. Each
+        internal node (that is, not including the end points) is purposefully
+        repeated twice, once for each triangle that node touches.  This allows
+        for discontinuous fields between triangles (e.g. if one wishes to plot
+        constant values on each MPAS cell).  The Cartesian and lon/lat
+        coordinates of these nodes are ``xNode``, ``yNode``, ``zNode``,
+        ``lonNode`` and ``latNode``.  The distance along the transect of each
+        intersection is ``dNode``. The index of the triangle and the first
+        triangle node in ``dsTris`` associated with each intersection node are
+        given by ``triangleIndices`` and ``triangleNodeIndices``, respectively.
+        The second node on the triangle for the edge associated with the
+        intersection is given by ``numpy.mod(triangleNodeIndices + 1, 3)``.
+
+        The MPAS cell tha a given node belongs to is given by ``cellIndices``.
+        Each node also has an associated set of 6 ``interpCellIndices`` and
+        ``interpCellWeights`` that can be used to interpolate from MPAS cell
+        centers to nodes first with area-weighted averaging to MPAS vertices
+        and then linear interpolation along triangle edges.  Some of the weights
+        may be zero, in which case the associated ``interpCellIndices`` will be
+        -1.
+
+        Finally, ``lonTransect`` and ``latTransect`` are included in the
+        dataset, along with Cartesian coordinates ``xTransect``, ``yTransect``,
+        ``zTransect``, and ``dTransect``, the great-circle distance along the
+        transect of each original transect point.  In order to interpolate
+        values (e.g. observations) from the original transect points to the
+        intersection nodes, linear interpolation indices
+        ``transectIndicesOnNode`` and weights ``transectWeightsOnNode`` are
+        provided.  The values at nodes are found by::
+
+          nodeValues = transectValues[transectIndicesOnNode]*transectWeightsOnNode
+          + transectValues[transectIndicesOnNode+1]*(1.0 - transectWeightsOnNode)
+    """
+    earth_radius = dsMesh.attrs['sphere_radius']
+    buffer = numpy.maximum(numpy.amax(dsMesh.dvEdge.values),
+                           numpy.amax(dsMesh.dcEdge.values))
+
+    x, y, z = _lon_lat_to_cartesian(lonTransect, latTransect, earth_radius,
+                                    degrees)
+
+    nTriangles = dsTris.sizes['nTriangles']
+    nNodes = dsTris.sizes['nNodes']
+    nodeCellWeights = dsTris.nodeCellWeights.values
+    nodeCellIndices = dsTris.nodeCellIndices.values
+
+    xNode = dsTris.xNode.values.ravel()
+    yNode = dsTris.yNode.values.ravel()
+    zNode = dsTris.zNode.values.ravel()
+
+    dNode = numpy.array([0.])
+    xOut = x[0].values
+    yOut = y[0].values
+    zOut = z[0].values
+
+    dTransect = numpy.zeros(lonTransect.shape)
+
+    tris = None
+    nodes = None
+    interpCells = None
+    cellWeights = None
+
+    first = True
+
+    dStart = 0.
+    for segIndex in range(len(x)-1):
+        transectv0 = Vector(x[segIndex].values,
+                            y[segIndex].values,
+                            z[segIndex].values)
+        transectv1 = Vector(x[segIndex+1].values,
+                            y[segIndex+1].values,
+                            z[segIndex+1].values)
+
+        subSlice = slice(segIndex, segIndex+2)
+        xSub, ySub, zSub, _, _ = subdivide_great_circle(
+            x[subSlice].values, y[subSlice].values, z[subSlice].values,
+            subdivisionRes, earth_radius)
+
+        coords = numpy.zeros((len(xSub), 3))
+        coords[:, 0] = xSub
+        coords[:, 1] = ySub
+        coords[:, 2] = zSub
+        radius = buffer + subdivisionRes
+
+        indexList = tree.query_ball_point(x=coords, r=radius)
+
+        uniqueIndices = set()
+        for indices in indexList:
+            uniqueIndices.update(indices)
+
+        n0IndicesCand = numpy.array(list(uniqueIndices))
+        trisCand = n0IndicesCand//nNodes
+        nextNodeIndex = numpy.mod(n0IndicesCand + 1, nNodes)
+        n1IndicesCand = nNodes * trisCand + nextNodeIndex
+
+        n0Cand = Vector(xNode[n0IndicesCand],
+                        yNode[n0IndicesCand],
+                        zNode[n0IndicesCand])
+        n1Cand = Vector(xNode[n1IndicesCand],
+                        yNode[n1IndicesCand],
+                        zNode[n1IndicesCand])
+
+        intersect = _intersects(n0Cand, n1Cand, transectv0,
+                                transectv1)
+
+        n0Inter = Vector(n0Cand.x[intersect],
+                         n0Cand.y[intersect],
+                         n0Cand.z[intersect])
+        n1Inter = Vector(n1Cand.x[intersect],
+                         n1Cand.y[intersect],
+                         n1Cand.z[intersect])
+
+        trisInter = trisCand[intersect]
+        n0IndicesInter = n0IndicesCand[intersect]
+        n1IndicesInter = n1IndicesCand[intersect]
+
+        intersections = _intersection(n0Inter, n1Inter, transectv0, transectv1)
+        intersections = Vector(earth_radius*intersections.x,
+                               earth_radius*intersections.y,
+                               earth_radius*intersections.z)
+
+        angularDistance = _angular_distance(first=transectv0,
+                                            second=intersections)
+
+        # compute the average angular distance to all intersections with a given
+        # triangle
+
+        distanceOnEdge = numpy.zeros((nTriangles*nNodes))
+        distanceWeights = numpy.zeros((nTriangles*nNodes))
+        distanceOnEdge[n0IndicesInter] = angularDistance
+        distanceWeights[n0IndicesInter] = 1.0
+
+        distanceOnEdge = distanceOnEdge.reshape(nTriangles, nNodes)
+        distanceWeights = distanceWeights.reshape(nTriangles, nNodes)
+        numer = numpy.sum(distanceOnEdge, axis=1)[trisInter]
+        denom = numpy.sum(distanceWeights, axis=1)[trisInter]
+        meanDistanceOnTriangle = numer/denom
+
+        # compute the angular distance half way between the intersections and
+        # the triangle average of the intersections, which can be used as a
+        # unique "sortingDistance" for intersection
+
+        sortingDistance = 0.5*(angularDistance + meanDistanceOnTriangle)
+
+        # sort intersections by the "sortingDistance"
+        indices = numpy.argsort(sortingDistance)
+        angularDistance = angularDistance[indices]
+        trisInter = trisInter[indices]
+        n0IndicesInter = n0IndicesInter[indices]
+        n1IndicesInter = n1IndicesInter[indices]
+
+        intersections = Vector(intersections.x[indices],
+                               intersections.y[indices],
+                               intersections.z[indices])
+
+        n0Inter = Vector(n0Inter.x[indices],
+                         n0Inter.y[indices],
+                         n0Inter.z[indices])
+
+        n1Inter = Vector(n1Inter.x[indices],
+                         n1Inter.y[indices],
+                         n1Inter.z[indices])
+
+        xOut = numpy.append(xOut, intersections.x)
+        yOut = numpy.append(yOut, intersections.y)
+        zOut = numpy.append(zOut, intersections.z)
+
+        dNode = numpy.append(dNode, dStart + earth_radius*angularDistance)
+
+        dStart += earth_radius*_angular_distance(first=transectv0,
+                                                 second=transectv1)
+
+        node0Inter = numpy.mod(n0IndicesInter, nNodes)
+        node1Inter = numpy.mod(n1IndicesInter, nNodes)
+
+        nodeWeights = (_angular_distance(first=intersections, second=n1Inter) /
+                       _angular_distance(first=n0Inter, second=n1Inter))
+
+        weights = numpy.zeros((len(trisInter), 6))
+        cellIndices = numpy.zeros((len(trisInter), 6), int)
+        for index in range(3):
+            weights[:, index] = (nodeWeights *
+                                 nodeCellWeights[trisInter, node0Inter, index])
+            cellIndices[:, index] = \
+                nodeCellIndices[trisInter, node0Inter, index]
+            weights[:, index+3] = ((1.0 - nodeWeights) *
+                                   nodeCellWeights[trisInter, node1Inter, index])
+            cellIndices[:, index+3] = \
+                nodeCellIndices[trisInter, node1Inter, index]
+
+        if first:
+            tris = trisInter
+            nodes = node0Inter
+            interpCells = cellIndices
+            cellWeights = weights
+            first = False
+        else:
+            tris = numpy.concatenate((tris, trisInter))
+            nodes = numpy.concatenate((nodes, node0Inter))
+            interpCells = numpy.concatenate((interpCells, cellIndices), axis=0)
+            cellWeights = numpy.concatenate((cellWeights, weights), axis=0)
+
+        dTransect[segIndex + 1] = dStart
+
+    # we need to figure out if the end points of the transect are in a triangle
+    # and add tris, nodes, interpCells and cellWeights if so
+
+    if len(tris) > 2 and tris[0] != tris[1]:
+        # the starting point is in a triangle so we need to duplicate the first
+        # entry in several fields to handle this
+        tris = numpy.concatenate((tris[0:1], tris))
+        nodes = numpy.concatenate((nodes[0:1], nodes))
+        interpCells = numpy.concatenate((interpCells[0:1, :], interpCells),
+                                        axis=0)
+        cellWeights = numpy.concatenate((cellWeights[0:1, :], cellWeights),
+                                        axis=0)
+    else:
+        # the starting point isn't in a triangle so we need to remove it from
+        # some fields
+        dNode = dNode[1:]
+        xOut = xOut[1:]
+        yOut = yOut[1:]
+        zOut = zOut[1:]
+
+    if len(tris) > 2 and tris[-1] != tris[-2]:
+        # the end point is in a triangle so we need to add final entries or
+        # duplicate the last entry in several fields to handle this
+        tris = numpy.concatenate((tris, tris[-1:]))
+        nodes = numpy.concatenate((nodes, nodes[-1:]))
+        interpCells = numpy.concatenate((interpCells, interpCells[-1:, :]),
+                                        axis=0)
+        cellWeights = numpy.concatenate((cellWeights, cellWeights[-1:, :]),
+                                        axis=0)
+
+        dNode = numpy.append(dNode, dStart)
+        xOut = numpy.append(xOut, x[-1].values)
+        yOut = numpy.append(yOut, y[-1].values)
+        zOut = numpy.append(zOut, z[-1].values)
+
+    assert(numpy.all(tris[0::2] == tris[1::2]))
+
+    lonOut, latOut = _cartesian_to_lon_lat(xOut, yOut, zOut, earth_radius,
+                                           degrees)
+
+    dsOut = xarray.Dataset()
+    dsOut['xNode'] = ('nNodes', xOut)
+    dsOut['yNode'] = ('nNodes', yOut)
+    dsOut['zNode'] = ('nNodes', zOut)
+    dsOut['dNode'] = ('nNodes', dNode)
+    dsOut['lonNode'] = ('nNodes', lonOut)
+    dsOut['latNode'] = ('nNodes', latOut)
+
+    cellIndices = dsTris.triCellIndices.values[tris]
+
+    dsOut['triangleIndices'] = ('nNodes', tris)
+    dsOut['triangleNodeIndices'] = ('nNodes', nodes)
+    dsOut['cellIndices'] = ('nNodes', cellIndices)
+    dsOut['interpCellIndices'] = (('nNodes', 'nWeights'), interpCells)
+    dsOut['interpCellWeights'] = (('nNodes', 'nWeights'), cellWeights)
+
+    transectIndicesOnNode = numpy.zeros(nodes.shape, int)
+    transectWeightsOnNode = numpy.zeros(nodes.shape)
+    for segIndex in range(len(dTransect)-1):
+        d0 = dTransect[segIndex]
+        d1 = dTransect[segIndex+1]
+        mask = numpy.logical_and(dNode >= d0, dNode < d1)
+        transectIndicesOnNode[mask] = segIndex
+        transectWeightsOnNode[mask] = (d1 - dNode[mask])/(d1 - d0)
+    transectIndicesOnNode[-1] = len(dTransect)-1
+    transectWeightsOnNode[-1] = 0.0
+
+    dsOut['lonTransect'] = lonTransect
+    dsOut['latTransect'] = latTransect
+    dsOut['xTransect'] = x
+    dsOut['yTransect'] = y
+    dsOut['zTransect'] = z
+    dsOut['dTransect'] = (lonTransect.dims, dTransect)
+    dsOut['transectIndicesOnNode'] = ('nNodes', transectIndicesOnNode)
+    dsOut['transectWeightsOnNode'] = ('nNodes', transectWeightsOnNode)
+
+    return dsOut
+
+
+def subdivide_great_circle(x, y, z, maxRes, earthRadius):  # {{{
+    """
+    Subdivide each segment of the transect so the horizontal resolution
+    approximately matches the requested resolution
+
+    Uses a formula for interpolating unit vectors on the sphere from
+    https://en.wikipedia.org/wiki/Slerp
+    Parameters
+    ----------
+    x : numpy.array
+    y : numpy.array
+    z : numpy.array
+        The cartsian coordinates of a transect, where the number of segments
+        is ``len(x) - 1``.  ``x``, ``y`` and ``z`` are of the same length.
+
+    maxRes : float
+        The maximum allowed spacing in m after subdivision
+
+    earthRadius : float
+        The radius of the Earth in m
+
+    Returns
+    -------
+    xOut : numpy.array
+    yOut : numpy.array
+    zOut : numpy.array
+        The transect subdivided into segments with segment length at most
+        ``maxRes``.  All the points in ``x``, ``y`` and ``z`` are guaranteed
+        to be included.
+
+    dIn : numpy.array
+        The distance along the transect before subdivision
+
+    dOut : numpy.array
+        The distance along the transect after subdivision
+
+    """
+
+    angularDistance = _angular_distance(x=x, y=y, z=z)
+
+    dx = angularDistance * earthRadius
+
+    nSegments = numpy.maximum(
+        (dx / maxRes + 0.5).astype(int), 1)
+
+    dIn = numpy.zeros(x.shape)
+    dIn[1:] = numpy.cumsum(dx)
+
+    frac = []
+    outIndices = []
+    delta = []
+    for index in range(len(dIn) - 1):
+        n = nSegments[index]
+        frac.extend(numpy.arange(0, n)/n)
+        outIndices.extend(index*numpy.ones(n, int))
+        delta.extend(angularDistance[index]*numpy.ones(n))
+    frac.append(1.)
+    outIndices.append(len(dIn) - 2)
+    delta.append(angularDistance[-1])
+
+    frac = numpy.array(frac)
+    delta = numpy.array(delta)
+    outIndices = numpy.array(outIndices)
+
+    denom = 1./numpy.sin(delta)
+    a = denom*numpy.sin((1.-frac)*delta)
+    b = denom*numpy.sin(frac*delta)
+
+    xOut = a*x[outIndices] + b*x[outIndices+1]
+    yOut = a*y[outIndices] + b*y[outIndices+1]
+    zOut = a*z[outIndices] + b*z[outIndices+1]
+
+    dOut = (-frac + 1.)*dIn[outIndices] + frac*dIn[outIndices+1]
+
+    return xOut, yOut, zOut, dIn, dOut
+
+
+def cartesian_to_great_circle_distance(x, y, z, earth_radius):
+    """
+    Cartesian transect points to great-circle distance
+
+    Parameters
+    ----------
+    x, y, z : numpy.array
+        Cartesian coordinates along a transect
+
+    earth_radius : float
+        The radius of the earth
+
+    Returns
+    -------
+    distance : numpy.array
+        The distance along the transect
+    """
+    distance = numpy.zeros(x.shape)
+    for segIndex in range(len(x)-1):
+        transectv0 = Vector(x[segIndex], y[segIndex], z[segIndex])
+        transectv1 = Vector(x[segIndex+1], y[segIndex+1], z[segIndex+1])
+
+        distance[segIndex+1] = distance[segIndex] + \
+            earth_radius*_angular_distance(first=transectv0, second=transectv1)
+
+    return distance
+
+
+def _lon_lat_to_cartesian(lon, lat, earth_radius, degrees):
+    """Convert from lon/lat to Cartesian x, y, z"""
+
+    if degrees:
+        lon = numpy.deg2rad(lon)
+        lat = numpy.deg2rad(lat)
+    x = earth_radius * numpy.cos(lat) * numpy.cos(lon)
+    y = earth_radius * numpy.cos(lat) * numpy.sin(lon)
+    z = earth_radius * numpy.sin(lat)
+    return x, y, z
+
+
+def _cartesian_to_lon_lat(x, y, z, earth_radius, degrees):
+    """Convert from  Cartesian x, y, z to lon/lat"""
+    lon = numpy.arctan2(y, x)
+    lat = numpy.arcsin(z/earth_radius)
+    if degrees:
+        lon = numpy.rad2deg(lon)
+        lat = numpy.rad2deg(lat)
+    return lon, lat
+
+
+def _angular_distance(x=None, y=None, z=None, first=None, second=None):
+    """
+    Compute angular distance between points on the sphere, following:
+    https://en.wikipedia.org/wiki/Great-circle_distance
+
+    Parameters
+    ----------
+    x, y, z : numpy.array, optional
+        The cartsian coordinates of a transect, where the number of segments
+        is ``len(x) - 1``.  ``x``, ``y`` and ``z`` are of the same length and
+        all must be present if ``first`` and ``second`` are not provided.
+
+    first, second : Vector
+        The start and end points of each segment of the transect, where the
+        ``x``, ``y``, and ``z`` attributes of each vector are ``numpy.array``
+        objects.
+
+    Returns
+    -------
+    angularDistance : numpy.array
+        The angular distance (in radians) between segments of the transect.
+    """
+    if first is None or second is None:
+        first = Vector(x[0:-1], y[0:-1], z[0:-1])
+        second = Vector(x[1:], y[1:], z[1:])
+
+    angularDistance = numpy.arctan2(_mag(_cross(first, second)),
+                                    _dot(first, second))
+
+    return angularDistance
+
+
+def _intersects(a1, a2, b1, b2):
+    """
+    Based on https://stackoverflow.com/a/26669130/7728169
+    Determine if the great circle arc from ``a1`` to ``a2`` intersects that
+    from ``b1`` to ``b2``.
+
+    Parameters
+    ----------
+    a1, a2, b1, b2 : Vector
+        Cartesian coordinates of the end points of two great circle arcs.
+        The types of the attributes ``x``, ``y``, and ``z`` must either be
+        ``numpy.arrays`` of identical size for all 4 vectors (in which case
+        intersections are found element-wise), or scalars for
+        at least one of either the ``a``s or the ``b``s.
+
+    Returns
+    -------
+    intersect : numpy.array
+        A boolean array of the same size as the ``a``s or the ``b``s, whichever
+        is greater, indicating if the particular pair of arcs intersects
+    """
+    return numpy.logical_and(_straddles(a1, a2, b1, b2),
+                             _straddles(b1, b2, a1, a2))
+
+
+def _intersection(a1, a2, b1, b2):
+    """
+    Based on https://stackoverflow.com/a/26669130/7728169
+    Find the intersection point between great circle arc from ``a1`` to ``a2``
+    and from ``b1`` to ``b2``.  The arcs should have already have been found
+    to intersect by calling ``_intersects()``
+
+    Parameters
+    ----------
+    a1, a2, b1, b2 : Vector
+        Cartesian coordinates of the end points of two great circle arcs.
+        The types of the attributes ``x``, ``y``, and ``z`` must either be
+        ``numpy.arrays`` of identical size for all 4 vectors (in which case
+        intersections are found element-wise), or scalars for
+        at least one of either the ``a``s or the ``b``s.
+
+    Returns
+    -------
+    points : Vector
+        An array of Cartesian points *on the unit sphere* indicating where the
+        arcs intersect
+    """
+    points = _cross(_cross(a1, a2), _cross(b1, b2))
+    s = numpy.sign(_det(a1, b1, b2))/_mag(points)
+    points = Vector(s*points.x,  s*points.y, s*points.z)
+    return points
+
+
+def _straddles(a1, a2, b1, b2):
+    """
+    Based on https://stackoverflow.com/a/26669130/7728169
+    Determines if the great circle segment determined by (a1, a2)
+    straddles the great circle determined by (b1, b2)
+
+    Parameters
+    ----------
+    a1, a2, b1, b2 : Vector
+        Cartesian coordinates of the end points of two great circle arcs.
+        The types of the attributes ``x``, ``y``, and ``z`` must either be
+        ``numpy.arrays`` of identical size for all 4 vectors (in which case
+        intersections are found element-wise), or scalars for
+        at least one of either the ``a``s or the ``b``s.
+
+    Returns
+    -------
+    straddle : numpy.array
+        A boolean array of the same size as the ``a``s or the ``b``s, whichever
+        is greater, indicating if the great circle segment determined by
+        (a1, a2) straddles the great circle determined by (b1, b2)
+    """
+    return _det(a1, b1, b2) * _det(a2, b1, b2) < 0
+
+
+class Vector:
+    """
+    A class for representing Cartesian vectors with ``x``, ``y`` and ``z``
+    components that are either ``float`` or ``numpy.array`` objects of identical
+    size.
+    """
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+def _dot(v1, v2):
+    """The dot product between two ``Vector`` objects ``v1`` and ``v2``"""
+    return v1.x * v2.x + v1.y * v2.y + v1.z * v2.z
+
+
+def _cross(v1, v2):
+    """The cross product between two ``Vector`` objects ``v1`` and ``v2``"""
+    return Vector(v1.y * v2.z - v1.z * v2.y,
+                  v1.z * v2.x - v1.x * v2.z,
+                  v1.x * v2.y - v1.y * v2.x)
+
+
+def _det(v1, v2, v3):
+    """The determinant of the matrix defined by the three ``Vector`` objects"""
+    return _dot(v1, _cross(v2, v3))
+
+
+def _mag(v):
+    """The magnitude of the ``Vector`` object ``v``"""
+    return numpy.sqrt(_dot(v, v))

--- a/conda_package/mpas_tools/viz/transects.py
+++ b/conda_package/mpas_tools/viz/transects.py
@@ -392,12 +392,11 @@ def subdivide_great_circle(x, y, z, maxRes, earthRadius):  # {{{
 
     Uses a formula for interpolating unit vectors on the sphere from
     https://en.wikipedia.org/wiki/Slerp
+
     Parameters
     ----------
-    x : numpy.array
-    y : numpy.array
-    z : numpy.array
-        The cartsian coordinates of a transect, where the number of segments
+    x, y, z : numpy.array
+        The Cartesian coordinates of a transect, where the number of segments
         is ``len(x) - 1``.  ``x``, ``y`` and ``z`` are of the same length.
 
     maxRes : float
@@ -408,9 +407,7 @@ def subdivide_great_circle(x, y, z, maxRes, earthRadius):  # {{{
 
     Returns
     -------
-    xOut : numpy.array
-    yOut : numpy.array
-    zOut : numpy.array
+    xOut, yOut, zOut : numpy.array
         The transect subdivided into segments with segment length at most
         ``maxRes``.  All the points in ``x``, ``y`` and ``z`` are guaranteed
         to be included.

--- a/conda_package/mpas_tools/viz/transects.py
+++ b/conda_package/mpas_tools/viz/transects.py
@@ -172,6 +172,10 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
             uniqueIndices.update(indices)
 
         n0IndicesCand = numpy.array(list(uniqueIndices))
+
+        if len(n0IndicesCand) == 0:
+            continue
+
         trisCand = n0IndicesCand//nNodes
         nextNodeIndex = numpy.mod(n0IndicesCand + 1, nNodes)
         n1IndicesCand = nNodes * trisCand + nextNodeIndex

--- a/conda_package/mpas_tools/viz/transects.py
+++ b/conda_package/mpas_tools/viz/transects.py
@@ -121,7 +121,6 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
     x, y, z = _lon_lat_to_cartesian(lonTransect, latTransect, earth_radius,
                                     degrees)
 
-    nTriangles = dsTris.sizes['nTriangles']
     nNodes = dsTris.sizes['nNodes']
     nodeCellWeights = dsTris.nodeCellWeights.values
     nodeCellIndices = dsTris.nodeCellIndices.values
@@ -283,7 +282,7 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
     while len(indices) < len(sortIndices):
         index = len(indices)
         currentTri = trisSorted[indices[-1]]
-        if nodesAreSame[index]:
+        if index < len(nodesAreSame) and nodesAreSame[index]:
             # the next two nodes are the same, so we need to know which
             # corresponds to the current triangle
             if trisSorted[index] == currentTri:


### PR DESCRIPTION
This work builds on the triangle mesh produced for MPAS meshes in #319.  

1. For a general MPAS mesh, the intersections of a transect defined by a series of lon/lat points with the edges of triangles making up an MPAS cell can be computed.  
2. For the ocean, a vertical coordinate is computed for intersection points and cells below the bathymetry are culled.  quadrilaterals are then divided into triangles, allowing for visualization with `tripcolor` or `tricontourf`.