### PR TITLE
Add argument to `write_netcdf` for the NetCDF engine

### DIFF
--- a/conda_package/mpas_tools/io.py
+++ b/conda_package/mpas_tools/io.py
@@ -7,8 +7,14 @@ from datetime import datetime
 import sys
 
 
-def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals,
-                 format='NETCDF3_64BIT', char_dim_name='StrLen'):
+default_format = 'NETCDF3_64BIT'
+default_engine = None
+default_char_dim_name = 'StrLen'
+default_fills = netCDF4.default_fillvals
+
+
+def write_netcdf(ds, fileName, fillValues=None, format=None, engine=None,
+                 char_dim_name=None):
     """
     Write an xarray.Dataset to a file with NetCDF4 fill values and the given
     name of the string dimension.  Also adds the time and command-line to the
@@ -23,17 +29,41 @@ def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals,
         The path for the NetCDF file to write
 
     fillValues : dict, optional
-        A dictionary of fill values for different NetCDF types
+        A dictionary of fill values for different NetCDF types.  Default is
+        ``mpas_tools.io.default_fills``, which can be modified but which
+        defaults to ``netCDF4.default_fillvals``
 
     format : {'NETCDF4', 'NETCDF4_CLASSIC', 'NETCDF3_64BIT',
               'NETCDF3_CLASSIC'}, optional
-        The NetCDF file format to use
+        The NetCDF file format to use.  Default is
+        ``mpas_tools.io.default_format``, which can be modified but which
+        defaults to ``'NETCDF3_64BIT'``
+
+    engine : {'netcdf4', 'scipy', 'h5netcdf'}, optional
+        The library to use for NetCDF output.  The default is the same as
+        in :py:meth:`xarray.Dataset.to_netcdf` and depends on ``format``.
+        You can override the default by setting
+        ``mpas_tools.io.default_engine``
 
     char_dim_name : str, optional
         The name of the dimension used for character strings, or None to let
-        xarray figure this out.
+        xarray figure this out. Default is
+        ``mpas_tools.io.default_char_dim_name``, which can be modified but
+        which defaults to ``'StrLen'`
 
     """
+    if format is None:
+        format = default_format
+
+    if fillValues is None:
+        fillValues = default_fills
+
+    if engine is None:
+        engine = default_engine
+
+    if char_dim_name is None:
+        char_dim_name = default_char_dim_name
+
     encodingDict = {}
     variableNames = list(ds.data_vars.keys()) + list(ds.coords.keys())
     for variableName in variableNames:
@@ -59,7 +89,7 @@ def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals,
         # reading Time otherwise
         ds.encoding['unlimited_dims'] = {'Time'}
 
-    ds.to_netcdf(fileName, encoding=encodingDict, format=format)
+    ds.to_netcdf(fileName, encoding=encodingDict, format=format, engine=engine)
 
 
 def update_history(ds):

--- a/conda_package/mpas_tools/mesh/mask.py
+++ b/conda_package/mpas_tools/mesh/mask.py
@@ -163,6 +163,10 @@ def entry_point_compute_mpas_region_masks():
         default='forkserver',
         help="The multiprocessing method use for python mask creation "
              "('fork', 'spawn' or 'forkserver')")
+    parser.add_argument("--format", dest="format", type=str,
+                        help="NetCDF file format")
+    parser.add_argument("--engine", dest="engine", type=str,
+                        help="NetCDF output engine")
     args = parser.parse_args()
 
     dsMesh = xr.open_dataset(args.mesh_file_name, decode_cf=False,
@@ -182,7 +186,8 @@ def entry_point_compute_mpas_region_masks():
             showProgress=args.show_progress,
             subdivisionThreshold=args.subdivision)
 
-    write_netcdf(dsMasks, args.mask_file_name)
+    write_netcdf(dsMasks, args.mask_file_name, format=args.format,
+                 engine=args.engine)
 
 
 def compute_mpas_transect_masks(dsMesh, fcMask, earthRadius,
@@ -352,6 +357,10 @@ def entry_point_compute_mpas_transect_masks():
                         action="store_true",
                         help="Whether to add the transectEdgeMaskSigns "
                              "variable")
+    parser.add_argument("--format", dest="format", type=str,
+                        help="NetCDF file format")
+    parser.add_argument("--engine", dest="engine", type=str,
+                        help="NetCDF output engine")
     args = parser.parse_args()
 
     dsMesh = xr.open_dataset(args.mesh_file_name, decode_cf=False,
@@ -374,7 +383,8 @@ def entry_point_compute_mpas_transect_masks():
             subdivisionResolution=args.subdivision,
             addEdgeSign=args.add_edge_sign)
 
-    write_netcdf(dsMasks, args.mask_file_name)
+    write_netcdf(dsMasks, args.mask_file_name, format=args.format,
+                 engine=args.engine)
 
 
 def compute_mpas_flood_fill_mask(dsMesh, fcSeed, logger=None):
@@ -444,6 +454,10 @@ def entry_point_compute_mpas_flood_fill_mask():
     parser.add_argument("-o", "--mask_file_name", dest="mask_file_name",
                         type=str, required=True,
                         help="An output MPAS region masks file")
