### PR TITLE
Add support for "unified" land-ocean meshes

### DIFF
--- a/conda_package/mpas_tools/mesh/creation/jigsaw_to_netcdf.py
+++ b/conda_package/mpas_tools/mesh/creation/jigsaw_to_netcdf.py
@@ -4,15 +4,16 @@ from __future__ import absolute_import, division, print_function, \
 import numpy as np
 
 from netCDF4 import Dataset as NetCDFFile
-from mpas_tools.mesh.creation.open_msh import readmsh
 from mpas_tools.mesh.creation.util import circumcenter
+
+from jigsawpy import jigsaw_msh_t, loadmsh
 
 import argparse
 
 
 def jigsaw_to_netcdf(msh_filename, output_name, on_sphere, sphere_radius=None):
     """
-    Converts mesh data defined in triangle format to NetCDF
+    Converts mesh data defined in JIGSAW format to NetCDF
 
     Parameters
     ----------
@@ -26,34 +27,42 @@ def jigsaw_to_netcdf(msh_filename, output_name, on_sphere, sphere_radius=None):
         The radius of the sphere in meters.  If ``on_sphere=True`` this argument
         is required, otherwise it is ignored.
     """
-    # Authors: Phillip J. Wolfram, Matthew Hoffman and Xylar Asay-Davis
+    # Authors: Phillip J. Wolfram, Matthew Hoffman, Xylar Asay-Davis
+    #          and Darren Engwirda
 
     grid = NetCDFFile(output_name, 'w', format='NETCDF3_CLASSIC')
 
     # Get dimensions
     # Get nCells
-    msh = readmsh(msh_filename)
-    nCells = msh['POINT'].shape[0]
+    msh = jigsaw_msh_t()
+    loadmsh(msh_filename, msh)
+    nCells = msh.point.shape[0]
 
     # Get vertexDegree and nVertices
     vertexDegree = 3  # always triangles with JIGSAW output
-    nVertices = msh['TRIA3'].shape[0]
+    nVertices = msh.tria3.shape[0]
 
     if vertexDegree != 3:
-        ValueError("This script can only compute vertices with triangular "
-                   "dual meshes currently.")
+        ValueError('This script can only compute vertices with triangular '
+                   'dual meshes currently.')
 
     grid.createDimension('nCells', nCells)
     grid.createDimension('nVertices', nVertices)
     grid.createDimension('vertexDegree', vertexDegree)
 
     # Create cell variables and sphere_radius
-    xCell_full = msh['POINT'][:, 0]
-    yCell_full = msh['POINT'][:, 1]
-    zCell_full = msh['POINT'][:, 2]
+    if msh.vert3.size > 0:
+        xCell_full = msh.vert3['coord'][:, 0]
+        yCell_full = msh.vert3['coord'][:, 1]
+        zCell_full = msh.vert3['coord'][:, 2]
+    else:
+        xCell_full = msh.vert2['coord'][:, 0]
+        yCell_full = msh.vert2['coord'][:, 1]
+        zCell_full = np.zeros(nVertices, dtype=float)
+
     for cells in [xCell_full, yCell_full, zCell_full]:
-        assert cells.shape[0] == nCells, 'Number of anticipated nodes is' \
-                                         ' not correct!'
+        assert cells.shape[0] == nCells, 'Number of anticipated nodes is ' \
+                                         'not correct!'
     if on_sphere:
         grid.on_a_sphere = "YES"
         grid.sphere_radius = sphere_radius
@@ -66,7 +75,7 @@ def jigsaw_to_netcdf(msh_filename, output_name, on_sphere, sphere_radius=None):
         grid.sphere_radius = 0.0
 
     # Create cellsOnVertex
-    cellsOnVertex_full = msh['TRIA3'][:, :3] + 1
+    cellsOnVertex_full = msh.tria3['index'] + 1
     assert cellsOnVertex_full.shape == (nVertices, vertexDegree), \
         'cellsOnVertex_full is not the right shape!'
 
@@ -75,7 +84,7 @@ def jigsaw_to_netcdf(msh_filename, output_name, on_sphere, sphere_radius=None):
     yVertex_full = np.zeros((nVertices,))
     zVertex_full = np.zeros((nVertices,))
 
