### PR TITLE
Fixes to acme_namelist_file_generator

### DIFF
--- a/source_code_processing/e3sm_namelist_file_generator/generate_e3sm_namelist_files.py
+++ b/source_code_processing/e3sm_namelist_file_generator/generate_e3sm_namelist_files.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 """
-This script can be used to autogenerate some of the files used by ACME/CESM to
+This script can be used to autogenerate some of the files used by E3SM/CESM to
 define namelist options for each component.  These files are:
 
 * models/<COMPONENT>/bld/build-namelist:
-  This perl script builds the namelist that ACME uses for the component.
+  This perl script builds the namelist that E3SM uses for the component.
   It creates the default namelist that the component will use by a hardcoded
   list of namelist options that should be included.
   It uses the namelist_definition_*.xml file to validate the data type of
@@ -17,7 +17,7 @@ define namelist options for each component.  These files are:
 
 * models/<COMPONENT>/bld/namelist-files/namelist_defaults_<MODEL>.xml:
   This xml file defines the default value for each namelist option defined in
-  namelist_definition_*.xml.  The default values defined here for ACME could differ
+  namelist_definition_*.xml.  The default values defined here for E3SM could differ
   from the defaults used in standalone MPAS.
 
 This script requires a processed registry file from a compiled instance of MPAS
@@ -38,12 +38,13 @@ Optionally, a pre-existing namelist_defaults_*.xml file can be specified.  If it
 there will be warnings to the screen and lines written to the newly generated
 namelist_default_*.xml file that is output indicating where the values in the
 pre-existing namelist_defaults file differ from those in the MPAS Registry file.
-This is useful when the defaults used for ACME differ from those used in standalone
-MPAS, and the ACME defaults should be preserved.  This information alerts the operator
+This is useful when the defaults used for E3SM differ from those used in standalone
+MPAS, and the E3SM defaults should be preserved.  This information alerts the operator
 to these diferences and allows the conflicts to be manually resolved.
 
 """
 
+from __future__ import print_function
 import collections
 import argparse
 import xml.etree.ElementTree as ET
@@ -148,13 +149,13 @@ def write_definition_file(registry):#{{{
 	# Write definitions footer
 	definitions.write('</namelist_definition>\n')
 	definitions.close()
-	print "=== Complete.\n"
+	print("=== Complete.\n")
 
 #}}}
 
 def write_defaults_file(registry, defaults_tree, use_defaults):#{{{
 	nl_defaults_filename = "namelist_defaults.xml"
-	print "=== Writing namelist defaults to: " + nl_defaults_filename
+	print("=== Writing namelist defaults to: " + nl_defaults_filename)
 	defaults = open(nl_defaults_filename, 'w+')
 
 	# Write defaults header#{{{
@@ -177,7 +178,7 @@ def write_defaults_file(registry, defaults_tree, use_defaults):#{{{
 				wrote_opt = False
 				for nml_defaults in defaults_tree.iter("namelist_defaults"):
 					for def_option in nml_defaults.iter("%s"%(option_name.strip())):
- 						if ( not len(def_option.attrib) == 0 ):
+						if ( not len(def_option.attrib) == 0 ):
 							defaults.write("<%s"%(option_name))
 							for key, val in def_option.attrib.items():
 								defaults.write(" %s=\"%s\""%(key.strip(), val.strip()))
@@ -185,9 +186,9 @@ def write_defaults_file(registry, defaults_tree, use_defaults):#{{{
 							wrote_opt = True
 						elif len(def_option.attrib) == 0:
 							if not option_default_value.strip() == def_option.text.strip().strip("'"):
-								print "  Default values don't match for option: %s"%(option_name.strip())
-								print "    Values are: Reg (%s) Def (%s)"%(option_default_value.strip(), def_option.text.strip())
-								print "    Writing both. Clean up manually..."
+								print("  Default values don't match for option: %s"%(option_name.strip()))
+								print("    Values are: Reg (%s) Def (%s)"%(option_default_value.strip(), def_option.text.strip()))
+								print("    Writing both. Clean up manually...")
 
 								if option_type == 'character':
 									defaults.write("<<<<<<<<< FROM REGISTRY\n")
