### PR TITLE
Remove compiler-specific options from FFLAGS in grid_rotate Makefile

### DIFF
--- a/mesh_tools/grid_rotate/Makefile
+++ b/mesh_tools/grid_rotate/Makefile
@@ -1,5 +1,5 @@
 FC = $(shell nc-config --fc)
-FFLAGS = -m64 -O2 -ffree-form -Wall
+FFLAGS = -O3
 FCINCLUDES = $(shell nc-config --fflags)
 FCLIBS = $(shell nc-config --flibs)
 


### PR DESCRIPTION
This PR removes GNU-specific flags from the grid_rotate tool's Makefile,
enabling the tool to be compiled "out-of-the-box" with many Fortran compilers.

Previously, the FFLAGS variable in the grid_rotate Makefile contained
GNU-specific flags (-m64 -ffree-form -Wall). The -m64 flag has been
removed from the 'gfortran' build option in the main MPAS-Model repository, the
-ffree-form option is unnecessary because the GNU Fortran compiler assumes files
with a .f90 suffix are free-format, and changing the -O2 flag to -O3 is
consistent with the use of -O3 for the 'gfortran' build target in the main
MPAS-Model repository.

The -Wall flag doesn't appear to be generally portable across compilers, but in
the interest of using only generic flags (assuming -O3 is recognized by most
compilers that are in use in the MPAS community), the -Wall flag has been
removed. Accordingly, developers are encouraged to manually add -Wall when
testing code changes to the grid_rotate tool.

With the changes to FFLAGS, the grid_rotate tool now compiles without
modification with the GNU, Intel, NVHPC, and Cray compilers (assuming nc-config
is in the user's PATH).