### PR TITLE
Fix bug when looping over variables

### DIFF
--- a/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
+++ b/landice/mesh_tools_li/conversion_exodus_init_to_mpasli_mesh.py
@@ -150,7 +150,7 @@ for var_name in var_names:
     if var_name == "beta":
         smooth_iter_num = 0
         extrapolation = "min"
-    if var_name == "muFriction":
+    elif var_name == "muFriction":
         smooth_iter_num = 0
         extrapolation = "min"
     elif var_name == "stiffnessFactor":


### PR DESCRIPTION
When var_name was `"beta"`, `extrapolation` was being reset to `None` instead of `"min"` because of the inadvertent `"if"` instead of `"elif"`. Testing confirms this commit fixes the issue and properly sets the `extrapolation` method for `beta` to `"min"`.