### PR TITLE
In grid_rotate/Makefile, set the Fortran compiler using 'nc-config --fc'

### DIFF
--- a/mesh_tools/grid_rotate/Makefile
+++ b/mesh_tools/grid_rotate/Makefile
@@ -1,4 +1,4 @@
-FC = gfortran
+FC = $(shell nc-config --fc)
 FFLAGS = -m64 -O2 -ffree-line-length-none -ffree-form -Wall
 FCINCLUDES = $(shell nc-config --fflags)
 FCLIBS = $(shell nc-config --flibs)

--- a/mesh_tools/grid_rotate/README
+++ b/mesh_tools/grid_rotate/README
@@ -23,12 +23,17 @@ I. OVERVIEW
 II. BUILDING THE CODE
 
    This standalone consists of the files: grid_rotate.f90, namelist.input, and
-   Makefile
+   Makefile .
 
    Building requires NetCDF and a Fortran compiler.
 
-   Update the Makefile to use your preferred compiler and make certain the
-   environment variable NETCDF points to your installation of NetCDF; make
+   Before building, ensure that the directory containing the 'nc-config' utility
+   is in your $PATH; this directory is usually in bin/ subdirectory of your
+   NetCDF installation root directory. The 'nc-config' utility is part of most
+   modern NetCDF installations, and if you do not have nc-config, it will be
+   necessary to manually set the name of your Fortran compiler, as well as the
+   library paths, in the Makefile; specifically, the following variables must be
+   manually set: FC, FCINCLUDES, and FCLIBS.
 
 
 III.  RUNNING THE CODE
@@ -66,7 +71,7 @@ III.  RUNNING THE CODE
    the following nameslist settings will work:
 
 &input
-     config_original_latitude_degrees = 0
+   config_original_latitude_degrees = 0
    config_original_longitude_degrees = 0
 
    config_new_latitude_degrees = 0


### PR DESCRIPTION
This merge sets the Fortran compiler using `nc-config --fc` in the grid_rotate
top-level Makefile.

Previously, the name of the Fortran compiler was hard-wired to 'gfortran'. Even
in cases where grid_rotate was being built with the GNU compilers, this could
fail with undefined references, for example, if the NetCDF library was build
with parallel I/O support (in which case, we need to link with the MPI wrapper).

Now, the value of the FC variable in the top-level Makefile is set to the output
of 'nc-config --fc'.

One potential issue worth noting is that, while the Fortran compiler can change
depending on the output of nc-config, the Fortran compiler flags (FFLAGS) are
still hard-wired in the top-level Makefile.