### PR TITLE
Fix flux files processing when no threshold calving cells are boundary cells

### DIFF
--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -317,6 +317,9 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
                         thresholdBoundaryLength[i] += dvEdge[edgesOnCell[i,j]-1]
             bdyIndices = np.where(thresholdBoundary == 1)[0]
             print(f"Found {len(index_cf)} cells with threshold calving at time {t}; {len(bdyIndices)} are boundary cells.")
+            if len(bdyIndices) == 0:
+                print(f"0 boundary cells were found; skipping to next time step")
+                continue
             # Now loop over all threshold cells and assign their volume to the nearest boundary cell
             for i in index_cf:
                 if thresholdBoundary[i] == 1:

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -253,7 +253,8 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
 
             prev_t = max(t-1, 0)  # ensure that index_cf never uses thickness from last (-1) time step
             index_cf = np.where((faceMeltingThickness[t, :] > 0.0) * (bed[:] < 0.0) *
-                                (faceMeltingThickness[t, :] != thickness[prev_t, :]))[0]
+                                (faceMeltingThickness[t, :] != thickness[prev_t, :]) * 
+                                (thickness[prev_t, :] > 0.))[0]
             for i in index_cf:
                 # faceMeltSpeed is calculated for ice below water line, but needs to be aplied
                 # to full ice thickness, so we need a vertically averaged speed. Also ensure that


### PR DESCRIPTION
If none of the threshold calving cells in a given time step are boundary cells, then `bdyIndices` is empty and will cause an error. In this case, just skip to the next time step.