### PR TITLE
Add a general script for plotting 2D output

### DIFF
--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -19,6 +19,7 @@ parser = OptionParser(description=__doc__)
 parser.add_option("-r", dest="runs", help="path to .nc file or dir containing output.nc file (strings separated by commas; no spaces)", default=None, metavar="FILENAME")
 parser.add_option("-t", dest="timeLevels", help="integer time levels at which to plot (int separated by commas; no spaces)", default='-1')
 parser.add_option("-v", dest="variables", help="variable(s) to plot (list separated by commas; no spaces)", default='thickness')
+parser.add_option("-l", dest="log_plot", help="Whether to plot the log10 of each variable (True or False list separated by commas; no spaces)", default=None)
 parser.add_option("-c", dest="colormaps", help="colormaps to use for plotting (list separated by commas, no spaces", default=None)
 parser.add_option("-s", dest="saveNames", help="filename for saving. If empty or None, will plot to screen instead of saving.", default=None, metavar="FILENAME")
 
@@ -28,6 +29,11 @@ variables = options.variables.split(',')
 timeLevs = options.timeLevels.split(',')  # split time levels into list
 # convert timeLevs to list of ints
 timeLevs = [int(i) for i in timeLevs]
+
+if options.log_plot is not None:
+    log_plot = options.log_plot.split(',')
+else:
+    log_plot = [False] * len(variables)
 
 if options.colormaps is not None:
     colormaps = options.colormaps.split(',')
@@ -101,8 +107,16 @@ for ii, run in enumerate(runs):
     varPlot[run] = {}  # is a dict of dicts too complicated?
     cbars = []
     # Loop over variables
-    for row, (variable, colormap, cbar_ax) in enumerate(zip(variables, colormaps, cbar_axs)):
+    for row, (variable, log, colormap, cbar_ax) in enumerate(zip(variables, log_plot, colormaps, cbar_axs)):
         var_to_plot = f.variables[variable][:]
+        if log == 'True':
+            var_to_plot = np.log10(var_to_plot)
+            # Get rid of +/- inf values that ruin vmin and vmax
+            # calculations below.
+            var_to_plot[np.isinf(var_to_plot)] = np.nan
+            colorbar_label_prefix = 'log10 '
+        else:
+            colorbar_label_prefix = ''
         units = f.variables[variable].units
         varPlot[run][variable] = []
         if 'cellMask' in f.variables.keys():
@@ -137,7 +151,7 @@ for ii, run in enumerate(runs):
             axs[index].set_title(f'year = {yr[timeLev]:0.2f}')
 
         cbars.append(Colorbar(ax=cbar_ax, mappable=varPlot[run][variable][0], orientation='vertical',
-                 label=f'{variable} (${units}$)'))
+                 label=f'{colorbar_label_prefix}{variable} (${units}$)'))
 
     if options.saveNames is not None:
         figs[run].savefig(saveNames[ii], dpi=400, bbox_inches='tight')

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -26,6 +26,8 @@ options, args = parser.parse_args()
 runs = options.runs.split(',') # split run directories into list
 variables = options.variables.split(',')
 timeLevs = options.timeLevels.split(',')  # split time levels into list
+# convert timeLevs to list of ints
+timeLevs = [int(i) for i in timeLevs]
 
 if options.colormaps is not None:
     colormaps = options.colormaps.split(',')
@@ -115,7 +117,6 @@ for ii, run in enumerate(runs):
         # Loop over time levels
         for col, timeLev in enumerate(timeLevs):
             index = row * (nCols - 1) + col
-            timeLev = int(timeLev) #these are strings for some reason; make int to index
             # plot initial grounding line position, initial extent, and GL position at t=timeLev
             axs[index].tricontour(triang, groundingLineMask[0, :],
                               levels=[0.9999], colors='grey', linestyles='solid')
