### PR TITLE
Add 'muFriction' and 'eigencalvingParameter' to  MPAS I/O  field names

### DIFF
--- a/landice/mesh_tools_li/create_landice_grid_from_generic_MPAS_grid.py
+++ b/landice/mesh_tools_li/create_landice_grid_from_generic_MPAS_grid.py
@@ -24,6 +24,7 @@ parser.add_option("-l", "--level", dest="levels", help="Number of vertical level
 parser.add_option("-v", "--vert", dest="vertMethod", help="Method of vertical layer spacing: uniform, glimmer.  Glimmer spacing follows Eq. 35 of Rutt, I. C., M. Hagdorn, N. R. J. Hulton, and A. J. Payne (2009), The Glimmer community ice sheet model, J. Geophys. Res., 114, F02004, doi:10.1029/2008JF001015", default='glimmer', metavar="FILENAME")
 parser.add_option("--beta", dest="beta", action="store_true", help="DEPRECATED")
 parser.add_option("--effecpress", dest="effecpress", action="store_true", help="DEPRECATED")
+parser.add_option("--eigencalving", dest="eigencalving", action="store_true", help="Use this flag to include the field 'eigencalvingParameter' needed for specifying eigencalving parameter in the resulting file.")
 parser.add_option("--diri", dest="dirichlet", action="store_true", help="Use this flag to include the fields 'dirichletVelocityMask', 'uReconstructX', 'uReconstructY' needed for specifying Dirichlet velocity boundary conditions in the resulting file.")
 parser.add_option("--thermal", dest="thermal", action="store_true", help="Use this flag to include the fields 'temperature', 'surfaceAirTemperature', 'basalHeatFlux' needed for specifying thermal initial conditions in the resulting file.")
 parser.add_option("--hydro", dest="hydro", action="store_true", help="Use this flag to include the fields 'waterThickness', 'tillWaterThickness', 'basalMeltInput', 'externalWaterInput', 'frictionAngle', 'waterPressure', 'waterFluxMask' needed for specifying hydro initial conditions in the resulting file.")
@@ -210,6 +211,11 @@ print('Added variable: muFriction')
 newvar = fileout.createVariable('effectivePressure', datatype, ('Time', 'nCells'))
 newvar[:] = 1.0  # Give a default effective pressure of 1.0 so that, for the linear sliding law, beta = mu*effecpress = mu.
 print('Added variable: effectivePressure')
+
+if options.eigencalving:
+   newvar = fileout.createVariable('eigencalvingParameter', datatype, ('Time', 'nCells'))
+   newvar[:] = 3.14e16  # Give default value for eigencalvingParameter
+   print('Added optional eigencalving variable: eigencalvingParameter')
 
 if options.dirichlet:
    newvar = fileout.createVariable('dirichletVelocityMask', datatypeInt, ('Time', 'nCells', 'nVertInterfaces'))

--- a/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
+++ b/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
@@ -683,6 +683,8 @@ elif filetype=='mpas':
      fieldInfo['basalHeatFlux'] =    {'InputName':'basalHeatFlux', 'scalefactor':1.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}
      fieldInfo['surfaceAirTemperature'] =    {'InputName':'surfaceAirTemperature', 'scalefactor':1.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}
      fieldInfo['beta'] = {'InputName':'beta', 'scalefactor':1.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}
+     fieldInfo['muFriction'] = {'InputName':'muFriction', 'scalefactor':1.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}
+     fieldInfo['eigencalvingParameter'] = {'InputName':'eigencalvingParameter', 'scalefactor':1.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}
      # obs fields
      fieldInfo['observedSurfaceVelocityX'] = {'InputName':'observedSurfaceVelocityX', 'scalefactor':1.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}
      fieldInfo['observedSurfaceVelocityY'] = {'InputName':'observedSurfaceVelocityY', 'scalefactor':1.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}


### PR DESCRIPTION
This PR adds 
1) new fields `muFriction` and `eigencalvingParameter` to the MPAS I/O field names in `interpolate_mpasli_to_grid.py` 
2) a new optional field 'eigencalvingParameter' in 'create_landice_grid_from_generic_MPAS_grid.py'
