### PR TITLE
Land Ice: modify script to create MPAS grid

### DIFF
--- a/landice/mesh_tools_li/create_landice_grid_from_generic_MPAS_grid.py
+++ b/landice/mesh_tools_li/create_landice_grid_from_generic_MPAS_grid.py
@@ -23,6 +23,7 @@ parser.add_option("-o", "--out", dest="fileoutName", help="output filename.  Def
 parser.add_option("-l", "--level", dest="levels", help="Number of vertical levels to use in the output file.  Defaults to the number in the input file", metavar="FILENAME")
 parser.add_option("-v", "--vert", dest="vertMethod", help="Method of vertical layer spacing: uniform, glimmer.  Glimmer spacing follows Eq. 35 of Rutt, I. C., M. Hagdorn, N. R. J. Hulton, and A. J. Payne (2009), The Glimmer community ice sheet model, J. Geophys. Res., 114, F02004, doi:10.1029/2008JF001015", default='glimmer', metavar="FILENAME")
 parser.add_option("--beta", dest="beta", action="store_true", help="Use this flag to include the field 'beta' in the resulting file.")
+parser.add_option("--mu", dest="mu", action="store_true", help="Use this flag to include the field 'muFriction' in the resulting file.")
 parser.add_option("--effecpress", dest="effecpress", action="store_true", help="Use this flag to include the field 'effectivePressure' in the resulting file.")
 parser.add_option("--diri", dest="dirichlet", action="store_true", help="Use this flag to include the fields 'dirichletVelocityMask', 'uReconstructX', 'uReconstructY' needed for specifying Dirichlet velocity boundary conditions in the resulting file.")
 parser.add_option("--thermal", dest="thermal", action="store_true", help="Use this flag to include the fields 'temperature', 'surfaceAirTemperature', 'basalHeatFlux' needed for specifying thermal initial conditions in the resulting file.")
@@ -204,9 +205,14 @@ if options.beta:
    newvar[:] = 1.0e8  # Give a default beta that won't have much sliding.
    print('Added optional variable: beta')
 
+if options.mu:
+   newvar = fileout.createVariable('muFriction', datatype, ('Time', 'nCells'))
+   newvar[:] = 1.0e8  # Give a default mu that won't have much sliding.
+   print('Added optional variable: muFriction')
+
 if options.effecpress:
    newvar = fileout.createVariable('effectivePressure', datatype, ('Time', 'nCells'))
-   newvar[:] = 1.0e8  # Give a default effective pressure that won't have much sliding.
+   newvar[:] = 1.0  # Give a default effective pressure of 1.0 so that, for the linear sliding law, beta = mu*effecpress = mu.
    print('Added optional variable: effectivePressure')
 
 if options.dirichlet:

--- a/landice/mesh_tools_li/create_landice_grid_from_generic_MPAS_grid.py
+++ b/landice/mesh_tools_li/create_landice_grid_from_generic_MPAS_grid.py
@@ -22,9 +22,8 @@ parser.add_option("-i", "--in", dest="fileinName", help="input filename.  Defaul
 parser.add_option("-o", "--out", dest="fileoutName", help="output filename.  Defaults to 'landice_grid.nc'", metavar="FILENAME")
 parser.add_option("-l", "--level", dest="levels", help="Number of vertical levels to use in the output file.  Defaults to the number in the input file", metavar="FILENAME")
 parser.add_option("-v", "--vert", dest="vertMethod", help="Method of vertical layer spacing: uniform, glimmer.  Glimmer spacing follows Eq. 35 of Rutt, I. C., M. Hagdorn, N. R. J. Hulton, and A. J. Payne (2009), The Glimmer community ice sheet model, J. Geophys. Res., 114, F02004, doi:10.1029/2008JF001015", default='glimmer', metavar="FILENAME")
-parser.add_option("--beta", dest="beta", action="store_true", help="Use this flag to include the field 'beta' in the resulting file.")
-parser.add_option("--mu", dest="mu", action="store_true", help="Use this flag to include the field 'muFriction' in the resulting file.")
-parser.add_option("--effecpress", dest="effecpress", action="store_true", help="Use this flag to include the field 'effectivePressure' in the resulting file.")
+parser.add_option("--beta", dest="beta", action="store_true", help="DEPRECATED")
+parser.add_option("--effecpress", dest="effecpress", action="store_true", help="DEPRECATED")
 parser.add_option("--diri", dest="dirichlet", action="store_true", help="Use this flag to include the fields 'dirichletVelocityMask', 'uReconstructX', 'uReconstructY' needed for specifying Dirichlet velocity boundary conditions in the resulting file.")
 parser.add_option("--thermal", dest="thermal", action="store_true", help="Use this flag to include the fields 'temperature', 'surfaceAirTemperature', 'basalHeatFlux' needed for specifying thermal initial conditions in the resulting file.")
 parser.add_option("--hydro", dest="hydro", action="store_true", help="Use this flag to include the fields 'waterThickness', 'tillWaterThickness', 'basalMeltInput', 'externalWaterInput', 'frictionAngle', 'waterPressure', 'waterFluxMask' needed for specifying hydro initial conditions in the resulting file.")
@@ -200,20 +199,17 @@ newvar = fileout.createVariable('floatingBasalMassBal', datatype, ('Time', 'nCel
 newvar[:] = numpy.zeros(newvar.shape)
 print('Added default variables: thickness, temperature, bedTopography, sfcMassBal, floatingBasalMassBal')
 
-if options.beta:
-   newvar = fileout.createVariable('beta', datatype, ('Time', 'nCells'))
-   newvar[:] = 1.0e8  # Give a default beta that won't have much sliding.
-   print('Added optional variable: beta')
+newvar = fileout.createVariable('beta', datatype, ('Time', 'nCells'))
+newvar[:] = 1.0e8  # Give a default beta that won't have much sliding.
+print('Added variable: beta')
 
-if options.mu:
-   newvar = fileout.createVariable('muFriction', datatype, ('Time', 'nCells'))
-   newvar[:] = 1.0e8  # Give a default mu that won't have much sliding.
-   print('Added optional variable: muFriction')
+newvar = fileout.createVariable('muFriction', datatype, ('Time', 'nCells'))
+newvar[:] = 1.0e8  # Give a default mu that won't have much sliding.
+print('Added variable: muFriction')
 
-if options.effecpress:
-   newvar = fileout.createVariable('effectivePressure', datatype, ('Time', 'nCells'))
-   newvar[:] = 1.0  # Give a default effective pressure of 1.0 so that, for the linear sliding law, beta = mu*effecpress = mu.
-   print('Added optional variable: effectivePressure')
+newvar = fileout.createVariable('effectivePressure', datatype, ('Time', 'nCells'))
+newvar[:] = 1.0  # Give a default effective pressure of 1.0 so that, for the linear sliding law, beta = mu*effecpress = mu.
+print('Added variable: effectivePressure')
 
 if options.dirichlet:
    newvar = fileout.createVariable('dirichletVelocityMask', datatypeInt, ('Time', 'nCells', 'nVertInterfaces'))


### PR DESCRIPTION
Modified file create_grid_landice_grid_from_generic_MPAS_grid.py to
* always create muFriction, initializated at 1e8 [yr/m]
* change the default of effectivePressure to 1 [Pa] instead of 1e8 [Pa]
* always create beta
* deprecate the --beta and --effecPress command line options

In the future, beta will be removed from MALI.  After that transition is complete, this script will be modified to remove beta and the deprecated options.  The current version supports both backwards and forwards compatibility. 