@@ -129,9 +130,9 @@ for ii, run in enumerate(runs):
             # are weighted equally in determining vmin and vmax.
             varPlot[run][variable].append(
                               axs[index].tripcolor(
-                                  triang, var_to_plot[timeLev,:], cmap=colormap,
-                                  shading='flat', vmin=np.nanquantile(var_to_plot, 0.01),
-                                  vmax=np.nanquantile(var_to_plot, 0.99)))
+                                  triang, var_to_plot[timeLev, :], cmap=colormap,
+                                  shading='flat', vmin=np.nanquantile(var_to_plot[timeLevs, :], 0.01),
+                                  vmax=np.nanquantile(var_to_plot[timeLevs, :], 0.99)))
             axs[index].set_aspect('equal')
             axs[index].set_title(f'year = {yr[timeLev]:0.2f}')
 

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -123,8 +123,15 @@ for ii, run in enumerate(runs):
                               levels=[0.9999], colors='white', linestyles='solid')
             axs[index].tricontour(triang, initialExtentMask[timeLev, :],
                               levels=[0.9999], colors='black', linestyles='solid')
-            varPlot[run][variable].append(axs[index].tripcolor(triang, 
-                       var_to_plot[timeLev,:], cmap=colormap, shading='flat'))
+
+            # Plot 2D field at each desired time. Use quantile range of 0.01-0.99 to cut out
+            # outliers. Could improve on this by accounting for areaCell, as currently all cells
+            # are weighted equally in determining vmin and vmax.
+            varPlot[run][variable].append(
+                              axs[index].tripcolor(
+                                  triang, var_to_plot[timeLev,:], cmap=colormap,
+                                  shading='flat', vmin=np.nanquantile(var_to_plot, 0.01),
+                                  vmax=np.nanquantile(var_to_plot, 0.99)))
             axs[index].set_aspect('equal')
             axs[index].set_title(f'year = {yr[timeLev]:0.2f}')
 

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -108,6 +108,7 @@ for ii, run in enumerate(runs):
             floatMask = (cellMask & floatValue) // floatValue
             dynamicMask = (cellMask & dynamicValue) // dynamicValue
             groundingLineMask = (cellMask & groundingLineValue) // groundingLineValue
+            initialExtentMask = (cellMask & initialExtentValue) // initialExtentValue
         else:
             print(f'cellMask is not present in output file {run}')
         
@@ -115,7 +116,12 @@ for ii, run in enumerate(runs):
         for col, timeLev in enumerate(timeLevs):
             index = row * (nCols - 1) + col
             timeLev = int(timeLev) #these are strings for some reason; make int to index
