### PR TITLE
Update landice Exodus conversion script user interface

### DIFF
--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -178,7 +178,9 @@ for var_name in var_names:
 
             #Albany has inverted layer/level ordering relative to MPAS.
             if var_name == "surfaceTemperature":
-                nVert_albany = int(stride)-1
+                nVert_albany = nVert_max - 1
+            elif var_name == "basalTemperature":
+                nVert_albany = 0  # This not needed, because it will be 0 for basalTemperature, but adding this case to make that assumption explicit
             else:
                 nVert_albany = nVert_max - nVert - 1
 

--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -198,7 +198,6 @@ for var_name in var_names:
                 y_exo_layer = y_exo[nVert_albany*stride:(nVert_albany+1)*stride]
                 layer_num = len(data_exo)//node_num
             else:
-            else:
                 sys.exit("Invalid ordering in Exodus file.  Ordering must be 0 or 1.")
 
             node_num_layer = len(x_exo_layer)

--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -192,9 +192,9 @@ for var_name in var_names:
                 y_exo_layer = y_exo[nVert_albany::layer_num]
             elif ordering == 0.0:
                 node_num = int(stride)
-                data_exo_layer = data_exo[nVert_albany*stride:(nVert_albany+1)*stride]
-                x_exo_layer = x_exo[nVert_albany*stride:(nVert_albany+1)*stride]
-                y_exo_layer = y_exo[nVert_albany*stride:(nVert_albany+1)*stride]
+                data_exo_layer = data_exo[nVert_albany*node_num:(nVert_albany+1)*node_num]
+                x_exo_layer = x_exo[nVert_albany*node_num:(nVert_albany+1)*node_num]
+                y_exo_layer = y_exo[nVert_albany*node_num:(nVert_albany+1)*node_num]
                 if len(data_exo) % node_num != 0:
                    sys.exit("ERROR: The total number of Exodus nodes cannot be divided evenly by the number of nodes in a level.")
                 layer_num = len(data_exo)//node_num

--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -191,11 +191,13 @@ for var_name in var_names:
                 x_exo_layer = x_exo[nVert_albany::layer_num]
                 y_exo_layer = y_exo[nVert_albany::layer_num]
             elif ordering == 0.0:
+                stride=11608
                 node_num = int(stride)
-                data_exo_layer = data_exo[0:node_num+1]
-                x_exo_layer = x_exo[0:node_num+1]
-                y_exo_layer = y_exo[0:node_num+1]
+                data_exo_layer = data_exo[nVert_albany*stride:(nVert_albany+1)*stride]
+                x_exo_layer = x_exo[nVert_albany*stride:(nVert_albany+1)*stride]
+                y_exo_layer = y_exo[nVert_albany*stride:(nVert_albany+1)*stride]
                 layer_num = len(data_exo)//node_num
+            else:
             else:
                 sys.exit("Invalid ordering in Exodus file.  Ordering must be 0 or 1.")
 

--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -167,7 +167,7 @@ for var_name in var_names:
                 nVert_max = np.shape(dataset.variables[var_name])[2]
         else:
             nVert_max = 1
-        
+
         albanyTemperature = np.zeros((nCells, nVert_max)) #initialize albanyTemperature array to fill in below
         dataset.variables[var_name][:] = 0 # Fill variable with zeros in order to ensure proper values in void
 
@@ -175,7 +175,7 @@ for var_name in var_names:
         # loop through nVertLevels (or nVertInterfaces) and convert variables from Albany to MPAS units
         for nVert in np.arange(0, nVert_max):
             print('Converting layer/level {} of {}'.format(nVert+1, nVert_max))
-            
+
             #Albany has inverted layer/level ordering relative to MPAS.
             if var_name == "surfaceTemperature":
                 nVert_albany = int(stride)-1
@@ -236,17 +236,17 @@ for var_name in var_names:
             MPAS_layers = np.arange(1, nVert_max) - 0.5 # MPAS and albany temperature layers are staggered
             temperatureInterpolant = interp1d(albany_layers, albanyTemperature, axis=1)
             dataset.variables["temperature"][0,:,:] = temperatureInterpolant(MPAS_layers)
-            
+
             # Add reasonable (non-zero) temperatures outside of ice mask. Make this a linear
             # interpolation between min(273.15, surfaceAirTemperature) at the surface and 268.15K at the bed.
             surfaceAirTemperature = dataset.variables["surfaceAirTemperature"][0,:]
             surfaceAirTemperature[surfaceAirTemperature > 273.15] = 273.15
-            
+
             for nLayer in np.arange(0, dataset.dimensions["nVertLevels"].size):
                 tempInterpCells = dataset.variables["temperature"][0,:,nLayer] == 0.0
                 dataset.variables["temperature"][0,tempInterpCells,nLayer] = (1 - np.sum(dataset.variables["layerThicknessFractions"][0:nLayer+1])) * \
                                 surfaceAirTemperature[tempInterpCells] + np.sum(dataset.variables["layerThicknessFractions"][0:nLayer+1]) * 268.15 
-                                
+
             print('\nTemperature interpolation complete')
 
         # Extrapolate and smooth beta and stiffnessFactor fields

--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -206,8 +206,11 @@ for var_name in var_names:
             elif var_name == "uReconstructX" or var_name == "uReconstructY":
                 dataset.variables[var_name][0,cellID_array-1, nVert] = data_exo_layer / (60. * 60. * 24 * 365)
             elif var_name == "thickness":
