### PR TITLE
Add a yaml file describing the `mpas_tools` dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 .ropeproject
 
 .DS_Store
+
+# pycharm
+.idea

--- a/conda_package/.gitignore
+++ b/conda_package/.gitignore
@@ -1,0 +1,5 @@
+# Files created by "python -m pip install -e ."
+/landice/
+/mesh_tools/
+/ocean/
+/visualization/

--- a/conda_package/dev_environment.yaml
+++ b/conda_package/dev_environment.yaml
@@ -1,0 +1,35 @@
+name: mpas_tools_dev
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  # Base
+  - python 3.8
+  - affine
+  - cartopy
+  - dask
+  - geometric_features >=0.1.12
+  - hdf5
+  - jigsaw >=0.9.12
+  - jigsawpy >=0.2.1
+  - libnetcdf
+  - matplotlib-base
+  - netcdf4
+  - numpy
+  - progressbar2
+  - pyamg
+  - pyevtk
+  - pyflann
+  - pyproj
+  - python-igraph
+  - rasterio
+  - scikit-image
+  - scipy
+  - shapely
+  - xarray
+  # Development
+  - pip
+  # Documentation
+  - sphinx
+  - mock
+  - sphinx_rtd_theme

--- a/conda_package/docs/.gitignore
+++ b/conda_package/docs/.gitignore
@@ -1,0 +1,3 @@
+# Files created by "python -m pip install -e ."
+/_build
+/generated

--- a/conda_package/docs/building_docs.rst
+++ b/conda_package/docs/building_docs.rst
@@ -6,21 +6,13 @@ Building the Documentation
 
 To make a local test build of the documentation, it is easiest to follow the
 :ref:`dev_testing_changes` procedure for how to make a local build of the
-``mpas_tools`` package.  Then, you need to set up a conda environment with the
-test build and some other required packages:
+``mpas_tools`` package.  The development environment includes the packages
+needed to build the documentation. Simply run:
 
 code-block::
 
-  $ conda create -y -n test_mpas_tools_docs --use-local mpas_tools sphinx mock \
-       sphinx_rtd_theme
-  $ conda activate test_mpas_tools_docs
-
-Then, to build the documentation, run:
-
-code-block::
-
-  $ export DOCS_VERSION="test"
-  $ cd conda_package/docs
-  $ make html
+  export DOCS_VERSION="test"
+  cd conda_package/docs
+  make html
 
 Then, you can view the documentation by opening ``_build/html/index.html``.

--- a/conda_package/docs/making_changes.rst
+++ b/conda_package/docs/making_changes.rst
@@ -63,21 +63,73 @@ By convention, entry points do not typically include the ``.py`` extension.
 Dependencies
 ============
 
-If you changes introduce new dependencies, these need to be added to the recipe
-for the conda package in ``conda_package/recipe/meta.yaml``
+If you changes introduce new dependencies, these need to be added to both
+the recipe for the conda package in ``conda_package/recipe/meta.yaml`` and
+to the yaml file describing the development environment,
+``conda_package/dev_environment.yaml``.
 
-Add these changes to the end of the ``run`` section of ``requirements``:
+In ``meta.yaml``, add these changes in alphabetical order to the ``run``
+section of ``requirements``:
 
-.. code-block::
+.. code-block:: yaml
 
   requirements:
   ...
     run:
       - python
-      - netcdf4
-      ...
       - affine
+      ...
 
 These requirements *must* be on the ``conda-forge`` anaconda channel.  If you
 need help with this, please contact the developers.
 
+Add the new dependencies in alphabetical order to ``dev_environment.yaml``
+under the ``#Base`` comment:
+
+.. code-block:: yaml
+
+    ...
+    dependencies:
+      # Base
+      - python 3.8
+      - affine
+      ...
+
+Updating the Version
+====================
+
+Before a release of the package, the version of ``mpas_tools`` needs to be
+updated in 3 places.  First, in ``conda_package/mpas_tools/__init__.py``:
+
+.. code-block:: python
+
+  __version_info__ = (0, 6, 0)
+  __version__ = '.'.join(str(vi) for vi in __version_info__)
+
+Increment ``__version_info__`` (major, minor or micro version, depending on
+what makes sense).
+
+Second, the version in the conda recipe (``conda_package/recipe/meta.yaml``)
+needs to match:
+
+.. code-block::
+
+  {% set name = "mpas_tools" %}
+  {% set version = "0.6.0" %}
+
+Third, Add the new version to the :ref:`versions` in the documentation.
+
+.. code-block::
+
+    `v0.6.0`_         `0.6.0`_
+    ================ ===============
+
+    ...
+
+    .. _`v0.6.0`: ../0.6.0/index.html
+    .. _`0.6.0`: https://github.com/MPAS-Dev/MPAS-Analysis/tree/0.6.0
+
+
+The new links won't be valid until a new release is made and Azure Pipelines
+has generated the associated documentation.  Eventually, it should be possible
+to do this automatically but that has not yet been implemented.

--- a/conda_package/docs/testing_changes.rst
+++ b/conda_package/docs/testing_changes.rst
@@ -4,100 +4,51 @@
 Testing Changes to mpas_tools
 *****************************
 
