### PR TITLE
Switch mesh_spec attribute from double to string in MPAS cell culler

### DIFF
--- a/mesh_tools/mesh_conversion_tools/mpas_cell_culler.cpp
+++ b/mesh_tools/mesh_conversion_tools/mpas_cell_culler.cpp
@@ -25,7 +25,7 @@ double sphere_radius, xPeriod, yPeriod;
 string in_history = "";
 string in_file_id = "";
 string in_parent_id = "";
-double in_mesh_spec = 1.0;
+string in_mesh_spec = "1.0";
 bool outputMap = false;
 
 // Connectivity and location information {{{
@@ -728,7 +728,7 @@ int outputGridAttributes( const string inputFilename, const string outputFilenam
 	id_str = gen_random(ID_LEN);
 
 	if (!(history = grid.add_att(   "history", history_str.c_str() ))) return NC_ERR;
-	if (!(spec = grid.add_att(   "mesh_spec", in_mesh_spec ))) return NC_ERR;
+	if (!(spec = grid.add_att(   "mesh_spec", in_mesh_spec.c_str() ))) return NC_ERR;
 	if (!(conventions = grid.add_att(   "Conventions", "MPAS" ))) return NC_ERR;
 	if (!(source = grid.add_att(   "source", "MpasCellCuller.x" ))) return NC_ERR;
 	if (!(id = grid.add_att(   "file_id", id_str.c_str() ))) return NC_ERR;

--- a/mesh_tools/mesh_conversion_tools/netcdf_utils.cpp
+++ b/mesh_tools/mesh_conversion_tools/netcdf_utils.cpp
@@ -699,7 +699,7 @@ string netcdf_mpas_read_parentid(string filename){/*{{{*/
 
 }/*}}}*/
 //****************************************************************************80
-double netcdf_mpas_read_meshspec(string filename){/*{{{*/
+string netcdf_mpas_read_meshspec(string filename){/*{{{*/
 	//****************************************************************************80
 	//
 	//  Purpose:
@@ -712,11 +712,11 @@ double netcdf_mpas_read_meshspec(string filename){/*{{{*/
 	//
 	//  Modified:
 	//
-	//    18 February 2014
+	//    23 September 2020
 	//
 	//  Author:
 	//
-	//    Doug Jacobsen
+	//    Doug Jacobsen, Xylar Asay-Davis
 	//
 	//  Reference:
 	//
@@ -728,13 +728,14 @@ double netcdf_mpas_read_meshspec(string filename){/*{{{*/
 	//
 	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
 	//
-	//    Output, double NETCDF_MPAS_READ_MESHSPEC, the value of the mesh_spec attribute
+	//    Output, string NETCDF_MPAS_READ_MESHSPEC, the value of the mesh_spec attribute
 	//
 	NcAtt *att_id;
 	NcValues *vals;
 	bool valid;
 	string tmp_name;
 	string sph_name = "mesh_spec";
+	string mesh_spec_str = "";
 	//
 	//  Open the file.
 	//
@@ -764,17 +765,18 @@ double netcdf_mpas_read_meshspec(string filename){/*{{{*/
 		sph_name = "YES             ";
 
 		for(int i = 0; i < vals -> num(); i++){
-			return vals -> as_double(i);
+			mesh_spec_str += vals -> as_string(i);
+			return mesh_spec_str;
 		}
 	} else {
-		return 0.0;
+		return mesh_spec_str;
 	}
 	//
 	//  Close the file.
 	//
 	ncid.close ( );
 
-	return 0.0;
+	return mesh_spec_str;
 
 }/*}}}*/
 /*}}}*/

--- a/mesh_tools/mesh_conversion_tools/netcdf_utils.h
+++ b/mesh_tools/mesh_conversion_tools/netcdf_utils.h
@@ -14,7 +14,7 @@ double netcdf_mpas_read_yperiod(string filename);
 string netcdf_mpas_read_history(string filename);
 string netcdf_mpas_read_fileid(string filename);
 string netcdf_mpas_read_parentid(string filename);
-double netcdf_mpas_read_meshspec(string filename);
+string netcdf_mpas_read_meshspec(string filename);
 /*}}}*/
 
 /* Dimension reading functions {{{*/


### PR DESCRIPTION
The `mesh_spec` is stored as a string in other tools, and this is what the MPAS components expect.  Only the cell culler and the supporting utilities had it (incorrectly) as a double, and these are fixed in this merge.

closed #350 