### PR TITLE
Replace `$` with `$$` when writing config options

### DIFF
--- a/conda_package/mpas_tools/config.py
+++ b/conda_package/mpas_tools/config.py
@@ -364,7 +364,7 @@ class MpasConfigParser:
                 if include_sources:
                     source = self.sources[(section, option)]
                     fp.write(f'# source: {source}\n')
-                value = str(value).replace('\n', '\n\t')
+                value = str(value).replace('\n', '\n\t').replace('$', '$$')
                 fp.write(f'{option} = {value}\n\n')
             fp.write('\n')
 


### PR DESCRIPTION
This is necessary because we always use extended interpolation when we read config files, and a single `$` is interpreted as a reference to another config option.

closes #473 