### PR TITLE
 Switch from `pyflann` to scipy `KDTree`

### DIFF
--- a/conda_package/ci/linux_python3.7.yaml
+++ b/conda_package/ci/linux_python3.7.yaml
@@ -7,10 +7,12 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+target_platform:
+- linux-64

--- a/conda_package/ci/linux_python3.8.yaml
+++ b/conda_package/ci/linux_python3.8.yaml
@@ -7,10 +7,12 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+target_platform:
+- linux-64

--- a/conda_package/ci/linux_python3.9.yaml
+++ b/conda_package/ci/linux_python3.9.yaml
@@ -7,10 +7,12 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+target_platform:
+- linux-64

--- a/conda_package/ci/osx_python3.7.yaml
+++ b/conda_package/ci/osx_python3.7.yaml
@@ -7,10 +7,12 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+target_platform:
+- osx-64

--- a/conda_package/ci/osx_python3.8.yaml
+++ b/conda_package/ci/osx_python3.8.yaml
@@ -7,10 +7,12 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+target_platform:
+- osx-64

--- a/conda_package/ci/osx_python3.9.yaml
+++ b/conda_package/ci/osx_python3.9.yaml
@@ -7,10 +7,12 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+target_platform:
+- osx-64

--- a/conda_package/dev-spec.txt
+++ b/conda_package/dev-spec.txt
@@ -17,7 +17,6 @@ numpy
 progressbar2
 pyamg
 pyevtk
-pyflann
 pyproj
 python-igraph
 scikit-image

--- a/conda_package/docs/ocean/coastal_tools.rst
+++ b/conda_package/docs/ocean/coastal_tools.rst
@@ -60,7 +60,7 @@ a starting point for ``params``:
         "plot_box": North_America,
 
         # Options
-        "nn_search": "flann",
+        "nn_search": "kdtree",
         "plot_option": True
 
     }
@@ -116,8 +116,7 @@ Next, the distance to the coastal contours is computed using
 :py:func:`mpas_tools.ocean.coastal_tools.distance_to_coast()` with the
 following values from ``params``:
 
-* ``'nn_search'`` - Whether to use the ``'flann'`` or ``'kdtree'`` algorithm,
-  with the ``'flann'`` strongly recommended.
+* ``'nn_search'`` - currently, only the ``'kdtree'`` algorithm is supported
 * ``'smooth_coastline'`` - The number of neighboring cells along the coastline
   over which to average locations to smooth the coastline
 * ``'plot_option'`` - Whether to plot the distance function.
@@ -254,9 +253,9 @@ A key ingredient in defining resolution in coastal meshes is a field containing
 the distance from each location in the field to the nearest point on the
 coastline.  This distance field ``D`` is computed with
 :py:func:`mpas_tools.ocean.coastal_tools.distance_to_coast()`
-The user can optionally control the search algorithm used via
-``params['nn_search']`` (though ``'flann'``, the default, is highly
-recommended).  They can also decide to smooth the coastline as long as there is
+The user could previouly control the search algorithm used via
+``params['nn_search']`` but ``'kdtree'`` is now the only option.
+They can also decide to smooth the coastline as long as there is
 a single coastline contour---with multiple contours, the current algorithm will
 average the end of one contour with the start fo the next---by specifying an
 integer number of neighbors as ``params['smooth_coastline']``.  The default is

--- a/conda_package/mpas_tools/mesh/creation/signed_distance.py
+++ b/conda_package/mpas_tools/mesh/creation/signed_distance.py
@@ -12,7 +12,7 @@ from mpas_tools.mesh.creation.util import lonlat2xyz
 
 
 def signed_distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
-                                 max_length=None):
+                                 max_length=None, workers=-1):
     """
     Get the distance for each point on a lon/lat grid from the closest point
     on the boundary of the geojson regions.
@@ -35,6 +35,10 @@ def signed_distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
         The maximum distance (in degrees) between points on the boundary of the
         geojson region.  If the boundary is too coarse, it will be subdivided.
 
+    workers : int, optional
+        The number of threads used for finding nearest neighbors.  The default
+        is all available threads (``workers=-1``)
+
     Returns
     -------
     signed_distance : numpy.ndarray
@@ -42,7 +46,8 @@ def signed_distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
        to the shape boundary
     """
     distance = distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
