### PR TITLE
Fix invalid vertices in vertex transect masks

### DIFF
--- a/conda_package/ci/linux_python3.8.yaml
+++ b/conda_package/ci/linux_python3.8.yaml
@@ -6,6 +6,8 @@ cxx_compiler_version:
 - '9'
 hdf5:
 - 1.10.6
+libnetcdf:
+- 4.7.4
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/conda_package/ci/linux_python3.9.yaml
+++ b/conda_package/ci/linux_python3.9.yaml
@@ -6,6 +6,8 @@ cxx_compiler_version:
 - '9'
 hdf5:
 - 1.10.6
+libnetcdf:
+- 4.7.4
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/conda_package/mpas_tools/mesh/mask.py
+++ b/conda_package/mpas_tools/mesh/mask.py
@@ -1031,8 +1031,15 @@ def _get_polygons(dsMesh, maskType):
     elif maskType == 'vertex':
         # polygons are cells on vertex
         vertexIndices = dsMesh.cellsOnVertex.values - 1
-        valid = numpy.amax(vertexIndices >= 0, axis=1)
-        vertexIndices = vertexIndices[valid, :]
+        maxVertices = vertexIndices.shape[1]
+        firstValid = vertexIndices[:, 0]
+        for iVertex in range(1, maxVertices):
+            mask = firstValid < 0
+            firstValid[mask] = vertexIndices[mask, iVertex]
+        assert(numpy.all(firstValid >= 0))
+        for iVertex in range(maxVertices):
+            mask = vertexIndices[:, iVertex] < 0
+            vertexIndices[mask, iVertex] = firstValid[mask]
         lonVertex = dsMesh.lonCell.values
         latVertex = dsMesh.latCell.values
         lonCenter = dsMesh.lonVertex.values

--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -36,7 +36,9 @@ requirements:
     - cmake
   host:
     - python
+    - hdf5
     - hdf5 * nompi_*
+    - libnetcdf
     - libnetcdf * nompi_*
     - setuptools
     - netcdf4


### PR DESCRIPTION
With this fix, the first valid vertex is copied into any invalid vertices in the triangles around vertices.  Each vertex corresponds to a polygon, but some polygons are degenerate and presumably don't intersect the transect.

closes #413 