### PR TITLE
Add pyproj as a dependency

### DIFF
--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -54,6 +54,7 @@ requirements:
     - pyamg
     - rasterio
     - affine
+    - pyproj
 
 test:
   requires:


### PR DESCRIPTION
This was coming in through `cartopy` before but is not a required dependency of `cartopy` in the latest build, whereas it *is* required in `mpas_tools`.