### PR TITLE
Update `libnetcdf` version in CI

### DIFF
--- a/conda_package/ci/linux_python3.6.yaml
+++ b/conda_package/ci/linux_python3.6.yaml
@@ -7,7 +7,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/conda_package/ci/linux_python3.7.yaml
+++ b/conda_package/ci/linux_python3.7.yaml
@@ -7,7 +7,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/conda_package/ci/linux_python3.8.yaml
+++ b/conda_package/ci/linux_python3.8.yaml
@@ -7,7 +7,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/conda_package/ci/linux_python3.9.yaml
+++ b/conda_package/ci/linux_python3.9.yaml
@@ -7,7 +7,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/conda_package/ci/osx_python3.6.yaml
+++ b/conda_package/ci/osx_python3.6.yaml
@@ -7,7 +7,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/conda_package/ci/osx_python3.7.yaml
+++ b/conda_package/ci/osx_python3.7.yaml
@@ -7,7 +7,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/conda_package/ci/osx_python3.8.yaml
+++ b/conda_package/ci/osx_python3.8.yaml
@@ -7,7 +7,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/conda_package/ci/osx_python3.9.yaml
+++ b/conda_package/ci/osx_python3.9.yaml
@@ -7,7 +7,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 pin_run_as_build:
   python:
     min_pin: x.x


### PR DESCRIPTION
conda-forge is using `libnetcdf=4.8.0` so we should be testing with that version, too.