### PR TITLE
Generalize angleEdge for planar meshes in MpasMeshConverter

### DIFF
--- a/mesh_tools/mesh_conversion_tools/mpas_mesh_converter.cpp
+++ b/mesh_tools/mesh_conversion_tools/mpas_mesh_converter.cpp
@@ -2159,6 +2159,7 @@ int buildAngleEdge(){/*{{{*/
 
 			normal = cell_loc2 - cell_loc1;
 			angleEdge.at(iEdge) = acos( x_axis.dot(normal) / (x_axis.magnitude() * normal.magnitude()));
+			if (cell_loc2.y < cell_loc1.y) angleEdge.at(iEdge) = 2.0 * M_PI - angleEdge.at(iEdge);
 		} else {
 
 			np = pntFromLatLon(edges.at(iEdge).getLat()+0.05, edges.at(iEdge).getLon());


### PR DESCRIPTION
In MpasMeshConverter, the planar mesh calculation for angleEdge assumes
the connectivity of periodic_hex such that angleEdge would always be
between 0 and 180.

This commit eliminates that assumption and makes the angleEdge
calculation applicable to any mesh.  This is necessary for angleEdge to
be correct for planar meshes made with JIGSAW, for example.