### PR TITLE
Add keyword arguments to `check_call`

### DIFF
--- a/conda_package/docs/versions.rst
+++ b/conda_package/docs/versions.rst
@@ -24,6 +24,7 @@ Documentation    On GitHub
 `v0.9.0`_         `0.9.0`_
 `v0.10.0`_        `0.10.0`_
 `v0.11.0`_        `0.11.0`_
+`v0.12.0`_        `0.12.0`_
 ================ ===============
 
 .. _`stable`: ../stable/index.html
@@ -62,3 +63,5 @@ Documentation    On GitHub
 .. _`0.10.0`: https://github.com/MPAS-Dev/MPAS-Tools/tree/0.10.0
 .. _`v0.11.0`: ../0.11.0/index.html
 .. _`0.11.0`: https://github.com/MPAS-Dev/MPAS-Tools/tree/0.11.0
+.. _`v0.12.0`: ../0.12.0/index.html
+.. _`0.12.0`: https://github.com/MPAS-Dev/MPAS-Tools/tree/0.12.0

--- a/conda_package/mpas_tools/__init__.py
+++ b/conda_package/mpas_tools/__init__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 11, 0)
+__version_info__ = (0, 12, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/conda_package/mpas_tools/logging.py
+++ b/conda_package/mpas_tools/logging.py
@@ -3,7 +3,7 @@ import logging
 import subprocess
 
 
-def check_call(args, logger):
+def check_call(args, logger, **kwargs):
     """
     Call the given subprocess with logging to the given logger.
 
@@ -15,6 +15,9 @@ def check_call(args, logger):
     logger : logging.Logger
         The logger to write output to
 
+    kwargs : dict
+        Keyword arguments to pass to subprocess.Popen
+
     Raises
     ------
     subprocess.CalledProcessError
@@ -23,7 +26,7 @@ def check_call(args, logger):
     """
 
     process = subprocess.Popen(args, stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
+                               stderr=subprocess.PIPE, **kwargs)
     stdout, stderr = process.communicate()
 
     if stdout:

--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mpas_tools" %}
-{% set version = "0.11.0" %}
+{% set version = "0.12.0" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
The keyword arguments are passed along to `subprocess.Popen`. This is useful if a given call needs to do things like pass a new environment for `Popen` to use.

This merge also updates the version number to 0.12.0