-There are a few different ways to test the ``mpas_tools`` package.  Typically,
-the quickest turn-around between making changes and seeing their results are
-going to be seen if you can test the code straight out of the git repo.  This
-approach works for calling functions from the package within a python script
-but doesn't give you easy access to the "entry points"(see
-:ref:`dev_making_changes`). To more fully test the package, you will need to
-build the package locally, install it into a new conda environment, and test
-your code within that environment.
+Here, we describe the workflow for creating a development conda environment
+that points to ``mpas_tools`` in a branch from a local clone of the repo.
+This approach works both for calling functions from the package within a python
+script or another python package and for calling the "entry points"
+(command-line tools; see :ref:`dev_making_changes`).
 
-Testing from the git repo
-=========================
+Basic instructions on how to install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_
+are beyond the scope of this documentation. Make sure the conda-forge channel
+is added and that channel priority is "strict", meaning packages will
+definitely come from conda-forge if they are available there.
 
-If you are testing a simple python script that accesses ``mpas_tools``, you can
-make a symlink in the same directory as your python script to ``mpas_tools``
-within ``conda_package``.  Python should search the local path before looking
-elsewhere so this should work even if a previous version ``mpas_tools`` is
-already installed in the conda environment you are using.
+.. code-block:: bash
 
-Testing the conda package
-=========================
+    conda config --add channels conda-forge
+    conda config --set channel_priority strict
 
-Updating the Version
-********************
+To make a conda environment and install the current `mpas_tools` in a way that
+it will be used out of the repo directly (i.e. it will notice changes as you
+make them in your branch), run:
 
-As part of your testing, you should update the version of ``mpas_tools``.  This
-should be done both in ``conda_package/mpas_tools/__init__.py``:
+.. code-block:: bash
 
-.. code-block:: python
-
-  __version_info__ = (0, 0, 11)
-  __version__ = '.'.join(str(vi) for vi in __version_info__)
-
-Increment ``__version_info__`` (major, minor or micro version, depending on
-what makes sense).
-
-The version in the conda recipe (``conda_package/recipe/meta.yaml``) needs to
-match:
-
-.. code-block::
-
-  {% set name = "mpas_tools" %}
-  {% set version = "0.0.11" %}
-
-It is also a good idea to add the new version to the :ref:`versions`.  The new
-links won't be valid until a new release is made and Azure Pipelines has
-generated the associated documentation.  Eventually, it should be possible to
-do this automatically but that has not yet been implemented.
-
-Building the package
-********************
-
-To build the conda package, you will need to install conda-build into your base
-conda environment.  (Basic instructions on how to install Miniconda or Anaconda
-are beyond the scope of this documentation.)
-
-.. code-block::
-
-  $ conda config --add channels conda-forge
-  $ conda config --set channel_priority strict
-  $ conda install -n base conda-build
-
-To build the package, make sure you are in the base of the repo and run:
-
-.. code-block::
-
-  $ rm -rf ~/miniconda3/conda-bld
-  $ conda build -m conda_package/ci/linux_python3.8.yaml conda_package/recipe
-
-The first is to make sure you don't have existing packages already built that
-would get used in your building and testing instead of the versions from
-``conda-forge``.  If your conda setup is installed somewhere other than
-``~/miniconda3``, use the appropriate path.  If you would like to build for
-``osx`` instead of ``linux`` or for python ``3.6`` or ``3.7``, point
-``conda build`` to the appropriate YAML file.
-
-Installing the package
-**********************
-
-To make a new test environment to try out scripts, other python packages or
-other workflows that use the tools, run:
-
-.. code-block::
-
-  $ conda create -n test_mpas_tools --use-local python=3.8 mpas_tools
-
-You can name the environment whatever if useful to you.  Activate the
-environment with:
-
-.. code-block::
-
-  $ conda activate test_mpas_tools
+    cd conda_package
+    conda env create -f ./dev_environment.yaml
+    conda activate mpas_tools_dev
+    python -m pip install -e .
 
 You should now find that ``mpas_tools`` can be imported in python codes and the
 various scripts and entry points are available in the path.
+
+If you have already created the ``mpas_tools_dev`` environment, it may be best
+to remove it (see below) and create it again.  If you are in a rush, you can
+use:
+
+.. code-block:: bash
+
+    conda env update -f ./dev_environment
+    conda activate mpas_tools_dev
+    python -m pip install -e .
+
+to update the existing environment and make sure ``mpas_tools`` in the
+environment points to your current branch.
+
+There is no need to build a conda package, as previous instructions had
+suggested.
 
 Removing the test environment
 *****************************
@@ -106,6 +57,5 @@ If you're done with testing, you can remove the test environment
 
 .. code-block::
 
-  $ conda deactivate
-  $ conda remove --all -n test_mpas_tools
-
+  conda deactivate
+  conda remove --all -n mpas_tools_dev


### PR DESCRIPTION
This will let developers install `mpas_tools` into a conda environment in a way that points to the local branch.  This way, changes can easily be made to the `mpas_tools` package on the fly while testing the package in exactly the way a user or downstream package would.  This will be especially useful for testing changes in `mpas_tools` and packages that depend on these changes at the same time.

Creating a test environment is as simple as:
```
    cd conda_package
    conda env create -f ./dev_environment.yaml
    conda activate mpas_tools_dev
    python -m pip install -e .
```
No `conda build` or `conda create --use-local`.

The documentation has been updated with this new approach.