-                                     nn_search='flann', max_length=max_length)
+                                     nn_search='kdtree', max_length=max_length,
+                                     workers=workers)
 
     mask = mask_from_geojson(fc, lon_grd, lat_grd)
 
@@ -101,7 +106,8 @@ def mask_from_geojson(fc, lon_grd, lat_grd):
 
 
 def distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
-                          nn_search='kdtree', max_length=None):
+                          nn_search='kdtree', max_length=None,
+                          workers=-1):
     # {{{
     """
     Get the distance for each point on a lon/lat grid from the closest point
@@ -127,6 +133,10 @@ def distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
     max_length : float, optional
         The maximum distance (in degrees) between points on the boundary of the
         geojson region.  If the boundary is too coarse, it will be subdivided.
+
+    workers : int, optional
+        The number of threads used for finding nearest neighbors.  The default
+        is all available threads (``workers=-1``)
 
     Returns
     -------
@@ -181,7 +191,7 @@ def distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
     # Find distances of background grid coordinates to the coast
     print("   Finding distance")
     start = timeit.default_timer()
-    distance, _ = tree.query(pts)
+    distance, _ = tree.query(pts, workers=workers)
     end = timeit.default_timer()
     print("   Done")
     print("   {0:.0f} seconds".format(end-start))

--- a/conda_package/mpas_tools/mesh/creation/signed_distance.py
+++ b/conda_package/mpas_tools/mesh/creation/signed_distance.py
@@ -1,6 +1,5 @@
 import numpy as np
-import pyflann
-from scipy import spatial
+from scipy.spatial import KDTree
 import timeit
 import shapely.geometry
 import shapely.ops
@@ -102,7 +101,7 @@ def mask_from_geojson(fc, lon_grd, lat_grd):
 
 
 def distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
-                          nn_search='flann', max_length=None):
+                          nn_search='kdtree', max_length=None):
     # {{{
     """
     Get the distance for each point on a lon/lat grid from the closest point
@@ -122,7 +121,7 @@ def distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
     earth_radius : float
         Earth radius in meters
 
-    nn_search: {'kdtree', 'flann'}, optional
+    nn_search: {'kdtree'}, optional
         The method used to find the nearest point on the shape boundary
 
     max_length : float, optional
@@ -134,6 +133,10 @@ def distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
     distance : numpy.ndarray
        A 2D field of distances to the shape boundary
     """
+
+    if nn_search != 'kdtree':
+        raise ValueError(f'nn_search method {nn_search} not available.')
+
     print("Distance from geojson")
     print("---------------------")
 
@@ -167,20 +170,7 @@ def distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
     boundary_xyz = np.zeros((npoints, 3))
     boundary_xyz[:, 0], boundary_xyz[:, 1], boundary_xyz[:, 2] = \
         lonlat2xyz(boundary_lon, boundary_lat, earth_radius)
-    flann = None
-    tree = None
-    if nn_search == "kdtree":
-        tree = spatial.KDTree(boundary_xyz)
-    elif nn_search == "flann":
-        flann = pyflann.FLANN()
-        flann.build_index(
-            boundary_xyz,
-            algorithm='kdtree',
-            target_precision=1.0,
-            random_seed=0)
-    else:
-        raise ValueError('Bad nn_search: expected kdtree or flann, got '
-                         '{}'.format(nn_search))
+    tree = KDTree(boundary_xyz)
 
     # Convert background grid coordinates to x,y,z and put in a nx_grd x 3
     # array for kd-tree query
@@ -191,12 +181,7 @@ def distance_from_geojson(fc, lon_grd, lat_grd, earth_radius,
     # Find distances of background grid coordinates to the coast
     print("   Finding distance")
     start = timeit.default_timer()
-    distance = None
-    if nn_search == "kdtree":
-        distance, _ = tree.query(pts)
-    elif nn_search == "flann":
-        _, distance = flann.nn_index(pts, checks=2000, random_seed=0)
-        distance = np.sqrt(distance)
+    distance, _ = tree.query(pts)
     end = timeit.default_timer()
     print("   Done")
     print("   {0:.0f} seconds".format(end-start))

--- a/conda_package/mpas_tools/mesh/mask.py
+++ b/conda_package/mpas_tools/mesh/mask.py
@@ -1,6 +1,6 @@
 import xarray as xr
 import numpy
-import pyflann
+from scipy.spatial import KDTree
 import shapely.geometry
 import shapely.ops
 from shapely.geometry import box, Polygon, MultiPolygon, GeometryCollection
@@ -1164,9 +1164,8 @@ def _compute_seed_mask(fcSeed, lon, lat):
     the resulting mask to 1 there
     """
     points = numpy.vstack((lon, lat)).T
