### PR TITLE
Fix uninitialized values in kiteAreasOnVertex

### DIFF
--- a/mesh_tools/mesh_conversion_tools/mpas_mesh_converter.cpp
+++ b/mesh_tools/mesh_conversion_tools/mpas_mesh_converter.cpp
@@ -3067,6 +3067,9 @@ int outputVertexParameters( const string outputFilename) {/*{{{*/
 	// Build and write kiteAreasOnVertex
 	// TODO: Fix kite area for quads?
 	tmp_arr = new double[nVertices*vertexDegree];
+	for(i = 0; i < nVertices*vertexDegree; i++){
+	    tmp_arr[i] = 0.0;
+	}
 	i = 0;
 	count = 0;
 	for(vec_dbl_itr = kiteAreasOnVertex.begin(); vec_dbl_itr != kiteAreasOnVertex.end(); ++vec_dbl_itr){


### PR DESCRIPTION
Previously, the MPAS mesh converter was not initializing all values in the temporary buffer for writing out `kiteAreasOnVertex`, meaning some areas for nonexistent cells had garbage values.  This can cause MPAS model to fail in debug mode with arithmetic errors.