### PR TITLE
Add support for logging (e.g. to log files)

### DIFF
--- a/conda_package/mpas_tools/logging.py
+++ b/conda_package/mpas_tools/logging.py
@@ -1,0 +1,187 @@
+import sys
+import logging
+import subprocess
+
+
+def check_call(args, logger):
+    """
+    Call the given subprocess with logging to the given logger.
+
+    Parameters
+    ----------
+    args : list
+        A list of argument to the subprocess
+
+    logger : logging.Logger
+        The logger to write output to
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the given subprocess exists with nonzero status
+
+    """
+
+    process = subprocess.Popen(args, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+
+    if stdout:
+        stdout = stdout.decode('utf-8')
+        for line in stdout.split('\n'):
+            logger.info(line)
+    if stderr:
+        stderr = stderr.decode('utf-8')
+        for line in stderr.split('\n'):
+            logger.error(line)
+
+    if process.returncode != 0:
+        raise subprocess.CalledProcessError(process.returncode,
+                                            ' '.join(args))
+
+
+class LoggingContext(object):
+
+    """
+    A context manager for creating a logger or using an existing logger
+
+    Attributes
+    ----------
+    logger : logging.Logger
+        A logger that sends output to a log file or stdout/stderr
+    """
+
+    def __init__(self, name, logger=None, log_filename=None):
+        """
+        If ``logger`` is ``None``, create a new logger either to a log file
+        or stdout/stderr.  If ``logger`` is anything else, just set the logger
+        attribute
+
+        Parameters
+        ----------
+        name : str
+            A unique name for the logger (e.g. ``__name__`` of the calling
+            module)
+
+        logger : logging.Logger, optional
+           An existing logger that sends output to a log file or stdout/stderr
+           to be used in this context
+
+        log_filename : str, optional
+            The name of a file where output should be written.  If none is
+            supplied, output goes to stdout/stderr
+        """
+        self.logger = logger
+        self.name = name
+        self.log_filename = log_filename
+        self.handler = None
+        self.old_stdout = None
+        self.old_stderr = None
+        self.existing_logger = logger is not None
+
+    def __enter__(self):
+        if not self.existing_logger:
+            if self.log_filename is not None:
+                # redirect output to a log file
+                logger = logging.getLogger(self.name)
+                handler = logging.FileHandler(self.log_filename)
+            else:
+                logger = logging.getLogger(self.name)
+                handler = logging.StreamHandler(sys.stdout)
+
+            formatter = MpasFormatter()
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+            logger.setLevel(logging.INFO)
+            logger.propagate = False
+            self.logger = logger
+            self.handler = handler
+
+            if self.log_filename is not None:
+                self.old_stdout = sys.stdout
+                self.old_stderr = sys.stderr
+                sys.stdout = StreamToLogger(logger, logging.INFO)
+                sys.stderr = StreamToLogger(logger, logging.ERROR)
+        return self.logger
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if not self.existing_logger:
+            if self.old_stdout is not None:
+                self.handler.close()
+                # restore stdout and stderr
+                sys.stdout = self.old_stdout
+                sys.stderr = self.old_stderr
+
+            # remove the handlers from the logger (probably only necessary if
+            # writeLogFile==False)
+            self.logger.handlers = []
+
+        self.stdout = self.original_stdout = sys.stdout
+        self.stderr = self.original_stderr = sys.stderr
+
+
+class MpasFormatter(logging.Formatter):
+    """
+    A custom formatter for logging
+    Modified from:
+    https://stackoverflow.com/a/8349076/7728169
+    https://stackoverflow.com/a/14859558/7728169
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    # printing error messages without a prefix because they are sometimes
+    # errors and sometimes only warnings sent to stderr
+    dbg_fmt = "DEBUG: %(module)s: %(lineno)d: %(msg)s"
+    info_fmt = "%(msg)s"
+    err_fmt = info_fmt
+
+    def __init__(self, fmt=info_fmt):
+        logging.Formatter.__init__(self, fmt)
+
+    def format(self, record):
+
+        # Save the original format configured by the user
+        # when the logger formatter was instantiated
+        format_orig = self._fmt
+
+        # Replace the original format with one customized by logging level
+        if record.levelno == logging.DEBUG:
+            self._fmt = MpasFormatter.dbg_fmt
+
+        elif record.levelno == logging.INFO:
+            self._fmt = MpasFormatter.info_fmt
+
+        elif record.levelno == logging.ERROR:
+            self._fmt = MpasFormatter.err_fmt
+
+        # Call the original formatter class to do the grunt work
+        result = logging.Formatter.format(self, record)
+
+        # Restore the original format configured by the user
+        self._fmt = format_orig
+
+        return result
+
+
+class StreamToLogger(object):
+    """
+    Modified based on code by:
+    https://www.electricmonk.nl/log/2011/08/14/redirect-stdout-and-stderr-to-a-logger-in-python/
+    Copyright (C) 2011 Ferry Boender
+    License: GPL, see https://www.electricmonk.nl/log/posting-license/
+    Fake file-like stream object that redirects writes to a logger instance.
+    """
+
+    def __init__(self, logger, log_level=logging.INFO):
+        self.logger = logger
+        self.log_level = log_level
+        self.linebuf = ''
+
+    def write(self, buf):
+        for line in buf.rstrip().splitlines():
+            self.logger.log(self.log_level, str(line.rstrip()))
+
+    def flush(self):
+        pass

--- a/conda_package/mpas_tools/mesh/creation/jigsaw_driver.py
+++ b/conda_package/mpas_tools/mesh/creation/jigsaw_driver.py
@@ -3,11 +3,14 @@ from __future__ import absolute_import, division, print_function, \
 
 import numpy
 import jigsawpy
+from jigsawpy.savejig import savejig
+
+from mpas_tools.logging import check_call
 
 
 def jigsaw_driver(cellWidth, x, y, on_sphere=True, earth_radius=6371.0e3,
-                  geom_points=None, geom_edges=None):
-    '''
+                  geom_points=None, geom_edges=None, logger=None):
+    """
     A function for building a jigsaw mesh
 
     Parameters
@@ -31,7 +34,9 @@ def jigsaw_driver(cellWidth, x, y, on_sphere=True, earth_radius=6371.0e3,
     geom_edges : ndarray, optional
         list of edges between points in geom_points that define the bounding polygon
 
-    '''
+    logger : logging.Logger, optional
+        A logger for the output if not stdout
+    """
     # Authors
     # -------
     # Mark Petersen, Phillip Wolfram, Xylar Asay-Davis
@@ -65,12 +70,9 @@ def jigsaw_driver(cellWidth, x, y, on_sphere=True, earth_radius=6371.0e3,
        geom.mshID = 'EUCLIDEAN-MESH'
        geom.vert2 = geom_points
        geom.edge2 = geom_edges
-       #geom.edge2.index = geom_edges
-       print (geom_points)
     jigsawpy.savemsh(opts.geom_file, geom)
 
     # build mesh via JIGSAW!
-    mesh = jigsawpy.jigsaw_msh_t()
     opts.hfun_scal = 'absolute'
     opts.hfun_hmax = float("inf")
     opts.hfun_hmin = 0.0
@@ -78,4 +80,5 @@ def jigsaw_driver(cellWidth, x, y, on_sphere=True, earth_radius=6371.0e3,
     opts.optm_qlim = 0.9375
     opts.verbosity = +1
 
-    jigsawpy.cmd.jigsaw(opts)
+    savejig(opts.jcfg_file, opts)
+    check_call(['jigsaw', opts.jcfg_file], logger=logger)

--- a/conda_package/mpas_tools/ocean/build_mesh.py
+++ b/conda_package/mpas_tools/ocean/build_mesh.py
@@ -1,20 +1,24 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-from mpas_tools.mesh.creation import build_spherical_mesh as create_spherical_mesh
+from mpas_tools.mesh.creation import build_spherical_mesh as \
+    create_spherical_mesh
 from mpas_tools.mesh.creation import build_planar_mesh as create_planar_mesh
 from mpas_tools.cime.constants import constants
 from mpas_tools.ocean.inject_bathymetry import inject_bathymetry
 from mpas_tools.ocean.inject_meshDensity import inject_spherical_meshDensity, \
     inject_planar_meshDensity
-from mpas_tools.ocean.inject_preserve_floodplain import inject_preserve_floodplain
+from mpas_tools.ocean.inject_preserve_floodplain import \
+    inject_preserve_floodplain
 from mpas_tools.viz.paraview_extractor import extract_vtk
+from mpas_tools.logging import LoggingContext
 
 
 def build_spherical_mesh(cellWidth, lon, lat, out_filename='base_mesh.nc',
                          plot_cellWidth=True, vtk_dir='base_mesh_vtk',
                          preserve_floodplain=False, floodplain_elevation=20.0,
-                         do_inject_bathymetry=False):
+                         do_inject_bathymetry=False, logger=None,
+                         use_progress_bar=True):
     """
     Build an MPAS mesh using JIGSAW with the given cell sizes as a function of
     latitude and longitude
@@ -38,8 +42,8 @@ def build_spherical_mesh(cellWidth, lon, lat, out_filename='base_mesh.nc',
         The file name of the resulting MPAS mesh
 
     plot_cellWidth : bool, optional
-        Whether to produce a plot of ``cellWidth``. If so, it will be written to
-        ``cellWidthGlobal.png``.
+        Whether to produce a plot of ``cellWidth``. If so, it will be written
+        to ``cellWidthGlobal.png``.
 
     vtk_dir : str, optional
         The name of the directory where mesh data will be extracted for viewing
@@ -55,26 +59,35 @@ def build_spherical_mesh(cellWidth, lon, lat, out_filename='base_mesh.nc',
     do_inject_bathymetry : bool, optional
         Whether one of the default bathymetry datasets, ``earth_relief_15s.nc``
         or ``topo.msh``, should be added to the MPAS mesh
+
+    logger : logging.Logger, optional
+        A logger for the output if not stdout
+
+    use_progress_bar : bool, optional
+        Whether to display progress bars (problematic in logging to a file)
     """
 
-    # from https://github.com/E3SM-Project/E3SM/blob/master/cime/src/share/util/shr_const_mod.F90#L20
-    earth_radius = constants['SHR_CONST_REARTH']
+    with LoggingContext(__name__, logger=logger) as logger:
 
-    create_spherical_mesh(cellWidth, lon, lat, earth_radius,  out_filename,
-                          plot_cellWidth)
+        earth_radius = constants['SHR_CONST_REARTH']
 
-    print('Step 4. Inject meshDensity into the mesh file')
-    inject_spherical_meshDensity(cellWidth, lon, lat,
-                                 mesh_filename=out_filename)
+        create_spherical_mesh(cellWidth, lon, lat, earth_radius,  out_filename,
+                              plot_cellWidth, logger=logger)
 
-    _shared_steps(out_filename, vtk_dir, preserve_floodplain,
-                  floodplain_elevation, do_inject_bathymetry)
+        logger.info('Step 4. Inject meshDensity into the mesh file')
+        inject_spherical_meshDensity(cellWidth, lon, lat,
+                                     mesh_filename=out_filename)
+
+        _shared_steps(out_filename, vtk_dir, preserve_floodplain,
+                      floodplain_elevation, do_inject_bathymetry, logger,
+                      use_progress_bar)
 
 
 def build_planar_mesh(cellWidth, x, y, geom_points, geom_edges,
                       out_filename='base_mesh.nc', vtk_dir='base_mesh_vtk',
                       preserve_floodplain=False, floodplain_elevation=20.0,
-                      do_inject_bathymetry=False):
+                      do_inject_bathymetry=False, logger=None,
+                      use_progress_bar=True):
     """
     Build a planar MPAS mesh
 
@@ -110,36 +123,49 @@ def build_planar_mesh(cellWidth, x, y, geom_points, geom_edges,
     do_inject_bathymetry : bool, optional
         Whether one of the default bathymetry datasets, ``earth_relief_15s.nc``
         or ``topo.msh``, should be added to the MPAS mesh
+
+    logger : logging.Logger, optional
+        A logger for the output if not stdout
+
+    use_progress_bar : bool, optional
+        Whether to display progress bars (problematic in logging to a file)
     """
-    create_planar_mesh(cellWidth, x, y, geom_points, geom_edges, out_filename)
 
-    print('Step 4. Inject meshDensity into the mesh file')
-    inject_planar_meshDensity(cellWidth, x, y, mesh_filename=out_filename)
+    with LoggingContext(__name__, logger=logger) as logger:
 
-    _shared_steps(out_filename, vtk_dir, preserve_floodplain,
-                  floodplain_elevation, do_inject_bathymetry)
+        create_planar_mesh(cellWidth, x, y, geom_points, geom_edges,
+                           out_filename, logger=logger)
+
+        logger.info('Step 4. Inject meshDensity into the mesh file')
+        inject_planar_meshDensity(cellWidth, x, y, mesh_filename=out_filename)
+
+        _shared_steps(out_filename, vtk_dir, preserve_floodplain,
+                      floodplain_elevation, do_inject_bathymetry, logger,
+                      use_progress_bar)
 
 
 def _shared_steps(out_filename, vtk_dir, preserve_floodplain,
-                  floodplain_elevation, do_inject_bathymetry):
+                  floodplain_elevation, do_inject_bathymetry, logger,
+                  use_progress_bar):
     step = 5
 
     if do_inject_bathymetry:
-        print('Step {}. Injecting bathymetry'.format(step))
+        logger.info('Step {}. Injecting bathymetry'.format(step))
         inject_bathymetry(mesh_file=out_filename)
         step += 1
 
     if preserve_floodplain:
-        print('Step {}. Injecting flag to preserve floodplain'.format(step))
+        logger.info('Step {}. Injecting flag to preserve floodplain'.format(
+            step))
         inject_preserve_floodplain(mesh_file=out_filename,
                                    floodplain_elevation=floodplain_elevation)
         step += 1
 
-    print('Step {}. Create vtk file for visualization'.format(step))
+    logger.info('Step {}. Create vtk file for visualization'.format(step))
     extract_vtk(ignore_time=True, lonlat=True, dimension_list=['maxEdges='],
                 variable_list=['allOnCells'], filename_pattern=out_filename,
-                out_dir=vtk_dir)
+                out_dir=vtk_dir, use_progress_bar=use_progress_bar)
 
-    print("***********************************************")
-    print("**    The global mesh file is {}   **".format(out_filename))
-    print("***********************************************")
+    logger.info("***********************************************")
+    logger.info("**    The global mesh file is {}   **".format(out_filename))
+    logger.info("***********************************************")


### PR DESCRIPTION
This merge adds a logging module to the conda package that handles making a logger that outputs to sdtout/stderr.  It also supports running a subprocess and redirecting the output to the logger.

Logging support has been added to the JIGSAW driver (along with a bit of clean-up).

The progress bar in the paraview extractor has been made optional.

Logging support has been added to both the ocean and general mesh builder.