-    flann = pyflann.FLANN()
-    flann.build_index(points, algorithm='kmeans', target_precision=1.0,
-                      random_seed=0)
+
+    tree = KDTree(points)
 
     mask = numpy.zeros(len(lon), dtype=int)
 
@@ -1174,7 +1173,8 @@ def _compute_seed_mask(fcSeed, lon, lat):
     for index, feature in enumerate(fcSeed.features):
         points[index, :] = feature['geometry']['coordinates']
 
-    indices, distances = flann.nn_index(points, checks=2000, random_seed=0)
+    _, indices = tree.query(points)
+
     for index in indices:
         mask[index] = 1
 

--- a/conda_package/mpas_tools/ocean/coastal_tools.py
+++ b/conda_package/mpas_tools/ocean/coastal_tools.py
@@ -608,7 +608,7 @@ def extract_coastlines(nc_file, nc_vars, region_box, z_contour=0, n_longest=10,
 
 def distance_to_coast(coastlines, lon_grd, lat_grd, nn_search='kdtree',
                       smooth_window=0, plot_option=False, plot_box=[],
-                      call=None):
+                      call=None, workers=-1):
     # {{{
     """
     Extracts a set of coastline contours
@@ -647,6 +647,10 @@ def distance_to_coast(coastlines, lon_grd, lat_grd, nn_search='kdtree',
         The number of times the function has been called, used to give the
         plot a unique name.
 
+    workers : int, optional
+        The number of threads used for finding nearest neighbors.  The default
+        is all available threads (``workers=-1``)
+
     Returns
     -------
     D : ndarray
@@ -682,7 +686,7 @@ def distance_to_coast(coastlines, lon_grd, lat_grd, nn_search='kdtree',
     # Find distances of background grid coordinates to the coast
     print("   Finding distance")
     start = timeit.default_timer()
-    d, idx = tree.query(pts)
+    d, idx = tree.query(pts, workers=workers)
     end = timeit.default_timer()
     print("   Done")
     print("   " + str(end - start) + " seconds")

--- a/conda_package/mpas_tools/ocean/coastal_tools.py
+++ b/conda_package/mpas_tools/ocean/coastal_tools.py
@@ -240,7 +240,7 @@ default_params = {
     "plot_box": North_America,
 
     # Options
-    "nn_search": "flann",
+    "nn_search": "kdtree",
     "plot_option": True
 
 }
@@ -626,9 +626,7 @@ def distance_to_coast(coastlines, lon_grd, lat_grd, nn_search='kdtree',
         A 1D array of latitudes in degrees in the range from -90 to 90
 
     nn_search : {'kdtree'}, optional
-        The algorithm to use for the nearest neightbor search.  'flann' is
-        strongly recommended, as it is faster and more memory efficient in our
-        testing.
+        The algorithm to use for the nearest neightbor search.
 
     smooth_window : int, optional
         The number of adjacent coastline points to average together to smooth

--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -60,7 +60,6 @@ requirements:
     - progressbar2
     - pyamg
     - pyevtk
-    - pyflann
     - pyproj
     - python-igraph
     - scikit-image

--- a/conda_package/setup.py
+++ b/conda_package/setup.py
@@ -16,7 +16,6 @@ install_requires = [
     'progressbar2',
     'pyamg',
     'pyevtk',
-    'flann',
     'pyproj',
     'python-igraph',
     'scikit-image',


### PR DESCRIPTION
Anywhere there was the option to use both, there is now only one option (always 'kdtree').

This merge also updates ci builds of the conda package to use `libnetcdf 4.8.1`.

closes #441 