### PR TITLE
Fix re-registering of colormaps

### DIFF
--- a/conda_package/mpas_tools/viz/colormaps.py
+++ b/conda_package/mpas_tools/viz/colormaps.py
@@ -43,5 +43,6 @@ def _read_xml_colormap(xmlFile, mapName):
 
 
 def _register_colormap_and_reverse(mapName, cmap):
-    plt.register_cmap(mapName, cmap)
-    plt.register_cmap('{}_r'.format(mapName), cmap.reversed())
+    if mapName not in plt.colormaps():
+        plt.register_cmap(mapName, cmap)
+        plt.register_cmap('{}_r'.format(mapName), cmap.reversed())


### PR DESCRIPTION
Matplotlib will complain if we try to re-register a colormap that has already been registered.