-            axs[index].tricontour(triang, groundingLineMask[timeLev, :], 
+            # plot initial grounding line position, initial extent, and GL position at t=timeLev
+            axs[index].tricontour(triang, groundingLineMask[0, :],
+                              levels=[0.9999], colors='grey', linestyles='solid')
+            axs[index].tricontour(triang, groundingLineMask[timeLev, :],
+                              levels=[0.9999], colors='white', linestyles='solid')
+            axs[index].tricontour(triang, initialExtentMask[timeLev, :],
                               levels=[0.9999], colors='black', linestyles='solid')
             varPlot[run][variable].append(axs[index].tripcolor(triang, 
                        var_to_plot[timeLev,:], cmap=colormap, shading='flat'))

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -79,6 +79,10 @@ if args.mesh is not None:
    mesh = args.mesh.split(',')
    if len(mesh) == 1 and len(runs) > 1:
       mesh *= len(runs)
+   assert len(mesh) == len(runs), ("Define either one master mesh file, "
+                                   "or one mesh file per run file. "
+                                   f"You defined {len(mesh)} files and "
+                                   f"{len(runs)} run files.")
 else:
    mesh = runs
 

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -1,29 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Created on Mon Oct 18 15:40:48 2021
+Created on Dec 9, 2022
 
 @author: Trevor Hillebrand, Matthew Hoffman
 """
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import sys
-import os
 import numpy as np
-import numpy.ma as ma
 from netCDF4 import Dataset
 from optparse import OptionParser
 import matplotlib.pyplot as plt
-import matplotlib as mpl
-from matplotlib.pyplot import cm
 import matplotlib.tri as tri
 import matplotlib.gridspec as gridspec
 from matplotlib.colorbar import Colorbar
 
 
-rhoi = 910.0
-rhosw = 1028.0
 print("** Gathering information.  (Invoke with --help for more details. All arguments are optional)")
 parser = OptionParser(description=__doc__)
 parser.add_option("-r", dest="runs", help="path to .nc file or dir containing output.nc file (strings separated by commas; no spaces)", default=None, metavar="FILENAME")

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -16,7 +16,7 @@ time (white).
 """
 import numpy as np
 from netCDF4 import Dataset
-from optparse import OptionParser
+import argparse
 import matplotlib.pyplot as plt
 import matplotlib.tri as tri
 import matplotlib.gridspec as gridspec
@@ -24,33 +24,33 @@ from matplotlib.colorbar import Colorbar
 
 
 print("** Gathering information.  (Invoke with --help for more details. All arguments are optional)")
-parser = OptionParser(description=__doc__)
-parser.add_option("-r", dest="runs", help="path to .nc file or dir containing output.nc file (strings separated by commas; no spaces)", default=None, metavar="FILENAME")
-parser.add_option("-t", dest="timeLevels", help="integer time levels at which to plot (int separated by commas; no spaces)", default='-1')
-parser.add_option("-v", dest="variables", help="variable(s) to plot (list separated by commas; no spaces)", default='thickness')
-parser.add_option("-l", dest="log_plot", help="Whether to plot the log10 of each variable (True or False list separated by commas; no spaces)", default=None)
-parser.add_option("-c", dest="colormaps", help="colormaps to use for plotting (list separated by commas, no spaces", default=None)
-parser.add_option("-s", dest="saveNames", help="filename for saving. If empty or None, will plot to screen instead of saving.", default=None, metavar="FILENAME")
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("-r", dest="runs", help="path to .nc file or dir containing output.nc file (strings separated by commas; no spaces)", default=None, metavar="FILENAME")
+parser.add_argument("-t", dest="timeLevels", help="integer time levels at which to plot (int separated by commas; no spaces)", default='-1')
+parser.add_argument("-v", dest="variables", help="variable(s) to plot (list separated by commas; no spaces)", default='thickness')
+parser.add_argument("-l", dest="log_plot", help="Whether to plot the log10 of each variable (True or False list separated by commas; no spaces)", default=None)
+parser.add_argument("-c", dest="colormaps", help="colormaps to use for plotting (list separated by commas, no spaces", default=None)
+parser.add_argument("-s", dest="saveNames", help="filename for saving. If empty or None, will plot to screen instead of saving.", default=None, metavar="FILENAME")
 
-options, args = parser.parse_args()
-runs = options.runs.split(',') # split run directories into list
-variables = options.variables.split(',')
-timeLevs = options.timeLevels.split(',')  # split time levels into list
+args = parser.parse_args()
+runs = args.runs.split(',') # split run directories into list
+variables = args.variables.split(',')
+timeLevs = args.timeLevels.split(',')  # split time levels into list
 # convert timeLevs to list of ints
 timeLevs = [int(i) for i in timeLevs]
 
-if options.log_plot is not None:
-    log_plot = options.log_plot.split(',')
+if args.log_plot is not None:
+    log_plot = args.log_plot.split(',')
 else:
     log_plot = [False] * len(variables)
 
-if options.colormaps is not None:
-    colormaps = options.colormaps.split(',')
+if args.colormaps is not None:
+    colormaps = args.colormaps.split(',')
 else:
     colormaps = ['viridis'] * len(variables)
 
-if options.saveNames is not None:
-    saveNames = options.saveNames.split(',')
+if args.saveNames is not None:
+    saveNames = args.saveNames.split(',')
 
 initialExtentValue = 1
 dynamicValue = 2
@@ -165,7 +165,7 @@ for ii, run in enumerate(runs):
         cbars.append(Colorbar(ax=cbar_ax, mappable=varPlot[run][variable][0], orientation='vertical',
                  label=f'{colorbar_label_prefix}{variable} (${units}$)'))
 
-    if options.saveNames is not None:
+    if args.saveNames is not None:
         figs[run].savefig(saveNames[ii], dpi=400, bbox_inches='tight')
     
     f.close()

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -102,7 +102,10 @@ for ii, run in enumerate(runs):
     for row in np.arange(0, nRows):
         cbar_axs.append(plt.subplot(gs[run][row,-1]))
         for col in np.arange(0, nCols-1):
-            axs.append(plt.subplot(gs[run][row, col]))
+            if axs == []:
+                axs.append(plt.subplot(gs[run][row, col]))
+            else:
+                axs.append(plt.subplot(gs[run][row, col], sharex=axs[0], sharey=axs[0]))
 
     varPlot[run] = {}  # is a dict of dicts too complicated?
     cbars = []

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -4,6 +4,15 @@
 Created on Dec 9, 2022
 
 @author: Trevor Hillebrand, Matthew Hoffman
+
+Script to plot snapshot maps of MALI output for an arbitrary number of files,
+variables, and output times. There is no requirement for all output files
+to be on the same mesh. Each output file gets its own figure, each
+variable gets its own row, and each time gets its own column. Three contours
+are automatically plotted, showing intial ice extent (black), initial
+grounding-line position (grey), and grounding-line position at the desired
+time (white).
+
 """
 import numpy as np
 from netCDF4 import Dataset

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -26,12 +26,23 @@ from matplotlib.colors import Normalize, TwoSlopeNorm
 
 print("** Gathering information.  (Invoke with --help for more details. All arguments are optional)")
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument("-r", dest="runs", help="path to .nc file or dir containing output.nc file (strings separated by commas; no spaces)", default=None, metavar="FILENAME")
-parser.add_argument("-t", dest="timeLevels", help="integer time levels at which to plot (int separated by commas; no spaces)", default='-1')
-parser.add_argument("-v", dest="variables", help="variable(s) to plot (list separated by commas; no spaces)", default='thickness')
-parser.add_argument("-l", dest="log_plot", help="Whether to plot the log10 of each variable (True or False list separated by commas; no spaces)", default=None)
-parser.add_argument("-c", dest="colormaps", help="colormaps to use for plotting (list separated by commas, no spaces). This overrides default colormaps.", default=None)
-parser.add_argument("-s", dest="saveNames", help="filename for saving. If empty or None, will plot to screen instead of saving.", default=None, metavar="FILENAME")
+parser.add_argument("-r", dest="runs", default=None, metavar="FILENAME",
+                    help="path to .nc file or dir containing output.nc \
+                          file (strings separated by commas; no spaces)")
+parser.add_argument("-t", dest="timeLevels", default="-1",
+                    help="integer time levels at which to plot \
+                          (int separated by commas; no spaces)")
+parser.add_argument("-v", dest="variables", default='thickness',
+                    help="variable(s) to plot (list separated by commas; no spaces)")
+parser.add_argument("-l", dest="log_plot", default=None,
+                    help="Whether to plot the log10 of each variable \
+                          (True or False list separated by commas; no spaces)")
+parser.add_argument("-c", dest="colormaps", default=None,
+                    help="colormaps to use for plotting (list separated by commas \
+                          , no spaces). This overrides default colormaps.")
+parser.add_argument("-s", dest="saveNames", default=None, metavar="FILENAME",
+                    help="filename for saving. If empty or None, will plot \
+                          to screen instead of saving.")
 
 args = parser.parse_args()
 runs = args.runs.split(',') # split run directories into list
@@ -56,11 +67,11 @@ if args.saveNames is not None:
 # Set up a dictionary of default colormaps for common variables.
 # These can be overridden by the -c flag.
 defaultColors = {'thickness' : 'Blues',
-          'surfaceSpeed' : 'plasma',
-          'basalSpeed' : 'plasma',
-          'bedTopography' : 'BrBG',
-          'floatingBasalMassBalApplied' : 'cividis'
-         }
+                 'surfaceSpeed' : 'plasma',
+                 'basalSpeed' : 'plasma',
+                 'bedTopography' : 'BrBG',
+                 'floatingBasalMassBalApplied' : 'cividis'
+                }
 
 if args.colormaps is not None:
     colormaps = args.colormaps.split(',')

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -40,10 +40,12 @@ parser.add_argument("-l", dest="log_plot", default=None,
 parser.add_argument("-c", dest="colormaps", default=None,
                     help="colormaps to use for plotting (list separated by commas \
                           , no spaces). This overrides default colormaps.")
-parser.add_argument("-m", dest="mesh", default=None,
-                    help="Optional input file containing mesh variables. This \
+parser.add_argument("-m", dest="mesh", default=None, metavar="FILENAME",
+                    help="Optional input file(s) containing mesh variables. This \
                           is useful when plotting from files that have no mesh \
-                          variables to limit file size.")
+                          variables to limit file size. Define either one mesh file \
+                          to be applied to all run files, or one mesh file per \
+                          run file (list separated by commas; no spaces)")
 parser.add_argument("-s", dest="saveNames", default=None, metavar="FILENAME",
                     help="filename for saving. If empty or None, will plot \
                           to screen instead of saving.")

--- a/landice/output_processing_li/plot_maps.py
+++ b/landice/output_processing_li/plot_maps.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Oct 18 15:40:48 2021
+
+@author: Trevor Hillebrand, Matthew Hoffman
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+import os
+import numpy as np
+import numpy.ma as ma
+from netCDF4 import Dataset
+from optparse import OptionParser
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+from matplotlib.pyplot import cm
+import matplotlib.tri as tri
+import matplotlib.gridspec as gridspec
+from matplotlib.colorbar import Colorbar
+
+
+rhoi = 910.0
+rhosw = 1028.0
+print("** Gathering information.  (Invoke with --help for more details. All arguments are optional)")
+parser = OptionParser(description=__doc__)
+parser.add_option("-r", dest="runs", help="path to .nc file or dir containing output.nc file (strings separated by commas; no spaces)", default=None, metavar="FILENAME")
+parser.add_option("-t", dest="timeLevels", help="integer time levels at which to plot (int separated by commas; no spaces)", default='-1')
+parser.add_option("-v", dest="variables", help="variable(s) to plot (list separated by commas; no spaces)", default='thickness')
+parser.add_option("-c", dest="colormaps", help="colormaps to use for plotting (list separated by commas, no spaces", default=None)
+parser.add_option("-s", dest="saveNames", help="filename for saving. If empty or None, will plot to screen instead of saving.", default=None, metavar="FILENAME")
+
+options, args = parser.parse_args()
+runs = options.runs.split(',') # split run directories into list
+variables = options.variables.split(',')
+timeLevs = options.timeLevels.split(',')  # split time levels into list
+
+if options.colormaps is not None:
+    colormaps = options.colormaps.split(',')
+else:
+    colormaps = ['viridis'] * len(variables)
+
+if options.saveNames is not None:
+    saveNames = options.saveNames.split(',')
+
+initialExtentValue = 1
+dynamicValue = 2
+floatValue = 4
+groundingLineValue = 256
+
+def dist(i1, i2, xCell, yCell):  # helper distance fn
+    dist = ((xCell[i1]-xCell[i2])**2 + (yCell[i1]-yCell[i2])**2)**0.5
+    return dist
+
+# Loop over runs
+# Each run gets its own figure
+# Each variable gets its own row
+# Each time level gets its own column
+varPlot = {}
+figs = {}
+gs = {}
+for ii, run in enumerate(runs):
+    if '.nc' not in run:
+        run = run + '/output.nc'
+    f = Dataset(run, 'r')
+    yr = f.variables['daysSinceStart'][:] / 365.
+    f.set_auto_mask(False)
+
+    # Get mesh geometry and calculate triangulation. 
+    # If would be more efficient to do this outside
+    # this loop if all runs are on the same mesh, but we
+    # want this to be as general as possible.
+    xCell = f.variables["xCell"][:]
+    yCell = f.variables["yCell"][:]
+    dcEdge = f.variables["dcEdge"][:]
+
+    triang = tri.Triangulation(xCell, yCell)
+    triMask = np.zeros(len(triang.triangles))
+    maxDist = np.max(dcEdge) * 2.0  # maximum distance in m of edges between points. Make twice dcEdge to be safe
+    for t in range(len(triang.triangles)):
+        thisTri = triang.triangles[t, :]
+        if dist(thisTri[0], thisTri[1], xCell, yCell) > maxDist:
+            triMask[t] = True
+        if dist(thisTri[1], thisTri[2], xCell, yCell) > maxDist:
+            triMask[t] = True
+        if dist(thisTri[0], thisTri[2], xCell, yCell) > maxDist:
+            triMask[t] = True
+    triang.set_mask(triMask)
+
+    # set up figure for this run
+    figs[run] = plt.figure(figsize=(15,7))
+    figs[run].suptitle(run)
+    nRows = len(variables)
+    nCols = len(timeLevs) + 1
+
+    # last column is for colorbars
+    gs[run] = gridspec.GridSpec(nRows, nCols,
+                           height_ratios=[1] * nRows,
+                           width_ratios=[1] * (nCols - 1) + [0.1])
+    axs = []
+    cbar_axs = []
+    for row in np.arange(0, nRows):
+        cbar_axs.append(plt.subplot(gs[run][row,-1]))
+        for col in np.arange(0, nCols-1):
+            axs.append(plt.subplot(gs[run][row, col]))
+
+    varPlot[run] = {}  # is a dict of dicts too complicated?
+    cbars = []
+    # Loop over variables
+    for row, (variable, colormap, cbar_ax) in enumerate(zip(variables, colormaps, cbar_axs)):
+        var_to_plot = f.variables[variable][:]
+        units = f.variables[variable].units
+        varPlot[run][variable] = []
+        if 'cellMask' in f.variables.keys():
+            cellMask = f.variables["cellMask"][:]
+            floatMask = (cellMask & floatValue) // floatValue
+            dynamicMask = (cellMask & dynamicValue) // dynamicValue
+            groundingLineMask = (cellMask & groundingLineValue) // groundingLineValue
+        else:
+            print(f'cellMask is not present in output file {run}')
+        
+        # Loop over time levels
+        for col, timeLev in enumerate(timeLevs):
+            index = row * (nCols - 1) + col
+            timeLev = int(timeLev) #these are strings for some reason; make int to index
+            axs[index].tricontour(triang, groundingLineMask[timeLev, :], 
+                              levels=[0.9999], colors='black', linestyles='solid')
+            varPlot[run][variable].append(axs[index].tripcolor(triang, 
+                       var_to_plot[timeLev,:], cmap=colormap, shading='flat'))
+            axs[index].set_aspect('equal')
+            axs[index].set_title(f'year = {yr[timeLev]:0.2f}')
+
+        cbars.append(Colorbar(ax=cbar_ax, mappable=varPlot[run][variable][0], orientation='vertical',
+                 label=f'{variable} (${units}$)'))
+
+    if options.saveNames is not None:
+        figs[run].savefig(saveNames[ii], dpi=400, bbox_inches='tight')
+    
+    f.close()
+
+plt.show()


### PR DESCRIPTION
Add a generalized script for plotting 2D output for arbitrary numbers of output files, variables, and time levels.
The purposes of this script are:
1. to serve as a quick-view tool so that we don't have to `scp` large output files for simple visualization.
2. to serve as a template for more customized plotting scripts for presentations and publications.