### PR TITLE
Rename string dimension StrLen in write_netcdf

### DIFF
--- a/conda_package/mpas_tools/io.py
+++ b/conda_package/mpas_tools/io.py
@@ -8,8 +8,32 @@ import sys
 
 
 def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals,
-                 format='NETCDF3_64BIT'):
-    '''Write an xarray Dataset with NetCDF4 fill values where needed'''
+                 format='NETCDF3_64BIT', char_dim_name='StrLen'):
+    """
+    Write an xarray.Dataset to a file with NetCDF4 fill values and the given
+    name of the string dimension.  Also adds the time and command-line to the
+    history attribute.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset to save
+
+    fileName : str
+        The path for the NetCDF file to write
+
+    fillValues : dict, optional
+        A dictionary of fill values for different NetCDF types
+
+    format : {'NETCDF4', 'NETCDF4_CLASSIC', 'NETCDF3_64BIT',
+              'NETCDF3_CLASSIC'}, optional
+        The NetCDF file format to use
+
+    char_dim_name : str, optional
+        The name of the dimension used for character strings, or None to let
+        xarray figure this out.
+
+    """
     encodingDict = {}
     variableNames = list(ds.data_vars.keys()) + list(ds.coords.keys())
     for variableName in variableNames:
@@ -23,6 +47,10 @@ def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals,
                     break
         else:
             encodingDict[variableName] = {'_FillValue': None}
+
+        isString = numpy.issubdtype(ds[variableName].dtype, numpy.string_)
+        if isString and char_dim_name is not None:
+            encodingDict[variableName] = {'char_dim_name': char_dim_name}
 
     update_history(ds)
 

--- a/conda_package/mpas_tools/ocean/moc.py
+++ b/conda_package/mpas_tools/ocean/moc.py
@@ -67,11 +67,12 @@ def make_moc_basins_and_transects(gf, mesh_filename,
                                               logger=logger, dir=dir)
 
     if mask_filename is not None:
-        write_netcdf(dsMasks, mask_filename)
+        write_netcdf(dsMasks, mask_filename, char_dim_name='StrLen')
 
     dsMasksAndTransects = add_moc_southern_boundary_transects(dsMasks, dsMesh,
                                                               logger=logger)
-    write_netcdf(dsMasksAndTransects, mask_and_transect_filename)
+    write_netcdf(dsMasksAndTransects, mask_and_transect_filename,
+                 char_dim_name='StrLen')
 
 
 def build_moc_basins(gf, logger=None):


### PR DESCRIPTION
The calling code can change this to something else, but this is what MPAS cores will expect.

Explicitly specify string dimension is `StrLen` in the function for writing out MOC region and transect masks.