### PR TITLE
Add an iceMask field to the interpolation script

### DIFF
--- a/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
+++ b/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
@@ -649,6 +649,7 @@ fieldInfo = OrderedDict()
 if filetype=='cism':
 
    fieldInfo['thickness'] =     {'InputName':'thk',  'scalefactor':1.0, 'offset':0.0, 'gridType':'x1', 'vertDim':False}
+   fieldInfo['iceMask'] =  {'InputName':'iceMask',  'scalefactor':1.0, 'offset':0.0, 'gridType':'x1', 'vertDim':False}
    if not args.thicknessOnly:
      fieldInfo['bedTopography'] = {'InputName':'topg', 'scalefactor':1.0, 'offset':0.0, 'gridType':'x1', 'vertDim':False}
      fieldInfo['sfcMassBal'] =    {'InputName':'smb', 'scalefactor':1.0/(3600.0*24.0*365.0), 'offset':0.0, 'gridType':'x1', 'vertDim':False}  # Assuming mm/yr w.e. units for smb


### PR DESCRIPTION
Add an iceMask field to the interpolation script, which can be used
for trimming down fields to the original extent of ice after
interpolating. This is useful when fields must be extrapolated before
using the interpolation script in order to avoid including zeros, NaNs,
or large missing values in the interpolation at the ice edge.