-    for iVertex in np.arange(0, nVertices):
+    for iVertex in range(nVertices):
         cell1 = cellsOnVertex_full[iVertex, 0]
         cell2 = cellsOnVertex_full[iVertex, 1]
         cell3 = cellsOnVertex_full[iVertex, 2]
@@ -109,12 +118,16 @@ def jigsaw_to_netcdf(msh_filename, output_name, on_sphere, sphere_radius=None):
     var[:] = yCell_full
     var = grid.createVariable('zCell', 'f8', ('nCells',))
     var[:] = zCell_full
+    var = grid.createVariable('featureTagCell', 'i4', ('nCells',))
+    var[:] = msh.point['IDtag']
     var = grid.createVariable('xVertex', 'f8', ('nVertices',))
     var[:] = xVertex_full
     var = grid.createVariable('yVertex', 'f8', ('nVertices',))
     var[:] = yVertex_full
     var = grid.createVariable('zVertex', 'f8', ('nVertices',))
     var[:] = zVertex_full
+    var = grid.createVariable('featureTagVertex', 'i4', ('nVertices',))
+    var[:] = msh.tria3['IDtag']
     var = grid.createVariable(
         'cellsOnVertex', 'i4', ('nVertices', 'vertexDegree',))
     var[:] = cellsOnVertex_full

--- a/conda_package/mpas_tools/mesh/creation/jigsaw_to_netcdf.py
+++ b/conda_package/mpas_tools/mesh/creation/jigsaw_to_netcdf.py
@@ -58,7 +58,7 @@ def jigsaw_to_netcdf(msh_filename, output_name, on_sphere, sphere_radius=None):
     else:
         xCell_full = msh.vert2['coord'][:, 0]
         yCell_full = msh.vert2['coord'][:, 1]
-        zCell_full = np.zeros(nVertices, dtype=float)
+        zCell_full = np.zeros(nCells, dtype=float)
 
     for cells in [xCell_full, yCell_full, zCell_full]:
         assert cells.shape[0] == nCells, 'Number of anticipated nodes is ' \

--- a/conda_package/mpas_tools/ocean/coastline_alteration.py
+++ b/conda_package/mpas_tools/ocean/coastline_alteration.py
@@ -4,6 +4,12 @@ from __future__ import absolute_import, division, print_function, \
 import numpy
 import xarray
 
