### PR TITLE
Add facemelting to ismip6 processing script

### DIFF
--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -306,6 +306,7 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
         faceMeltSpeedVertAvg = faceMeltSpeed * np.abs(
                                bedTopography / (thickness + dHdt * deltat) )
         faceMeltingThickness = data['faceMeltingThickness'][:, :].values
+        dHdt = data['dHdt'][:, :].values / (3600.0 * 24.0 * 365.0) # convert units to m/s
         for t in range(time):
             if t%20 == 0:
                 print(f"    Time: {t+1} / {time}")

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -243,7 +243,7 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
         # Fields for validation and debugging
         debug_face_melt_flux = False
         if debug_face_melt_flux:
-            deltat_array = np.tile(deltat,  (np.shape(dHdt)[1],1)).transpose()
+            deltat_array = np.tile(deltat,  (np.shape(faceMeltSpeed)[1],1)).transpose()
             # Cleaned field for debugging and validation
             faceMeltingThicknessCleaned = faceMeltingThickness.copy()
         for t in range(time):

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -133,7 +133,7 @@ def do_time_avg_flux_vars(input_file, output_file):
                      'dHdt':              (['Time', 'nCells'], avgDHdt),
                      'fluxAcrossGroundingLineOnCells': (['Time', 'nCells'], avgGF),
                      'calvingFlux': (['Time', 'nCells'], avgCF),
-                     'faceMeltAndCalvingFlux': (['Time', 'nCells'], faceMeltAndCalvingFlux),
+                     'faceMeltAndCalvingFlux': (['Time', 'nCells'], avgCFandFM),
                      'iceMask':        (['Time', 'nCells'], maxIceMask),
                      'timeBndsMin': (['Time'], timeBndsMin),
                      'timeBndsMax': (['Time'], timeBndsMax),
@@ -339,7 +339,6 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
                 # is defined everywhere, but only applied on grounded ice
                 if faceMeltingThickness[t,i] > 0.0:
                     faceMeltFluxArray[t,i] = faceMeltSpeedVertAvg[t,i] * rho_i # convert to proper units
-                    continue # no need to keep searching the neighbors of this cell
     data['faceMeltAndCalvingFlux'] = faceMeltFluxArray + calvingFluxArray  # ismip6 only wants the combined fields
     print("===done facemelt flux processing!===")
 

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -295,6 +295,7 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
 
     if 'faceMeltSpeed' in data:
         faceMeltSpeed = data['faceMeltSpeed'][:, :].values
+        dHdt = data['dHdt'][:, :].values / (3600.0 * 24.0 * 365.0) # convert units to m/s
         # faceMeltSpeed is defined below the water line, but face-melting is
         # applied to the full ice thickness, so the effective speed is
         # averaged over the full thickness. Add (dHdt * deltat) to thickness
@@ -303,10 +304,12 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
         # that config_sea_level = 0, and that faceMeltSpeed is only valid for 
         # grounded cells, i.e., that bedTopography and lowerSurface are equivalent
         # (which is currently the case).
+
+        # Make an array of deltat to multiply by dHdt
+        deltat_array = np.tile(deltat,  (np.shape(dHdt)[1],1)).transpose()
         faceMeltSpeedVertAvg = faceMeltSpeed * np.abs(
-                               bedTopography / (thickness - dHdt * deltat) )
+                               bedTopography / (thickness - dHdt * deltat_array) )
         faceMeltingThickness = data['faceMeltingThickness'][:, :].values
-        dHdt = data['dHdt'][:, :].values / (3600.0 * 24.0 * 365.0) # convert units to m/s
         for t in range(time):
             if t%20 == 0:
                 print(f"    Time: {t+1} / {time}")

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -305,7 +305,7 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
         # (which is currently the case).
         faceMeltSpeedVertAvg = faceMeltSpeed * np.abs(
                                bedTopography / (thickness + dHdt * deltat) )
-        faceMeltThickness = data['faceMeltThickness'][:, :].values
+        faceMeltingThickness = data['faceMeltingThickness'][:, :].values
         for t in range(time):
             if t%20 == 0:
                 print(f"    Time: {t+1} / {time}")
@@ -317,14 +317,11 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
     
             index_cf = np.where((faceMeltSpeed[t, :] > 0.0) * (bed[:] < 0.0))[0]
             for i in index_cf:
