### PR TITLE
Update hdf5 version to match conda-forge

### DIFF
--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
   host:
     - python
     - netcdf4
-    - hdf5
-    - libnetcdf
+    - hdf5 * nompi_*
+    - libnetcdf * nompi_*
     - setuptools
     - netcdf4
     - openmp  # [osx]

--- a/conda_package/travis_ci/linux_python3.6.yaml
+++ b/conda_package/travis_ci/linux_python3.6.yaml
@@ -9,7 +9,7 @@ cxx_compiler_version:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 libnetcdf:
 - 4.7.4
 pin_run_as_build:

--- a/conda_package/travis_ci/linux_python3.7.yaml
+++ b/conda_package/travis_ci/linux_python3.7.yaml
@@ -9,7 +9,7 @@ cxx_compiler_version:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 libnetcdf:
 - 4.7.4
 pin_run_as_build:

--- a/conda_package/travis_ci/linux_python3.8.yaml
+++ b/conda_package/travis_ci/linux_python3.8.yaml
@@ -9,7 +9,7 @@ cxx_compiler_version:
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:
-- 1.10.5
+- 1.10.6
 libnetcdf:
 - 4.7.4
 pin_run_as_build:


### PR DESCRIPTION
Pin the build `hdf5` and `libnetcdf` libraries to the no-MPI versions. The user can still choose to install `mpas_tools` in an environment with the MPI libraries later on.