### PR TITLE
Rework file I/O in mesh converters for thread-safety

### DIFF
--- a/conda_package/mpas_tools/mesh/conversion.py
+++ b/conda_package/mpas_tools/mesh/conversion.py
@@ -46,15 +46,11 @@ def convert(dsIn, graphInfoFileName=None, logger=None, dir=None):
         if graphInfoFileName is not None:
             graphInfoFileName = os.path.abspath(graphInfoFileName)
 
-        # go into the directory of the output file so the graph.info file ends
-        # up in the same place
-        owd = os.getcwd()
         outDir = os.path.dirname(outFileName)
-        os.chdir(outDir)
+
         _call_subprocess(['MpasMeshConverter.x', inFileName, outFileName],
                          logger)
-        os.chdir(owd)
-
+        
         dsOut = xarray.open_dataset(outFileName)
         dsOut.load()
 
@@ -143,18 +139,13 @@ def cull(dsIn, dsMask=None, dsInverse=None, dsPreserve=None,
                 write_netcdf(ds, fileName)
                 args.extend(['-p', fileName])
 
-        # go into the directory of the output file so the graph.info file ends
-        # up in the same place
-
         if graphInfoFileName is not None:
             graphInfoFileName = os.path.abspath(graphInfoFileName)
 
-        owd = os.getcwd()
         outDir = os.path.dirname(outFileName)
-        os.chdir(outDir)
-        _call_subprocess(args, logger)
-        os.chdir(owd)
 
+        _call_subprocess(args, logger)
+        
         dsOut = xarray.open_dataset(outFileName)
         dsOut.load()
 

--- a/mesh_tools/mesh_conversion_tools/mpas_cell_culler.cpp
+++ b/mesh_tools/mesh_conversion_tools/mpas_cell_culler.cpp
@@ -12,6 +12,8 @@
 
 #include "netcdf_utils.h"
 
+#include "string_utils.h"
+
 #define ID_LEN 10
 
 using namespace std;
@@ -53,10 +55,11 @@ int markEdges();
 int outputGridDimensions(const string outputFilename);
 int outputGridAttributes(const string inputFilename, const string outputFilename);
 int mapAndOutputGridCoordinates(const string inputFilename, const string outputFilename);
-int mapAndOutputCellFields(const string inputFilename, const string outputFilename);
+int mapAndOutputCellFields(const string inputFilename, const string outputPath, 
+                           const string outputFilename);
 int mapAndOutputEdgeFields(const string inputFilename, const string outputFilename);
 int mapAndOutputVertexFields(const string inputFilename, const string outputFilename);
-int outputCellMap();
+int outputCellMap(const string outputPath);
 /*}}}*/
 
 void print_usage(){/*{{{*/
@@ -95,6 +98,9 @@ int main ( int argc, char *argv[] ) {
 	int error;
 	string out_name = "culled_mesh.nc";
 	string in_name = "mesh.nc";
+    string out_path = "";
+    string out_file = "";
+    string out_fext = "";
 	vector<string> mask_names;
 	vector<int> mask_ops;
 
@@ -183,6 +189,8 @@ int main ( int argc, char *argv[] ) {
 		return 1;
 	}
 
+    file_part(out_name, out_path, out_file, out_fext);
+
 	srand(time(NULL));
 
 	cout << "Reading input grid." << endl;
@@ -228,7 +236,7 @@ int main ( int argc, char *argv[] ) {
 	}
 
 	cout << "Mapping and writing cell fields and culled_graph.info" << endl;
-	if(error = mapAndOutputCellFields(in_name, out_name)){
+	if(error = mapAndOutputCellFields(in_name, out_path, out_name)){
 		cout << "Error - " << error << endl;
 		exit(error);
 	}
@@ -247,7 +255,7 @@ int main ( int argc, char *argv[] ) {
 
 	cout << "Outputting cell map" << endl;
 	if (outputMap) {
-		if(error = outputCellMap()){
+		if(error = outputCellMap(out_path)){
 			cout << "Error - " << error << endl;
 			exit(error);
 		}
@@ -256,13 +264,13 @@ int main ( int argc, char *argv[] ) {
 	return 0;
 }
 
-int outputCellMap(){/*{{{*/
+int outputCellMap(const string outputPath){/*{{{*/
 
 	int iCell;
 	ofstream outputfileForward, outputfileBackward;
 
 	// forwards mapping
-	outputfileForward.open("cellMapForward.txt");
+	outputfileForward.open(path_join(outputPath, "cellMapForward.txt"));
 
 	for (iCell=0 ; iCell < nCells ; iCell++) {
 
@@ -290,7 +298,7 @@ int outputCellMap(){/*{{{*/
 
 	}
 
-	outputfileBackward.open("cellMapBackward.txt");
+	outputfileBackward.open(path_join(outputPath, "cellMapBackward.txt"));
 
 	for (iCell=0 ; iCell < nCellsNew ; iCell++) {
 
@@ -948,7 +956,8 @@ int mapAndOutputGridCoordinates( const string inputFilename, const string output
 
 	return 0;
 }/*}}}*/
-int mapAndOutputCellFields( const string inputFilename, const string outputFilename) {/*{{{*/
+int mapAndOutputCellFields( const string inputFilename, const string outputPath, 
+                            const string outputFilename) {/*{{{*/
 	/*****************************************************************
 	 *
 	 * This function maps and writes all of the cell related fields. Including
@@ -1065,7 +1074,7 @@ int mapAndOutputCellFields( const string inputFilename, const string outputFilen
 	edgeCount = edgeCount / 2;
 
 	// Build graph.info file
-	ofstream graph("culled_graph.info");
+	ofstream graph(path_join(outputPath, "culled_graph.info"));
 	graph << nCellsNew << " " << edgeCount << endl;
 	for(int iCell = 0; iCell < nCellsNew; iCell++){
 		for(int j = 0; j < nEdgesOnCellNew[iCell]; j++){

--- a/mesh_tools/mesh_conversion_tools/mpas_cell_culler.cpp
+++ b/mesh_tools/mesh_conversion_tools/mpas_cell_culler.cpp
@@ -98,9 +98,9 @@ int main ( int argc, char *argv[] ) {
 	int error;
 	string out_name = "culled_mesh.nc";
 	string in_name = "mesh.nc";
-    string out_path = "";
-    string out_file = "";
-    string out_fext = "";
+	string out_path = "";
+	string out_file = "";
+	string out_fext = "";
 	vector<string> mask_names;
 	vector<int> mask_ops;
 
@@ -189,7 +189,7 @@ int main ( int argc, char *argv[] ) {
 		return 1;
 	}
 
-    file_part(out_name, out_path, out_file, out_fext);
+	file_part(out_name, out_path, out_file, out_fext);
 
 	srand(time(NULL));
 

--- a/mesh_tools/mesh_conversion_tools/mpas_mesh_converter.cpp
+++ b/mesh_tools/mesh_conversion_tools/mpas_mesh_converter.cpp
@@ -121,9 +121,9 @@ int main ( int argc, char *argv[] ) {
 	int error;
 	string out_name = "mesh.nc";
 	string in_name = "grid.nc";
-    string out_path = "";
-    string out_file = "";
-    string out_fext = "";
+	string out_path = "";
+	string out_file = "";
+	string out_fext = "";
 
 	cout << endl << endl;
 	cout << "************************************************************" << endl;
@@ -171,7 +171,7 @@ int main ( int argc, char *argv[] ) {
 		return 1;
 	}
 
-    file_part(out_name, out_path, out_file, out_fext);
+	file_part(out_name, out_path, out_file, out_fext);
 
 	srand(time(NULL));
 

--- a/mesh_tools/mesh_conversion_tools/mpas_mesh_converter.cpp
+++ b/mesh_tools/mesh_conversion_tools/mpas_mesh_converter.cpp
@@ -16,6 +16,8 @@
 #include "pnt.h"
 #include "edge.h"
 
+#include "string_utils.h"
+
 #define MESH_SPEC 1.0
 #define ID_LEN 10
 
@@ -119,6 +121,9 @@ int main ( int argc, char *argv[] ) {
 	int error;
 	string out_name = "mesh.nc";
 	string in_name = "grid.nc";
+    string out_path = "";
+    string out_file = "";
+    string out_fext = "";
 
 	cout << endl << endl;
 	cout << "************************************************************" << endl;
@@ -166,6 +171,7 @@ int main ( int argc, char *argv[] ) {
 		return 1;
 	}
 
+    file_part(out_name, out_path, out_file, out_fext);
 
 	srand(time(NULL));
 
@@ -272,7 +278,7 @@ int main ( int argc, char *argv[] ) {
 	}
 
 	cout << "Write graph.info file" << endl;
-	if(error = writeGraphFile("graph.info")){
+	if(error = writeGraphFile(path_join(out_path, "graph.info"))){
 		cout << "Error - " << error << endl;
 		exit(error);
 	}

--- a/mesh_tools/mesh_conversion_tools/string_utils.h
+++ b/mesh_tools/mesh_conversion_tools/string_utils.h
@@ -1,0 +1,104 @@
+
+#   include <string>
+
+#   pragma once
+
+#   ifndef __STRING_UTILS__
+#   define __STRING_UTILS__
+
+    /*
+    --------------------------------------------------------
+     * SEPARATOR: return the OS-specific path separator
+    --------------------------------------------------------
+     */
+
+    inline char separator (
+        )
+    {
+#   ifdef _WIN32
+        return '\\';
+#   else
+        return '/';
+#   endif
+    }
+
+    /*
+    --------------------------------------------------------
+     * PATH-JOIN: joint two path names with a separator
+    --------------------------------------------------------
+     */
+
+    std::string path_join (
+        std::string const& _root,
+        std::string const& _stem
+        )
+    {
+        if(!_root.empty() && !_stem.empty() &&
+            _root. back() != separator() &&
+            _stem.front() != separator())
+        {
+            return _root + separator() + _stem;
+        }
+        else
+        {
+            return _root + _stem;
+        }
+    }
+
+    /*
+    --------------------------------------------------------
+     * FILE-PART: split a file name into path/name.fext
+    --------------------------------------------------------
+     */
+
+    void file_part (
+        std::string const& _fsrc,
+        std::string      & _path,
+        std::string      & _name,
+        std::string      & _fext
+        )
+    {
+        typename std::string::size_type
+            _spos = _fsrc.find_last_of("\\/");
+
+        typename std::string::size_type
+            _dpos = _fsrc.find_last_of("."  );
+
+        typename std::string::const_iterator
+            _pos0, _pos1, _pos2,
+            _pos3, _pos4, _pos5;
+
+        if (_spos != std::string::npos )
+        {
+            _pos0 = _fsrc.begin();
+            _pos1 = _fsrc.begin()+_spos-0;
+            _pos2 = _fsrc.begin()+_spos+1;
+        }
+        else
+        {
+            _pos0 = _fsrc.begin();
+            _pos1 = _fsrc.begin();
+            _pos2 = _fsrc.begin();
+        }
+
+        if (_dpos != std::string::npos &&
+           (_spos == std::string::npos ||
+            _dpos >= _spos) )
+        {
+            _pos3 = _fsrc.begin()+_dpos-0;
+            _pos4 = _fsrc.begin()+_dpos+1;
+            _pos5 = _fsrc.end  ();
+        }
+        else
+        {
+            _pos3 = _fsrc.end  ();
+            _pos4 = _fsrc.end  ();
+            _pos5 = _fsrc.end  ();
+        }
+
+        _path = std::string(_pos0, _pos1);
+        _name = std::string(_pos2, _pos3);
+        _fext = std::string(_pos4, _pos5);
+    }
+
+#   endif   //__STRING_UTILS__


### PR DESCRIPTION
This PR reworks the way the C++ `MpasMeshConverter.x` and `MpasCellCuller.x`, as well as the MPAS-Tools `conversion.py` wrapper, handles file I/O to eliminate the need to change into local directories to account for hard-coded relative file names (e.g. `graph.info`).

Eliminating the `os.getcwd()` + `os.chdir()` pattern in `conversion.py` makes these routines thread-safe, allowing them to be called across parallel threads.

These changes write all output files generated by the mesh-converter/culler (e.g. `graph.info`, `cellMapForward.txt`, etc) into the directory defined by the output filename.