-                ne = nEdgesOnCell[i]
-                for j in range(ne):
-                    neighborCellId = cellsOnCell[i, j] - 1
-                    # Use this cell if it has nonzero faceMeltingThickness (because faceMeltSpeed is defined everywhere,
-                    # but only applied on grounded ice) and a neighbor with zero faceMeltSpeed that is below sea level
-                    if faceMeltingThickness[t,i] > 0.0 and faceMeltSpeed[t,neighborCellId] == 0.0 and bed[neighborCellId] < 0.0:
-                        faceMeltFluxArray[t,i] = faceMeltSpeedVertAvg[t,i] * rho_i # convert to proper units
-                        continue # no need to keep searching the neighbors of this cell
+                # Use this cell if it has nonzero faceMeltingThickness because faceMeltSpeed
+                # is defined everywhere, but only applied on grounded ice
+                if faceMeltingThickness[t,i] > 0.0
+                    faceMeltFluxArray[t,i] = faceMeltSpeedVertAvg[t,i] * rho_i # convert to proper units
+                    continue # no need to keep searching the neighbors of this cell
     data['faceMeltAndCalvingFlux'] = faceMeltFluxArray + calvingFluxArray  # ismip6 only wants the combined fields
     print("===done facemelt flux processing!===")
 

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -38,6 +38,7 @@ def do_time_avg_flux_vars(input_file, output_file):
     dHdt = dataIn['dHdt'][:,:] / (3600.0 * 24.0 * 365.0) # convert units to m/s
     glFlux = dataIn['fluxAcrossGroundingLineOnCells'][:, :]
     calvingFlux = dataIn['calvingFlux'][:, :]
+    faceMeltAndCalvingFlux = dataIn['faceMeltAndCalvingFlux'][:, :]
 
     iceMask = (cellMask[:, :] & 2) / 2  # grounded: dynamic ice
 
@@ -68,6 +69,7 @@ def do_time_avg_flux_vars(input_file, output_file):
 
     avgSmb = np.zeros((len(years), nCells)) * np.nan
     avgCF = np.zeros((len(years), nCells)) * np.nan
+    avgCFandFM = np.zeros((len(years), nCells)) * np.nan
     avgBmbfl = np.zeros((len(years), nCells)) * np.nan
     avgBmbgr = np.zeros((len(years), nCells)) * np.nan
     avgDHdt = np.zeros((len(years), nCells)) * np.nan
@@ -84,6 +86,7 @@ def do_time_avg_flux_vars(input_file, output_file):
         sumYearBmb = 0
         sumYearDHdt = 0
         sumYearCF = 0
+        sumYearCFandFM = 0
         sumYearGF = 0
         sumYearBHF = 0
         sumYearTime = 0
@@ -101,6 +104,7 @@ def do_time_avg_flux_vars(input_file, output_file):
                 sumYearBmbgr = sumYearBmbgr + groundedBasalMassBalApplied[i, :] * deltat[i]
                 sumYearDHdt = sumYearDHdt + dHdt[i, :] * deltat[i]
                 sumYearCF = sumYearCF + calvingFlux[i,:] * deltat[i]
+                sumYearCFandFM = sumYearCFandFM + faceMeltAndCalvingFlux[i,:] * deltat[i]
                 sumYearGF = sumYearGF + glFlux[i, :] * deltat[i]
                 sumYearTime = sumYearTime + deltat[i]
 
@@ -114,6 +118,7 @@ def do_time_avg_flux_vars(input_file, output_file):
         avgBmbgr[j,:] = sumYearBmbgr / sumYearTime
         avgDHdt[j,:] = sumYearDHdt / sumYearTime
         avgCF[j,:] = sumYearCF / sumYearTime
+        avgCFandFM[j,:] = sumYearCFandFM / sumYearTime
         avgGF[j,:] = sumYearGF / sumYearTime
         maxIceMask[j,:] = (sumIceMask>0) # Get mask for anywhere that had ice during this year
 
@@ -128,6 +133,7 @@ def do_time_avg_flux_vars(input_file, output_file):
                      'dHdt':              (['Time', 'nCells'], avgDHdt),
                      'fluxAcrossGroundingLineOnCells': (['Time', 'nCells'], avgGF),
                      'calvingFlux': (['Time', 'nCells'], avgCF),
+                     'faceMeltAndCalvingFlux': (['Time', 'nCells'], faceMeltAndCalvingFlux),
                      'iceMask':        (['Time', 'nCells'], maxIceMask),
                      'timeBndsMin': (['Time'], timeBndsMin),
                      'timeBndsMax': (['Time'], timeBndsMax),

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -319,11 +319,8 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
         else:
             bed = np.tile(bedTopography[0,:], (np.shape(deltat)[0], 1)) # just have a single value
 
