### PR TITLE
Fix paraview extractor and macros to be compatible with Paraview 5.8.0

### DIFF
--- a/conda_package/mpas_tools/viz/paraview_extractor.py
+++ b/conda_package/mpas_tools/viz/paraview_extractor.py
@@ -1565,7 +1565,7 @@ def build_cell_geom_lists(nc_file, output_32bit, lonlat):  # {{{
                                                           nc_file.x_period,
                                                           nc_file.y_period)
 
-    connectivity = verticesOnCell[validVertices]
+    connectivity = numpy.array(verticesOnCell[validVertices], int)
     offsets = numpy.cumsum(nEdgesOnCell, dtype=int)
     valid_mask = numpy.ones(nCells, bool)
 

--- a/conda_package/mpas_tools/viz/paraview_extractor.py
+++ b/conda_package/mpas_tools/viz/paraview_extractor.py
@@ -1328,8 +1328,7 @@ def write_vtp_header(path, prefix, active_var_index, var_indices,
 
     if cellData:
         vtkFile.openData(str("Cell"),
-                         scalars=[str(var) for var in
-                                  variable_list[active_var_index]])
+                         scalars=variable_list[active_var_index])
         for iVar in var_indices:
             var_name = variable_list[iVar]
             (out_var_names, dim_list) = \
@@ -1339,8 +1338,7 @@ def write_vtp_header(path, prefix, active_var_index, var_indices,
         vtkFile.closeData(str("Cell"))
     if pointData:
         vtkFile.openData(str("Point"),
-                         scalars=[str(var) for var in
-                                  variable_list[active_var_index]])
+                         scalars=variable_list[active_var_index])
         for iVar in var_indices:
             var_name = variable_list[iVar]
             (out_var_names, dim_list) = \

--- a/visualization/paraview_vtk_field_extractor/annotate_date.py
+++ b/visualization/paraview_vtk_field_extractor/annotate_date.py
@@ -53,7 +53,7 @@ programmableFilter1.PythonPath = ''
 
 # create a new 'Python Annotation'
 pythonAnnotation1 = paraview.simple.PythonAnnotation(Input=programmableFilter1)
-pythonAnnotation1.ArrayAssociation = 'Row Data'
+pythonAnnotation1.ArrayAssociation = 'Field Data'
 pythonAnnotation1.Expression = \
     '"{}".format(input.RowData["datetime"].GetValue(0))'
 


### PR DESCRIPTION
First, makes sure that connectivity is a 64-bit integer (was 32-bit because this is how it is stored in MPAS meshes).

Second, fixes the text in the "active" field for cell and point data.

Also fixes the date annotation macro, since this is also a Paraview 5.8.0 issue.

closes #325 
closes #327 