@@ -220,13 +221,13 @@ def write_defaults_file(registry, defaults_tree, use_defaults):#{{{
 	defaults.write('\n')
 	defaults.write('</namelist_defaults>\n')
 	defaults.close()
-	print "=== Complete.\n"
+	print("=== Complete.\n")
 
 #}}}
 
 def write_build_namelist_section(registry):#{{{
 	bld_nl_sec_filename = "build-namelist-section-new"
-	print "=== Writing section of the 'build-namelist' file that writes a list of namelist options to: " + bld_nl_sec_filename
+	print("=== Writing section of the 'build-namelist' file that writes a list of namelist options to: " + bld_nl_sec_filename)
 	build_nml = open(bld_nl_sec_filename, 'w+')
 
 	group_list = open('build-namelist-group-list', 'w+')
@@ -262,8 +263,8 @@ def write_build_namelist_section(registry):#{{{
 	group_list.write(');\n')
 	group_list.close()
 	build_nml.close()
-	print "   NOTE: You should ensure the build-namelist generated has the correct syntax. Some options need additional logic this script is not capable of generating."
-	print "=== Complete.\n"
+	print("   NOTE: You should ensure the build-namelist generated has the correct syntax. Some options need additional logic this script is not capable of generating.")
+	print("=== Complete.\n")
 #}}}
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
@@ -284,12 +285,14 @@ try:
 	registry_tree = ET.parse(args.registry)
 except:
 	parser.error('%s does not exist or is not parsable. Exiting.\nSometimes blank lines at the beginning of the file break the parser.'%args.registry)
+        raise
 
 if use_defaults:
 	try:
 		defaults_tree = ET.parse(args.defaults)
 	except:
 		parser.error('%s does not exist or is not parsable. Exiting.\nSometimes blank lines at the beginning of the file break the parser.'%args.defaults)
+                raise
 
 	defaults = defaults_tree.getroot()
 else:
@@ -300,4 +303,3 @@ registry = registry_tree.getroot()
 write_definition_file(registry)
 write_defaults_file(registry, defaults, use_defaults)
 write_build_namelist_section(registry)
-

--- a/source_code_processing/e3sm_namelist_file_generator/generate_e3sm_namelist_files.py
+++ b/source_code_processing/e3sm_namelist_file_generator/generate_e3sm_namelist_files.py
@@ -51,7 +51,7 @@ import xml.etree.ElementTree as ET
 
 def write_definition_file(registry):#{{{
 	nl_defin_filename = "namelist_definitions.xml"
-	print "=== Writing namelist definitions to: " + nl_defin_filename
+	print("=== Writing namelist definitions to: " + nl_defin_filename)
 	definitions = open(nl_defin_filename, 'w+')
 
 	# Write definitions header#{{{
@@ -285,14 +285,14 @@ try:
 	registry_tree = ET.parse(args.registry)
 except:
 	parser.error('%s does not exist or is not parsable. Exiting.\nSometimes blank lines at the beginning of the file break the parser.'%args.registry)
-        raise
+	raise
 
 if use_defaults:
 	try:
 		defaults_tree = ET.parse(args.defaults)
 	except:
 		parser.error('%s does not exist or is not parsable. Exiting.\nSometimes blank lines at the beginning of the file break the parser.'%args.defaults)
-                raise
+		raise
 
 	defaults = defaults_tree.getroot()
 else:

--- a/source_code_processing/e3sm_namelist_file_generator/generate_e3sm_namelist_files.py
+++ b/source_code_processing/e3sm_namelist_file_generator/generate_e3sm_namelist_files.py
@@ -199,7 +199,7 @@ def write_defaults_file(registry, defaults_tree, use_defaults):#{{{
 
 								defaults.write("=======================\n")
 								defaults.write("<%s>%s</%s>\n"%(option_name.strip(), def_option.text.strip(), option_name.strip()))
-								defaults.write("<<<<<<<<< FROM OLD DEFAULTS\n")
+								defaults.write(">>>>>>>>> FROM OLD DEFAULTS\n")
 							else:
 								defaults.write("<%s>%s</%s>\n"%(option_name.strip(), def_option.text.strip(), option_name.strip()))
 							wrote_opt = True


### PR DESCRIPTION
Consistent line indentation
Print statements compatable with python 2/3
Added raise statements to try blocks for improved debugging
Renamed ACME to E3SM