### PR TITLE
Fix importlib.resources imports for python 3.8

### DIFF
--- a/conda_package/dev-spec.txt
+++ b/conda_package/dev-spec.txt
@@ -5,8 +5,9 @@
 python>=3.8
 cartopy
 dask
-geometric_features>=1.0.0,<2.0.0
+geometric_features>=1.0.1,<2.0.0
 hdf5
+importlib_resources
 inpoly
 jigsaw>=0.9.12
 jigsawpy>=0.2.1

--- a/conda_package/mpas_tools/config.py
+++ b/conda_package/mpas_tools/config.py
@@ -1,11 +1,15 @@
 from configparser import RawConfigParser, ConfigParser, ExtendedInterpolation
 import os
-from importlib import resources
 import inspect
 import sys
 import numpy as np
 import ast
 from io import StringIO
+try:
+    from importlib.resources import files as imp_res_files
+except ImportError:
+    # python<=3.8
+    from importlib_resources import files as imp_res_files
 
 
 class MpasConfigParser:
@@ -83,8 +87,8 @@ class MpasConfigParser:
             Whether to raise an exception if the config file isn't found
         """
         try:
-            with resources.path(package, config_filename) as path:
-                self._add(path, user=False)
+            path = imp_res_files(package) / config_filename
+            self._add(path, user=False)
         except (ModuleNotFoundError, FileNotFoundError, TypeError):
             if exception:
                 raise

--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -54,8 +54,9 @@ requirements:
     - python
     - cartopy
     - dask
-    - geometric_features >=1.0.0,<2.0.0
+    - geometric_features >=1.0.1,<2.0.0
     - hdf5
+    - importlib_resources  # [py<=38]
     - inpoly
     - jigsaw >=0.9.12
     - jigsawpy >=0.2.1


### PR DESCRIPTION
This merge also updates:
* Require `importlib_resources` for python 3.8
* Required `geometric_features` (to fix the same issue)