+from scipy.spatial import distance
+from scipy.sparse import csr_matrix
+from scipy.sparse.csgraph import connected_components
+
+from mpas_tools.mesh.creation.util import lonlat2xyz
+
 
 def add_critical_land_blockages(dsMask, dsBlockages):
     """
@@ -31,6 +37,135 @@ def add_critical_land_blockages(dsMask, dsBlockages):
         dsMask.regionCellMasks[:, 0] = numpy.maximum(
             dsBlockages.transectCellMasks[:, transectIndex],
             dsMask.regionCellMasks[:, 0])
+
+    return dsMask
+
+
+def subtract_critical_passages(dsMask, dsPassages):
+    """
+    Subtract the masks associated with one or more passages from the land
+    mask.
+
+    Parameters
+    ----------
+    dsMask : `xarray.Dataset`
+        The mask to which critical passages should be added
+    dsPassages : `xarray.Dataset`
+        The transect masks defining critical passages to be kept open for
+        ocean flow
+
+    Returns
+    -------
+    dsMask : `xarray.Dataset`
+        The mask with critical passages included
+    """
+    # Authors: Darren Engwirda
+
+    dsMask = dsMask.copy()
+
+    nTransects = dsPassages.sizes['nTransects']
+    for transectIndex in range(nTransects):
+        index = dsPassages.transectCellMasks[:, transectIndex] > 0
+        dsMask.regionCellMasks[index, 0] = 0
+
+    return dsMask
+
+
+def mask_reachable_ocean(dsMesh, dsMask, fcSeed):
+    """
+    Return a new land mask that ensures all ocean cells are "reachable" from
+    (at least) one of the ocean points. Isolated patches of ocean cells will
+    be added to the land mask.
+
+    Parameters
+    ----------
+    dsMesh : `xarray.Dataset`
+        The unculled base mesh object to which the land mask is applied.
+
+    dsMask : `xarray.Dataset`
+        The current land mask.
+
+    fcSeed : `geometric_features.FeatureCollection`
+        A set of "seed" points associated with the ocean domain. Used to
+        determine which cells in the ocean mesh are "unreachable" wrt. the
+        land mask via a flood-fill.
+
+    Returns
+    -------
+    dsMask : `xarray.Dataset`
+        The updated land mask, with the set of unreachable ocean cells added.
+    """
+    # Authors: Darren Engwirda
+
+    dsMask = dsMask.copy()
+
+    cellMasks = numpy.array(dsMask.regionCellMasks[:, 0])
+
+    nCells = dsMesh.sizes['nCells']
+
+    # a sparse matrix representation of masked cell-to-cell connectivity
+    iNext = +0
+    iPtrs = numpy.zeros(nCells + 1, dtype=int)
+    xData = numpy.zeros(
+        nCells * dsMesh.sizes['maxEdges'], dtype=int)
+    iCols = numpy.zeros(
+        nCells * dsMesh.sizes['maxEdges'], dtype=int)
+
+    countOnCell = numpy.array(dsMesh.nEdgesOnCell)
+    cellsOnCell = numpy.array(dsMesh.cellsOnCell)
+
+    # add graph edges between adjacent cells as long as they share common
+    # mask entries
+    for iCell in range(nCells):
+        for iEdge in range(countOnCell[iCell]):
+            iPair = cellsOnCell[iCell, iEdge] - 1
+            if (cellMasks[iCell] == cellMasks[iPair]):
+                xData[iNext] = +1
+                iCols[iNext] = iPair
+                iNext = iNext + 1
+
+        iPtrs[iCell + 1] = iNext
+
+    xData.resize((iPtrs[nCells]))
+    iCols.resize((iPtrs[nCells]))
+
+    spMesh = csr_matrix((xData, iCols, iPtrs), dtype=int)
+
+    # find "connected" parts of masked mesh, as the connected components of
+    # the masked cell-to-cell matrix
+    nLabel, labels = connected_components(
+        csgraph=spMesh, directed=False, return_labels=True)
+
+    # set seedMasks = +1 for the cells closest to any "seed" points defined
+    # for the ocean
+    seedMasks = numpy.zeros(nCells, dtype=int)
+
+    x, y, z = lonlat2xyz(
+        dsMesh.lonCell, dsMesh.latCell, R=1.E+0)
+
+    xyzCell = numpy.empty((nCells, 3), dtype=float)
+    xyzCell[:, 0] = x
+    xyzCell[:, 1] = y
+    xyzCell[:, 2] = z
+
+    for feature in fcSeed.features:
+        point = feature['geometry']['coordinates']
+
+        x, y, z = lonlat2xyz(point[0], point[1], R=1.E+0)
+
+        index = distance.cdist([[x, y, z]], xyzCell).argmin()
+
+        if (cellMasks[index] == 0):
+            seedMasks[index] = +1
+
+    # reset the land mask: mark all cells in any "connected" component that
+    # contains an ocean point as 0
+    dsMask.regionCellMasks[:, 0] = +1
+
+    for iLabel in range(nLabel):
+        labelMasks = seedMasks[labels == iLabel]
+        if (numpy.any(labelMasks > +0)):
+            dsMask.regionCellMasks[labels == iLabel, 0] = 0
 
     return dsMask
 

--- a/conda_package/recipe/build.sh
+++ b/conda_package/recipe/build.sh
@@ -10,7 +10,7 @@ ${PYTHON} -m pip install . --no-deps -vv
 
 cd mesh_tools/mesh_conversion_tools
 
-# build and install JIGSAW
+# build and install mesh-conversion-tools
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_BUILD_TYPE=Release ..

--- a/mesh_tools/mesh_conversion_tools/mpas_cell_culler.cpp
+++ b/mesh_tools/mesh_conversion_tools/mpas_cell_culler.cpp
@@ -25,7 +25,7 @@ double sphere_radius, xPeriod, yPeriod;
 string in_history = "";
 string in_file_id = "";
 string in_parent_id = "";
-string in_mesh_spec = "1.0";
+string in_mesh_spec = "1.1";
 bool outputMap = false;
 
 // Connectivity and location information {{{
@@ -772,12 +772,14 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 	NcVar *xCellVar, *yCellVar, *zCellVar, *xEdgeVar, *yEdgeVar, *zEdgeVar, *xVertexVar, *yVertexVar, *zVertexVar;
 	NcVar *lonCellVar, *latCellVar, *lonEdgeVar, *latEdgeVar, *lonVertexVar, *latVertexVar;
 	NcVar *idx2cellVar, *idx2edgeVar, *idx2vertexVar;
+	NcVar *tag2cellVar, *tag2vertexVar;
 
 	int i, idx_map;
 
 	double *xOld, *yOld, *zOld, *latOld, *lonOld;
 	double *xNew, *yNew, *zNew, *latNew, *lonNew;
-	int *idxToNew;
+	int *IDtagOld;
+	int *idxToNew, *IDtagNew;
 
 	// Build and write cell coordinate arrays
 	xOld = new double[nCells];
@@ -785,6 +787,7 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 	zOld = new double[nCells];
 	latOld = new double[nCells];
 	lonOld = new double[nCells];
+	IDtagOld = new int[nCells];
 
 	xNew = new double[nCellsNew];
 	yNew = new double[nCellsNew];
@@ -792,8 +795,10 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 	latNew = new double[nCellsNew];
 	lonNew = new double[nCellsNew];
 	idxToNew = new int[nCellsNew];
+	IDtagNew = new int[nCellsNew];
 
 	netcdf_mpas_read_xyzcell ( inputFilename, nCells, xOld, yOld, zOld );
+	netcdf_mpas_read_featuretagcell( inputFilename, nCells, IDtagOld );
 	netcdf_mpas_read_latloncell ( inputFilename, nCells, latOld, lonOld );
 
 	idx_map = 0;
@@ -805,6 +810,7 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 			latNew[idx_map] = latOld[iCell];
 			lonNew[idx_map] = lonOld[iCell];
 			idxToNew[idx_map] = idx_map+1;
+			IDtagNew[idx_map] = IDtagOld[iCell];
 			idx_map++;
 		}
 	}
@@ -821,11 +827,14 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 	if (!zCellVar->put(zNew,nCellsNew)) return NC_ERR;
 	if (!(idx2cellVar = grid.add_var("indexToCellID", ncInt, nCellsDim))) return NC_ERR;
 	if (!idx2cellVar->put(idxToNew,nCellsNew)) return NC_ERR;
+	if (!(tag2cellVar = grid.add_var("featureTagCell", ncInt, nCellsDim))) return NC_ERR;
+	if (!tag2cellVar->put(IDtagNew,nCellsNew)) return NC_ERR;
 	delete[] xOld;
 	delete[] yOld;
 	delete[] zOld;
 	delete[] latOld;
 	delete[] lonOld;
+	delete[] IDtagOld;
 
 	delete[] xNew;
 	delete[] yNew;
@@ -833,6 +842,7 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 	delete[] latNew;
 	delete[] lonNew;
 	delete[] idxToNew;
+	delete[] IDtagNew;
 
 	//Build and write edge coordinate arrays
 	xOld = new double[nEdges];
@@ -895,6 +905,7 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 	zOld = new double[nVertices];
 	latOld = new double[nVertices];
 	lonOld = new double[nVertices];
+	IDtagOld = new int[nVertices];
 
 	xNew = new double[nVerticesNew];
 	yNew = new double[nVerticesNew];
@@ -902,8 +913,10 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 	latNew = new double[nVerticesNew];
 	lonNew = new double[nVerticesNew];
 	idxToNew = new int[nVerticesNew];
+	IDtagNew = new int[nVerticesNew];
 
 	netcdf_mpas_read_xyzvertex ( inputFilename, nVertices, xOld, yOld, zOld );
+	netcdf_mpas_read_featuretagvertex( inputFilename, nVertices, IDtagOld );
 	netcdf_mpas_read_latlonvertex ( inputFilename, nVertices, latOld, lonOld );
 
 	idx_map = 0;
@@ -915,6 +928,7 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 			latNew[idx_map] = latOld[iVertex];
 			lonNew[idx_map] = lonOld[iVertex];
 			idxToNew[idx_map] = idx_map+1;
+			IDtagNew[idx_map] = IDtagOld[iVertex];
 			idx_map++;
 		}
 	}
@@ -931,11 +945,14 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 	if (!zVertexVar->put(zNew,nVerticesNew)) return NC_ERR;
 	if (!(idx2vertexVar = grid.add_var("indexToVertexID", ncInt, nVerticesDim))) return NC_ERR;
 	if (!idx2vertexVar->put(idxToNew, nVerticesNew)) return NC_ERR;
+	if (!(tag2vertexVar = grid.add_var("featureTagVertex", ncInt, nVerticesDim))) return NC_ERR;
+	if (!tag2vertexVar->put(IDtagNew, nVerticesNew)) return NC_ERR;
 	delete[] xOld;
 	delete[] yOld;
 	delete[] zOld;
 	delete[] latOld;
 	delete[] lonOld;
+	delete[] IDtagOld;
 
 	delete[] xNew;
 	delete[] yNew;
@@ -943,6 +960,7 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 	delete[] latNew;
 	delete[] lonNew;
 	delete[] idxToNew;
+	delete[] IDtagNew;
 
 	grid.close();
 

--- a/mesh_tools/mesh_conversion_tools/netcdf_utils.cpp
+++ b/mesh_tools/mesh_conversion_tools/netcdf_utils.cpp
@@ -995,6 +995,73 @@ void netcdf_mpas_read_latloncell ( string filename, int ncells, double latcell[]
 	return;
 }/*}}}*/
 //****************************************************************************80
+void netcdf_mpas_read_featuretagcell ( string filename, int ncells, int idtag[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_FEATURETAGCELL reads featureTagCell.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    19 October 2020
+	//
+	//  Author:
+	//
+	//    Darren Engwirda
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NCELLS, the number of nodes.
+	//
+	//    Output, int IDTAG[NCELLS], the integer ID "tags" associated with the
+    //    nodes.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITPERIOD
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Period64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	NcError err(NcError::silent_nonfatal); // Don't error if the variable isn't found.
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "    Reading featureTagCell" << endl;
+#endif
+	var_id = ncid.get_var ( "featureTagCell" );
+	if (var_id == NULL) {
+		for (int i = 0; i < ncells; ++i) {
+			idtag[i] = 0;
+		}
+	} else {
+		(*var_id).get ( &idtag[0], ncells );
+	}
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
 void netcdf_mpas_read_areacell ( string filename, int ncells, double areacell[] ){/*{{{*/
 
 	//****************************************************************************80
@@ -1761,6 +1828,73 @@ void netcdf_mpas_read_latlonvertex ( string filename, int nvertices, double latv
 #endif
 	var_id = ncid.get_var ( "lonVertex" );
 	(*var_id).get ( &lonvertex[0], nvertices );
+	//
+	//  Close the file.
+	//
+	ncid.close ( );
+
+	return;
+}/*}}}*/
+//****************************************************************************80
+void netcdf_mpas_read_featuretagvertex ( string filename, int nvertices, int idtag[] ){/*{{{*/
+
+	//****************************************************************************80
+	//
+	//  Purpose:
+	//
+	//    NETCDF_MPAS_READ_FEATURETAGVERTEX reads featureVertexTag.
+	//
+	//  Licensing:
+	//
+	//    This code is distributed under the GNU LGPL license.
+	//
+	//  Modified:
+	//
+	//    19 October 2020
+	//
+	//  Author:
+	//
+	//    Darren Engwirda
+	//
+	//  Reference:
+	//
+	//    Russ Rew, Glenn Davis, Steve Emmerson, Harvey Davies, Ed Hartne,
+	//    The NETCDF User's Guide,
+	//    Unidata Program Center, March 2009.
+	//
+	//  Parameters:
+	//
+	//    Input, string NC_FILENAME, the name of the NETCDF file to examine.
+	//
+	//    Input, int NVERTICES, the number of vertices.
+	//
+	//    Output, int IDTAG[NVERTICES], the integer ID "tags" associated with
+    //    the vertices.
+	//
+	NcVar *var_id;
+	//
+	//  Open the file.
+	#ifdef _64BITPERIOD
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly, NULL, 0, NcFile::Period64Bits );
+	#else
+		NcFile ncid ( filename.c_str ( ), NcFile::ReadOnly );
+	#endif
+	NcError err(NcError::silent_nonfatal); // Don't error if the variable isn't found.
+	//
+	//
+	//  Get the variable values.
+	//
+#ifdef _DEBUG
+	cout << "    Reading featureTagVertex" << endl;
+#endif
+	var_id = ncid.get_var ( "featureTagVertex" );
+	if (var_id == NULL) {
+		for (int i = 0; i < nvertices; ++i) {
+			idtag[i] = 0;
+		}
+	} else {
+		(*var_id).get ( &idtag[0], nvertices );
+	}
 	//
 	//  Close the file.
 	//

--- a/mesh_tools/mesh_conversion_tools/netcdf_utils.h
+++ b/mesh_tools/mesh_conversion_tools/netcdf_utils.h
@@ -24,6 +24,7 @@ int netcdf_mpas_read_dim ( string filename, string dim_name );
 /* Cell Reading Functions {{{*/
 void netcdf_mpas_read_xyzcell ( string filename, int ncells, double xcell[], double ycell[], double zcell[] );
 void netcdf_mpas_read_latloncell ( string filename, int ncells, double latcell[], double loncell[] );
+void netcdf_mpas_read_featuretagcell ( string filename, int ncells, int idtag[] );
 void netcdf_mpas_read_areacell ( string filename, int ncells, double areacell[] );
 void netcdf_mpas_read_nedgesoncell ( string filename, int ncells, int edgesoncell[] );
 void netcdf_mpas_read_cellsoncell ( string filename, int ncells, int maxedges, int cellsoncell[] );
@@ -39,6 +40,7 @@ void netcdf_mpas_read_cellseedmask ( string filename, int ncells, int cellseedma
 /* Vertex Reading Functions {{{*/
 void netcdf_mpas_read_xyzvertex ( string filename, int nvertices, double xvertex[], double yvertex[], double zvertex[] );
 void netcdf_mpas_read_latlonvertex ( string filename, int nvertices, double latvertex[], double lonvertex[] );
+void netcdf_mpas_read_featuretagvertex ( string filename, int nvertices, int idtag[] );
 void netcdf_mpas_read_areatriangle ( string filename, int nvertices, double areatriangle[] );
 void netcdf_mpas_read_cellsonvertex ( string filename, int nvertices, int vertexdegree, int cellsonvertex[] );
 void netcdf_mpas_read_kiteareasonvertex ( string filename, int nvertices, int vertexdegree, double kiteareasonvertex[] );

--- a/mesh_tools/mesh_conversion_tools/pnt.h
+++ b/mesh_tools/mesh_conversion_tools/pnt.h
@@ -7,14 +7,15 @@ class pnt {/*{{{*/
 	public:
 		double x, y, z;
 		double lat, lon;
-		int idx;
+		int idx, tag;
 		bool positiveLonRange;
 
-		pnt(double x_, double y_, double z_, int idx_) {
+		pnt(double x_, double y_, double z_, int idx_, int tag_) {
 			(*this).x = x_;
 			(*this).y = y_;
 			(*this).z = z_;
 			(*this).idx = idx_;
+			(*this).tag = tag_;
 			(*this).positiveLonRange = true;
 			(*this).buildLat();
 			(*this).buildLon();
@@ -25,6 +26,7 @@ class pnt {/*{{{*/
 			(*this).y = y_;
 			(*this).z = z_;
 			(*this).idx = 0;
+			(*this).tag = 0;
 			(*this).positiveLonRange = true;
 			(*this).buildLat();
 			(*this).buildLon();
@@ -35,6 +37,7 @@ class pnt {/*{{{*/
 			(*this).y = 0.0;
 			(*this).z = 0.0;
 			(*this).idx = 0;
+			(*this).tag = 0;
 			(*this).positiveLonRange = true;
 			(*this).lat = 0.0;
 			(*this).lon = 0.0;
@@ -49,6 +52,7 @@ class pnt {/*{{{*/
 			y = p.y;
 			z = p.z;
 			idx = p.idx;
+			tag = p.tag;
 			(*this).buildLat();
 			(*this).buildLon();
 			return *this;
@@ -63,7 +67,7 @@ class pnt {/*{{{*/
 			y_ = y-p.y;
 			z_ = z-p.z;
 
-			return pnt(x_,y_,z_,0);
+			return pnt(x_,y_,z_,0,0);
 		}/*}}}*/
 		pnt operator+(const pnt &p) const {/*{{{*/
 			double x_, y_, z_;
@@ -72,14 +76,14 @@ class pnt {/*{{{*/
 			y_ = y+p.y;
 			z_ = z+p.z;
 
-			return pnt(x_,y_,z_,0);
+			return pnt(x_,y_,z_,0,0);
 		}/*}}}*/
 		pnt operator*(double d) const {/*{{{*/
 			double x_, y_, z_;
 			x_ = x*d;
 			y_ = y*d;
 			z_ = z*d;
-			return pnt(x_,y_,z_,0);
+			return pnt(x_,y_,z_,0,0);
 		}/*}}}*/
 		pnt operator/(double d) const {/*{{{*/
 			double x_, y_, z_;
@@ -93,7 +97,7 @@ class pnt {/*{{{*/
 			x_ = x/d;
 			y_ = y/d;
 			z_ = z/d;
-			return pnt(x_,y_,z_,0);
+			return pnt(x_,y_,z_,0,0);
 		}/*}}}*/
 		pnt& operator/=(double d){/*{{{*/
 			if(d == 0.0){
@@ -129,7 +133,7 @@ class pnt {/*{{{*/
 				std::cout << x << " " << y << " " << z << " " << idx << std::endl;
 
 				assert(norm != 0);
-			}	
+			}
 			norm = sqrt(norm);
 
 			x = x/norm;
@@ -161,7 +165,7 @@ class pnt {/*{{{*/
 			y_ = z*p.x - p.z*x;
 			z_ = x*p.y - p.x*y;
 
-			return pnt(x_,y_,z_,0);
+			return pnt(x_,y_,z_,0,0);
 		}/*}}}*/
 		void fixPeriodicity(const pnt &p, const double xRef, const double yRef){/*{{{*/
 			/* The fixPeriodicity function fixes the periodicity of the current point relative
@@ -271,7 +275,7 @@ class pnt {/*{{{*/
 		}/*}}}*/
 	struct hasher {/*{{{*/
 		size_t operator()(const pnt &p) const {
-			uint32_t hash; 
+			uint32_t hash;
 			size_t i, key[3] = { (size_t)p.x, (size_t)p.y, (size_t)p.z };
 			for(hash = i = 0; i < sizeof(key); ++i) {
 				hash += ((uint8_t *)key)[i];
@@ -292,7 +296,7 @@ class pnt {/*{{{*/
 };/*}}}*/
 
 inline pnt operator*(const double d, const pnt &p){/*{{{*/
-	return pnt(d*p.x, d*p.y, d*p.z, 0);
+	return pnt(d*p.x, d*p.y, d*p.z, 0, 0);
 }/*}}}*/
 
 inline std::ostream & operator<<(std::ostream &os, const pnt &p){/*{{{*/


### PR DESCRIPTION
- Add `featureTagCell` + `featureTagVertex` to `jigsaw-to_netcdf.py`, and `mesh-conversion-tools` to enable labelling of cells/triangles via integer ID tags.
- New `tags` used to mark cells associated with geographic features: watersheds, rivers, basins, etc...
- Read jigsaw meshes via `jigsawpy` tools, to ensure consistent import of full `jigsaw_msh_t` data structure.
- Add `subtract_critical_passages` and `mask_reachable_ocean` to enable consistent culling of "unified" land-ocean meshes.
- See: [DOE-ICoM/icom-mesh/util/saveesm.py](https://github.com/DOE-ICoM/icom-mesh/tree/dev/util) for additional details.