### PR TITLE
exo to nc conversion: fix beta extrapolation

### DIFF
--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -52,7 +52,7 @@ from exodus import exodus
 # Map and copy Exodus data to MPAS data
 
 # Create dictionary of variables that are supported by the script
-mpas_exodus_var_dic = {"beta":"basal_friction", "thickness":"ice_thickness",\
+mpas_exodus_var_dic = {"beta":"basal_friction_log", "thickness":"ice_thickness",\
                        "stiffnessFactor":"stiffening_factor", \
                        "basalTemperature":"temperature", \
                        "surfaceTemperature":"temperature", \
@@ -201,7 +201,7 @@ for var_name in var_names:
             temperatureInterpolant = interp1d(albany_layers, albanyTemperature, axis=1)
             dataset.variables["temperature"][0,:,:] = temperatureInterpolant(MPAS_layers)
             print('\nTemperature interpolation complete')
-        
+
         # Extrapolate and smooth beta and stiffnessFactor fields
         if var_name in ["beta", "stiffnessFactor"]:
             # Extrapolation

--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -115,16 +115,13 @@ else:
 for var_name in var_names:
     #set appropriate methods for smoothing and extrapolation
     if var_name == "beta":
-        smooth_iter_num = 3
-        mask_scheme = "grd"
+        smooth_iter_num = 0
         extrapolation = "min"
     elif var_name == "stiffnessFactor":
         smooth_iter_num = 3
-        mask_scheme = "all"
         extrapolation = "idw"
     else:
         smooth_iter_num = 0
-        mask_scheme = "all"
         extrapolation = None
 
     if mpas_exodus_var_dic[var_name] in exo.get_node_variable_names() and var_name in dataset.variables.keys():
@@ -220,10 +217,11 @@ for var_name in var_names:
 
             keepCellMask = np.zeros((nCells,), dtype=np.int8)
 
-            if mask_scheme == 'grd':
-                keepCellMask[(thickness*ice_density/ocean_density + bedrock > 0.0) * (thickness>0.0)] = 1
+            # Define region of good data to extrapolate from.  Different methods for different variables
+            if var_name == "beta":
+                keepCellMask[varValue > 0.0] = 1
             # find the mask for grounded ice region
-            elif mask_scheme == 'all':
+            else:
                 keepCellMask[thickness > 0.0] = 1
 
             keepCellMaskNew = np.copy(keepCellMask)  # make a copy to edit that will be used later


### PR DESCRIPTION
The old method for extrapolating beta used the grounded ice extent as
the source region for extrapolation.  However, Albany optimization
includes one extended cell beyond that, which was getting clobbered by
the extrapolation step.  This commit fixes that by defining the source
region as the cells that have beta>0 in the exodus file (i.e., keep any
locations where the optimization returned a beta value and extrapolate
out from there.)

This commit also disables the smoothing of the beta extrapolation, which
seems to provide hit or miss results.