### PR TITLE
Fix error in MOC southern transect

### DIFF
--- a/conda_package/mpas_tools/ocean/moc.py
+++ b/conda_package/mpas_tools/ocean/moc.py
@@ -136,6 +136,8 @@ def _extract_southern_boundary(mesh, mocMask, latBuffer, logger):
 
     cellsOnEdgeInRange = numpy.logical_and(cellsOnEdge >= 0,
                                            cellsOnEdge < nCells)
+    # make sure both cells on the dummy edge at the end are out of range
+    cellsOnEdgeInRange[-1, :] = False
 
     southernBoundaryEdges = []
     southernBoundaryEdgeSigns = []


### PR DESCRIPTION
We need to make sure cells on the dummy edge at the end of the edge array are masked as out of range.

Addresses https://github.com/MPAS-Dev/compass/issues/218