### PR TITLE
Fix reading of SciVisColor colormaps

### DIFF
--- a/conda_package/docs/versions.rst
+++ b/conda_package/docs/versions.rst
@@ -30,6 +30,7 @@ Documentation    On GitHub
 `v0.15.0`_        `0.15.0`_
 `v0.16.0`_        `0.16.0`_
 `v0.17.0`_        `0.17.0`_
+`v0.18.0`_        `0.18.0`_
 ================ ===============
 
 .. _`stable`: ../stable/index.html
@@ -80,3 +81,5 @@ Documentation    On GitHub
 .. _`0.16.0`: https://github.com/MPAS-Dev/MPAS-Tools/tree/0.16.0
 .. _`v0.17.0`: ../0.17.0/index.html
 .. _`0.17.0`: https://github.com/MPAS-Dev/MPAS-Tools/tree/0.17.0
+.. _`v0.18.0`: ../0.18.0/index.html
+.. _`0.18.0`: https://github.com/MPAS-Dev/MPAS-Tools/tree/0.18.0

--- a/conda_package/mpas_tools/__init__.py
+++ b/conda_package/mpas_tools/__init__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 17, 0)
+__version_info__ = (0, 18, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/conda_package/mpas_tools/viz/colormaps.py
+++ b/conda_package/mpas_tools/viz/colormaps.py
@@ -1,5 +1,9 @@
 import xml.etree.ElementTree as ET
-import pkg_resources
+try:
+    from importlib.resources import files as imp_res_files
+except ImportError:
+    # python<=3.8
+    from importlib_resources import files as imp_res_files
 from matplotlib.colors import LinearSegmentedColormap
 import matplotlib.pyplot as plt
 
@@ -14,9 +18,8 @@ def register_sci_viz_colormaps():
                     'green-7', 'green-8', 'orange-5', 'orange-6',
                     'orange-green-blue-gray', 'purple-7', 'purple-8', 'red-1',
                     'red-3', 'red-4', 'yellow-1', 'yellow-7']:
-
-        xmlFile = pkg_resources.resource_filename(
-            __name__, 'SciVisColorColormaps/{}.xml'.format(mapName))
+        xmlFile = str(imp_res_files('mpas_tools.viz.SciVisColorColormaps') /
+                      f'{mapName}.xml')
         _read_xml_colormap(xmlFile, mapName)
 
 

--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mpas_tools" %}
-{% set version = "0.17.0" %}
+{% set version = "0.18.0" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
The old approach (with `pkg_resources`) is considered to be a bad practice and was giving me trouble in `polaris`, which has `mpas_tools` as a dependency.

This merge also updates to v0.18.0 for a release