-        ice_idx = np.where( (thickness  - dHdt * deltat_array) > 0.0)  # find cells with ice
-        faceMeltSpeedVertAvg = faceMeltSpeed.copy() * 0.0
-        faceMeltSpeedVertAvg[ice_idx] = faceMeltSpeed[ice_idx] * np.abs(
-                                        bed[ice_idx] / (thickness - dHdt * deltat_array)[ice_idx] )
         faceMeltingThickness = data['faceMeltingThickness'][:, :].values
+        faceMeltSpeedVertAvg = faceMeltingThickness.copy() * 0.0
         for t in range(time):
             if t%20 == 0:
                 print(f"    Time: {t+1} / {time}")
@@ -333,8 +330,10 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
             else:
                 bed = bedTopography[0,:] # just have a single value
     
-            index_cf = np.where((faceMeltSpeed[t, :] > 0.0) * (bed[:] < 0.0))[0]
+            index_cf = np.where((faceMeltingThickness[t, :] > 0.0) * (bed[:] < 0.0))[0]
             for i in index_cf:
+                faceMeltSpeedVertAvg[t,i] = faceMeltSpeed[t, i] * np.abs(bed[i] / thickness[t-1, i])
+                faceMeltSpeedVertAvg[t,i] = min(faceMeltSpeedVertAvg[t,i], faceMeltSpeed[t, i])
                 # Use this cell if it has nonzero faceMeltingThickness because faceMeltSpeed
                 # is defined everywhere, but only applied on grounded ice
                 if faceMeltingThickness[t,i] > 0.0:

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -307,8 +307,16 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
 
         # Make an array of deltat to multiply by dHdt
         deltat_array = np.tile(deltat,  (np.shape(dHdt)[1],1)).transpose()
-        faceMeltSpeedVertAvg = faceMeltSpeed * np.abs(
-                               bedTopography / (thickness - dHdt * deltat_array) )
+
+        if 'bedTopography' in data:
+            bed = bedTopography # have value per time level
+        else:
+            bed = np.tile(bedTopography[0,:], (np.shape(deltat)[0], 1)) # just have a single value
+
+        ice_idx = np.where( (thickness  - dHdt * deltat_array) > 0.0)  # find cells with ice
+        faceMeltSpeedVertAvg = faceMeltSpeed.copy() * 0.0
+        faceMeltSpeedVertAvg[ice_idx] = faceMeltSpeed[ice_idx] * np.abs(
+                                        bed[ice_idx] / (thickness - dHdt * deltat_array)[ice_idx] )
         faceMeltingThickness = data['faceMeltingThickness'][:, :].values
         for t in range(time):
             if t%20 == 0:

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -304,7 +304,7 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
         # grounded cells, i.e., that bedTopography and lowerSurface are equivalent
         # (which is currently the case).
         faceMeltSpeedVertAvg = faceMeltSpeed * np.abs(
-                               bedTopography / (thickness + dHdt * deltat) )
+                               bedTopography / (thickness - dHdt * deltat) )
         faceMeltingThickness = data['faceMeltingThickness'][:, :].values
         dHdt = data['dHdt'][:, :].values / (3600.0 * 24.0 * 365.0) # convert units to m/s
         for t in range(time):

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -319,7 +319,7 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
             for i in index_cf:
                 # Use this cell if it has nonzero faceMeltingThickness because faceMeltSpeed
                 # is defined everywhere, but only applied on grounded ice
-                if faceMeltingThickness[t,i] > 0.0
+                if faceMeltingThickness[t,i] > 0.0:
                     faceMeltFluxArray[t,i] = faceMeltSpeedVertAvg[t,i] * rho_i # convert to proper units
                     continue # no need to keep searching the neighbors of this cell
     data['faceMeltAndCalvingFlux'] = faceMeltFluxArray + calvingFluxArray  # ismip6 only wants the combined fields

--- a/landice/output_processing_li/ismip6_postprocessing/process_state_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_state_variables.py
@@ -112,6 +112,8 @@ def write_netcdf_2d_state_vars(mali_var_name, ismip6_var_name, var_std_name,
                 mask = var_sftgrf[i, :, :]
             elif ismip6_var_name == 'litempbotfl':
                 mask = var_sftflf[i, :, :]
+            elif ismip6_var_name == 'topg':
+                mask = np.ones(var_mali.shape[1:])  # don't mask topg
             else:
                 mask = var_sftgif[i, :, :]
             tmp = var_mali[i, :, :]


### PR DESCRIPTION
This merge adds facemelting to the ismip6 output processing.  If faceMeltSpeed is not in the output file, the processing will assume it was not needed.  It also includes a modification requested by ISMIP6 to not mask the topg field by ice extent.