+    parser.add_argument("--format", dest="format", type=str,
+                        help="NetCDF file format")
+    parser.add_argument("--engine", dest="engine", type=str,
+                        help="NetCDF output engine")
     args = parser.parse_args()
 
     dsMesh = xr.open_dataset(args.mesh_file_name, decode_cf=False,
@@ -454,7 +468,8 @@ def entry_point_compute_mpas_flood_fill_mask():
         dsMasks = compute_mpas_flood_fill_mask(
             dsMesh=dsMesh, fcSeed=fcSeed, logger=logger)
 
-    write_netcdf(dsMasks, args.mask_file_name)
+    write_netcdf(dsMasks, args.mask_file_name, format=args.format,
+                 engine=args.engine)
 
 
 def compute_lon_lat_region_masks(lon, lat, fcMask, logger=None, pool=None,
@@ -589,6 +604,10 @@ def entry_point_compute_lon_lat_region_masks():
         default='forkserver',
         help="The multiprocessing method use for python mask creation "
              "('fork', 'spawn' or 'forkserver')")
+    parser.add_argument("--format", dest="format", type=str,
+                        help="NetCDF file format")
+    parser.add_argument("--engine", dest="engine", type=str,
+                        help="NetCDF output engine")
     args = parser.parse_args()
 
     dsGrid = xr.open_dataset(args.grid_file_name, decode_cf=False,
@@ -607,7 +626,8 @@ def entry_point_compute_lon_lat_region_masks():
             chunkSize=args.chunk_size, showProgress=args.show_progress,
             subdivisionThreshold=args.subdivision)
 
-    write_netcdf(dsMasks, args.mask_file_name)
+    write_netcdf(dsMasks, args.mask_file_name, format=args.format,
+                 engine=args.engine)
 
 
 def compute_projection_grid_region_masks(
@@ -744,6 +764,10 @@ def entry_point_compute_projection_grid_region_masks():
         default='forkserver',
         help="The multiprocessing method use for python mask creation "
              "('fork', 'spawn' or 'forkserver')")
+    parser.add_argument("--format", dest="format", type=str,
+                        help="NetCDF file format")
+    parser.add_argument("--engine", dest="engine", type=str,
+                        help="NetCDF output engine")
     args = parser.parse_args()
 
     dsGrid = xr.open_dataset(args.grid_file_name, decode_cf=False,
@@ -765,7 +789,8 @@ def entry_point_compute_projection_grid_region_masks():
             showProgress=args.show_progress,
             subdivisionThreshold=args.subdivision, xdim=xdim, ydim=ydim)
 
-    write_netcdf(dsMasks, args.mask_file_name)
+    write_netcdf(dsMasks, args.mask_file_name, format=args.format,
+                 engine=args.engine)
 
 
 def _compute_mask_from_shapes(shapes1, shapes2, func, pool, chunkSize,

--- a/conda_package/mpas_tools/planar_hex.py
+++ b/conda_package/mpas_tools/planar_hex.py
@@ -13,7 +13,7 @@ from mpas_tools.io import write_netcdf
 def make_planar_hex_mesh(nx, ny, dc, nonperiodic_x,
                          nonperiodic_y, outFileName=None,
                          compareWithFileName=None,
-                         format='NETCDF3_64BIT'):
+                         format=None, engine=None):
     """
     Builds an MPAS periodic, planar hexagonal mesh with the requested
     dimensions, optionally saving it to a file, and returns it as an
@@ -42,8 +42,12 @@ def make_planar_hex_mesh(nx, ny, dc, nonperiodic_x,
         The name of a grid file to compare with to see if they are identical,
         used for testing purposes
 
-    format : {'NETCDF4', 'NETCDF4_CLASSIC', 'NETCDF3_64BIT', 'NETCDF3_CLASSIC'}, optional
+    format : {'NETCDF4', 'NETCDF4_CLASSIC', 'NETCDF3_64BIT', '
+             NETCDF3_CLASSIC'}, optional
         The NetCDF format to use for output
+
+    engine : {'netcdf4', 'scipy', 'h5netcdf'}, optional
+        The library to use for NetCDF output
 
     Returns
     -------
@@ -69,7 +73,7 @@ def make_planar_hex_mesh(nx, ny, dc, nonperiodic_x,
     mesh = mesh.drop_vars(['cellIdx', 'cellRow', 'cellCol'])
 
     if outFileName is not None:
-        write_netcdf(mesh, outFileName, format=format)
+        write_netcdf(mesh, outFileName, format=format, engine=engine)
 
     if compareWithFileName is not None:
         # used to make sure results are exactly identical to periodic_hex


### PR DESCRIPTION
Performance for the default `netcdf4` engine has found to be poor for large files on Chrysalis and Anvil, and `scipy` seems to perform better.  For now, `netcdf4` remains the default but the option to change is now provided.

To aid in this process, default values have been defined in the `mpas_tools.io` module that can be modified once, rather than
each time `write_netcdf()` is called.

The `planar_hex` tool and mask creation tools have been modified to take the format and engine as arguments, so that calling code can have more control of these if needed.