### PR TITLE
rename python-igraph to igraph in setup.py

### DIFF
--- a/conda_package/setup.py
+++ b/conda_package/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     'pyamg',
     'pyevtk',
     'pyproj',
-    'python-igraph',
+    'igraph',
     'scikit-image',
     'scipy',
     'shapely',


### PR DESCRIPTION
The name changed in the latest release