+                print("WARNING: thickness conversion is still experimental!  Carefully check results before using.")
+                # We have to be careful to not change MPAS geometry in the extended layer of cells - only touch it where the MPAS file already had nonzero thickness
+                thkMask = dataset.variables[var_name][0,cellID_array-1] > 1.0
+                dataset.variables[var_name][0,cellID_array-1] = data_exo_layer * 1000.0 * thkMask
                 # change bedTopography also when we change thickness, if that field exists
-                dataset.variables[var_name][0,cellID_array-1] = data_exo_layer * 1000.0
                 if 'bedTopography' in dataset.variables.keys():
                     thicknessOrig = np.copy(dataset.variables[var_name][0,cellID_array-1])
                     bedTopographyOrig = np.copy(dataset.variables['bedTopography'][0,cellID_array-1])

--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -191,11 +191,12 @@ for var_name in var_names:
                 x_exo_layer = x_exo[nVert_albany::layer_num]
                 y_exo_layer = y_exo[nVert_albany::layer_num]
             elif ordering == 0.0:
-                stride=11608
                 node_num = int(stride)
                 data_exo_layer = data_exo[nVert_albany*stride:(nVert_albany+1)*stride]
                 x_exo_layer = x_exo[nVert_albany*stride:(nVert_albany+1)*stride]
                 y_exo_layer = y_exo[nVert_albany*stride:(nVert_albany+1)*stride]
+                if len(data_exo) % node_num != 0:
+                   sys.exit("ERROR: The total number of Exodus nodes cannot be divided evenly by the number of nodes in a level.")
                 layer_num = len(data_exo)//node_num
             else:
                 sys.exit("Invalid ordering in Exodus file.  Ordering must be 0 or 1.")

--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -385,6 +385,7 @@ print("\nConversion, extrapolation, and smoothing complete. Enjoy!")
 
 # Update history attribute of netCDF file
 thiscommand = datetime.now().strftime("%a %b %d %H:%M:%S %Y") + ": " + " ".join(sys.argv[:])
+thiscommand = thiscommand+";  Variables successfully converted from Exodus to MPAS: " + ",".join(vars_converted)
 if hasattr(dataset, 'history'):
    newhist = '\n'.join([thiscommand, getattr(dataset, 'history')])
 else:

--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -29,7 +29,7 @@ parser = OptionParser(description='Convert data from exodus file to MPAS mesh. W
 parser.add_option("-e", "--exo", dest="exo_file", help="the exo input file")
 parser.add_option("-a", "--ascii", dest="id_file", help="the ascii global id input file")
 parser.add_option("-o", "--out", dest="nc_file", help="the mpas file to write to")
-parser.add_option("-v", "--variable", dest="var_name", help="the mpas variable(s) you want to convert from an exodus file. May be 'all', a single variable, or multiple variables comma-separated (no spaces)")
+parser.add_option("-v", "--variable", dest="var_name", help="the mpas variable(s) you want to convert from an exodus file. May be a single variable or multiple variables comma-separated (no spaces)")
 parser.add_option("--dynamics", dest="dynamics", action="store_true", help="Use to convert ice dynamics fields: beta, stiffnessFactor, uReconstructX/Y.  If stiffnessFactor was not included in the optimzation, it will be skipped.")
 parser.add_option("--thermal", dest="thermal", action="store_true", help="Use to convert thermal fields: temperature, surfaceTemperature, basalTemperature.  Only use when the Albany optimization included the thermal solution.")
 parser.add_option("--geometry", dest="geometry", action="store_true", help="Use to convert geometry fields: thickness and corresponding adjustment to bedTopography.  Only use when the Albany optimization included adjustment to the ice thickness.")
@@ -128,10 +128,7 @@ if options.geometry:
 
 if len(var_names)>0 and options.var_name:
     sys.exit("ERROR: Specifying one or more of --dynamics --thermal --geometry and also specifying variables through --variable is not supported.")
-if options.var_name == "all":
-    for mpas_name in mpas_exodus_var_dic:
-        var_names.append(mpas_name)
-elif options.var_name:
+if options.var_name:
     var_names = options.var_name.split(',') #parse variable names into a list
 
 if len(var_names) == 0:
@@ -156,6 +153,8 @@ for var_name in var_names:
         extrapolation = None
 
     print("\n---------------")
+    if not var_name in mpas_exodus_var_dic:
+        sys.exit("ERROR: variable '{}' not supported by this script.  Supported variables are: {}".format(var_name, mpas_exodus_var_dic.keys()))
     if mpas_exodus_var_dic[var_name] in exo.get_node_variable_names() and var_name in dataset.variables.keys():
         exo_var_name = mpas_exodus_var_dic[var_name]
         data_exo = np.array(exo.get_node_variable_values(exo_var_name,1))


### PR DESCRIPTION
This merge updates the Exodus conversion script to make it less likely to be used incorrectly.  Instead of specifying a variable list, the command line interface now should use --dynamics --thermal --geometry flags to explicitly choose conversion of sets of variables associated with different ways the optimization is run.  This merge also includes a lot of general clean up by providing more information to stdout and includes more error checking.

There also is an adjustment to the thickness conversion to exclude the extended row of cells that occur in floating ice in Albany.  This is still experimental and a warning is added to that effect.