### PR TITLE
Add a check and a warning in processing the ismip6 flux variables

### DIFF
--- a/landice/output_processing_li/ismip6_postprocessing/create_mapfile_mali_to_ismip6.py
+++ b/landice/output_processing_li/ismip6_postprocessing/create_mapfile_mali_to_ismip6.py
@@ -1,9 +1,12 @@
 from mpas_tools.scrip.from_mpas import scrip_from_mpas
 from subprocess import check_call
 import os
+import netCDF4
+import xarray as xr
 
 def build_mapping_file(mali_mesh_file,
-                       mapping_file, ismip6_grid_file=None,
+                       mapping_file, res_ismip6_grid,
+                       ismip6_grid_file=None,
                        method_remap=None):
     """
     Build a mapping file if it does not exist.
@@ -19,6 +22,8 @@ def build_mapping_file(mali_mesh_file,
     mapping_file : str
         weights for interpolation from mali_mesh_file to ismip6_grid_file
 
+    res_ismip6_grid: str
+        resolution of the ismip6 grid in kilometers
     ismip6_grid_file : str, optional
         The ISMIP6 file if mapping file does not exist
 
@@ -38,7 +43,7 @@ def build_mapping_file(mali_mesh_file,
     if method_remap is None:
         method_remap = "conserve"
 
-    ismip6_scripfile = "temp_ismip6_8km_scrip.nc"
+    ismip6_scripfile = f"temp_ismip6_{res_ismip6_grid}km_scrip.nc"
     mali_scripfile = "temp_mali_scrip.nc"
     ismip6_projection = "ais-bedmap2"
 
@@ -49,24 +54,10 @@ def build_mapping_file(mali_mesh_file,
     print(f"Creating temporary scripfiles "
           f"for ismip6 grid and mali mesh...")
 
-    args = ["create_SCRIP_file_from_planar_rectangular_grid.py",
-            "--input", ismip6_grid_file,
-            "--scrip", ismip6_scripfile,
-            "--proj", ismip6_projection,
-            "--rank", "2"]
+    # create a scripfile for ismip6 grid
+    create_atm_scrip(ismip6_grid_file, ismip6_scripfile)
 
-    check_call(args)
-
-    # create a MALI mesh scripfile if mapping file does not exist
-    # make sure the mali mesh file uses the longitude convention of [0 2pi]
-    # This should already be the case, so don't modify the input file
-    # Leaving this commented out in case it's necessary in some cases
-
-    #args = ["set_lat_lon_fields_in_planar_grid.py",
-    #        "--file", mali_mesh_file,
-    #        "--proj", ismip6_projection]
-    #check_call(args)
-
+    # create a MALI mesh scripfile
     scrip_from_mpas(mali_mesh_file, mali_scripfile)
 
     # create a mapping file using ESMF weight gen
@@ -104,3 +95,96 @@ def build_mapping_file(mali_mesh_file,
     print(f"Removing the temporary mesh and scripfiles...")
     os.remove(ismip6_scripfile)
     os.remove(mali_scripfile)
+
+
+def create_atm_scrip(source_grid_file, source_grid_scripfile):
+    """
+    create a scripfile for the ismip6 atmospheric forcing data.
+    Note: the atmospheric forcing data do not have 'x' and 'y' coordinates and
+    only have dimensions of them. This function uses 'lat' and 'lon'
+    coordinates to generate a scripfile.
+    Parameters
+    ----------
+    source_grid_file : str
+        input smb grid file
+    source_grid_scripfile : str
+        output scrip file of the input smb data
+    """
+
+    ds = xr.open_dataset(source_grid_file)
+    out_file = netCDF4.Dataset(source_grid_scripfile, 'w')
+
+    if "rlon" in ds and "rlat" in ds:  # this is for RACMO's rotated-pole grid
+        nx = ds.sizes["rlon"]
+        ny = ds.sizes["rlat"]
+    else:
+        nx = ds.sizes["x"]
+        ny = ds.sizes["y"]
+    units = "degrees"
+
+    grid_size = nx * ny
+
+    out_file.createDimension("grid_size", grid_size)
+    out_file.createDimension("grid_corners", 4)
+    out_file.createDimension("grid_rank", 2)
+
+    # Variables
+    grid_center_lat = out_file.createVariable("grid_center_lat", "f8",
+                                              ("grid_size",))
+    grid_center_lat.units = units
+    grid_center_lon = out_file.createVariable("grid_center_lon", "f8",
+                                              ("grid_size",))
+    grid_center_lon.units = units
+    grid_corner_lat = out_file.createVariable("grid_corner_lat", "f8",
+                                              ("grid_size", "grid_corners"))
+    grid_corner_lat.units = units
+    grid_corner_lon = out_file.createVariable("grid_corner_lon", "f8",
+                                              ("grid_size", "grid_corners"))
+    grid_corner_lon.units = units
+    grid_imask = out_file.createVariable("grid_imask", "i4", ("grid_size",))
+    grid_imask.units = "unitless"
+    out_file.createVariable("grid_dims", "i4", ("grid_rank",))
+
+    out_file.variables["grid_center_lat"][:] = ds.lat.values.flat
+    out_file.variables["grid_center_lon"][:] = ds.lon.values.flat
+    out_file.variables["grid_dims"][:] = [nx, ny]
+    out_file.variables["grid_imask"][:] = 1
+
+    if "lat_bnds" in ds and "lon_bnds" in ds:
+        lat_corner = ds.lat_bnds
+        if "time" in lat_corner.dims:
+            lat_corner = lat_corner.isel(time=0)
+
+        lon_corner = ds.lon_bnds
+        if "time" in lon_corner.dims:
+            lon_corner = lon_corner.isel(time=0)
+
+        lat_corner = lat_corner.values
+        lon_corner = lon_corner.values
+    else:
+        # this part is used for RACMO as it does not have lat_bnds & lon_bnds
+        lat_corner = _unwrap_corners(interp_extrap_corners_2d(ds.lat.values))
+        lon_corner = _unwrap_corners(interp_extrap_corners_2d(ds.lon.values))
+
+    grid_corner_lat = lat_corner.reshape((grid_size, 4))
+    grid_corner_lon = lon_corner.reshape((grid_size, 4))
+
+    out_file.variables["grid_corner_lat"][:] = grid_corner_lat
+    out_file.variables["grid_corner_lon"][:] = grid_corner_lon
+
+    out_file.close()
+
+
+def _unwrap_corners(in_field):
+    """
+    Turn a 2D array of corners into an array of rectangular mesh elements
+    """
+    out_field = np.zeros(((in_field.shape[0] - 1) *
+                          (in_field.shape[1] - 1), 4))
+    # corners are counterclockwise
+    out_field[:, 0] = in_field[0:-1, 0:-1].flat
+    out_field[:, 1] = in_field[0:-1, 1:].flat
+    out_field[:, 2] = in_field[1:, 1:].flat
+    out_field[:, 3] = in_field[1:, 0:-1].flat
+
+    return out_field

--- a/landice/output_processing_li/ismip6_postprocessing/create_mapfile_mali_to_ismip6.py
+++ b/landice/output_processing_li/ismip6_postprocessing/create_mapfile_mali_to_ismip6.py
@@ -24,6 +24,7 @@ def build_mapping_file(mali_mesh_file,
 
     res_ismip6_grid: str
         resolution of the ismip6 grid in kilometers
+
     ismip6_grid_file : str, optional
         The ISMIP6 file if mapping file does not exist
 
@@ -55,7 +56,13 @@ def build_mapping_file(mali_mesh_file,
           f"for ismip6 grid and mali mesh...")
 
     # create a scripfile for ismip6 grid
-    create_atm_scrip(ismip6_grid_file, ismip6_scripfile)
+    args = ["create_SCRIP_file_from_planar_rectangular_grid.py",
+            "--input", ismip6_grid_file,
+            "--scrip", ismip6_scripfile,
+            "--proj", ismip6_projection,
+            "--rank", "2"]
+
+    check_call(args)
 
     # create a MALI mesh scripfile
     scrip_from_mpas(mali_mesh_file, mali_scripfile)
@@ -95,96 +102,3 @@ def build_mapping_file(mali_mesh_file,
     print(f"Removing the temporary mesh and scripfiles...")
     os.remove(ismip6_scripfile)
     os.remove(mali_scripfile)
-
-
-def create_atm_scrip(source_grid_file, source_grid_scripfile):
-    """
-    create a scripfile for the ismip6 atmospheric forcing data.
-    Note: the atmospheric forcing data do not have 'x' and 'y' coordinates and
-    only have dimensions of them. This function uses 'lat' and 'lon'
-    coordinates to generate a scripfile.
-    Parameters
-    ----------
-    source_grid_file : str
-        input smb grid file
-    source_grid_scripfile : str
-        output scrip file of the input smb data
-    """
-
-    ds = xr.open_dataset(source_grid_file)
-    out_file = netCDF4.Dataset(source_grid_scripfile, 'w')
-
-    if "rlon" in ds and "rlat" in ds:  # this is for RACMO's rotated-pole grid
-        nx = ds.sizes["rlon"]
-        ny = ds.sizes["rlat"]
-    else:
-        nx = ds.sizes["x"]
-        ny = ds.sizes["y"]
-    units = "degrees"
-
-    grid_size = nx * ny
-
-    out_file.createDimension("grid_size", grid_size)
-    out_file.createDimension("grid_corners", 4)
-    out_file.createDimension("grid_rank", 2)
-
-    # Variables
-    grid_center_lat = out_file.createVariable("grid_center_lat", "f8",
-                                              ("grid_size",))
-    grid_center_lat.units = units
-    grid_center_lon = out_file.createVariable("grid_center_lon", "f8",
-                                              ("grid_size",))
-    grid_center_lon.units = units
-    grid_corner_lat = out_file.createVariable("grid_corner_lat", "f8",
-                                              ("grid_size", "grid_corners"))
-    grid_corner_lat.units = units
-    grid_corner_lon = out_file.createVariable("grid_corner_lon", "f8",
-                                              ("grid_size", "grid_corners"))
-    grid_corner_lon.units = units
-    grid_imask = out_file.createVariable("grid_imask", "i4", ("grid_size",))
-    grid_imask.units = "unitless"
-    out_file.createVariable("grid_dims", "i4", ("grid_rank",))
-
-    out_file.variables["grid_center_lat"][:] = ds.lat.values.flat
-    out_file.variables["grid_center_lon"][:] = ds.lon.values.flat
-    out_file.variables["grid_dims"][:] = [nx, ny]
-    out_file.variables["grid_imask"][:] = 1
-
-    if "lat_bnds" in ds and "lon_bnds" in ds:
-        lat_corner = ds.lat_bnds
-        if "time" in lat_corner.dims:
-            lat_corner = lat_corner.isel(time=0)
-
-        lon_corner = ds.lon_bnds
-        if "time" in lon_corner.dims:
-            lon_corner = lon_corner.isel(time=0)
-
-        lat_corner = lat_corner.values
-        lon_corner = lon_corner.values
-    else:
-        # this part is used for RACMO as it does not have lat_bnds & lon_bnds
-        lat_corner = _unwrap_corners(interp_extrap_corners_2d(ds.lat.values))
-        lon_corner = _unwrap_corners(interp_extrap_corners_2d(ds.lon.values))
-
-    grid_corner_lat = lat_corner.reshape((grid_size, 4))
-    grid_corner_lon = lon_corner.reshape((grid_size, 4))
-
-    out_file.variables["grid_corner_lat"][:] = grid_corner_lat
-    out_file.variables["grid_corner_lon"][:] = grid_corner_lon
-
-    out_file.close()
-
-
-def _unwrap_corners(in_field):
-    """
-    Turn a 2D array of corners into an array of rectangular mesh elements
-    """
-    out_field = np.zeros(((in_field.shape[0] - 1) *
-                          (in_field.shape[1] - 1), 4))
-    # corners are counterclockwise
-    out_field[:, 0] = in_field[0:-1, 0:-1].flat
-    out_field[:, 1] = in_field[0:-1, 1:].flat
-    out_field[:, 2] = in_field[1:, 1:].flat
-    out_field[:, 3] = in_field[1:, 0:-1].flat
-
-    return out_field

--- a/landice/output_processing_li/ismip6_postprocessing/post_process_mali_to_ismip6.py
+++ b/landice/output_processing_li/ismip6_postprocessing/post_process_mali_to_ismip6.py
@@ -61,10 +61,10 @@ def main():
     data_ismip6 = Dataset(args.ismip6_grid_file, "r")
     if 'x' and 'y' in data_ismip6.variables:
         ismip6_grid_file = args.ismip6_grid_file
-        print("'x' and 'y' coordinates exist in the file. Moving on...")
+        print("'x' and 'y' coordinates exist in the file.")
     else:
         print("'x' and 'y' coordinates don't exist in the file.")
-        print("Creating a copy file with them ...")
+        print("Creating them and a copy file of the ismip6 grid file...")
         copy_ismip6_file = f"temp_{os.path.basename(args.ismip6_grid_file)}"
         shutil.copy2(args.ismip6_grid_file, copy_ismip6_file)
         copy_ismip6_file = Dataset(copy_ismip6_file, "r+", format="netCDF4")
@@ -87,16 +87,6 @@ def main():
         for i in range(ny):
             y[i] = var_y[i]
 
-        # check the lower left and upper right corners of the grid
-        print("Checking grid corners...")
-        if not x[0] == -3040000 or not y[0] == -3040000:
-            raise ValueError(f"The lower left corner values must be at "
-                             f"-3040000m and -3040000m. But the values are at "
-                             f"{int(x[0])}m and {int(y[0])}m.")
-        elif not x[-1] == 3040000 or not y[-1] == 3040000:
-            raise ValueError(f"The upper right corner values must be at "
-                             f"3040000m and 3040000m. But the values are at "
-                             f"{x[-1]}m and {y[-1]}m.")
         x.units = 'm'
         x.standard_name = 'x'
         y.units = 'm'
@@ -105,6 +95,28 @@ def main():
         copy_ismip6_file.close()
         ismip6_grid_file = f"temp_{os.path.basename(args.ismip6_grid_file)}"
         temp_ismip6_grid_file = True
+
+    # check the lower left and upper right corners of the ismip6 grid
+    print("Checking the grid corners...")
+    data_ismip6 = Dataset(ismip6_grid_file, "r")
+    x = data_ismip6.variables["x"]
+    y = data_ismip6.variables["y"]
+    if not x[0] == -3040000 or not y[0] == -3040000:
+        raise ValueError(f"The lower left corner values must be at "
+                         f"-3040000m and -3040000m. But the values are at "
+                         f"{x[0]}m and {y[0]}m. Check the value you "
+                         f"provided for '--res' matches with the resolution of "
+                         f"the MALI output files. ")
+    elif not x[-1] == 3040000 or not y[-1] == 3040000:
+        raise ValueError(f"The upper right corner values must be at "
+                         f"3040000m and 3040000m. But the values are at "
+                         f"{x[-1]}m and {y[-1]}m. Check the value you "
+                         f"provided for '--res' matches with the resolution of "
+                         f"the MALI output files. ")
+    else:
+        print(f"Grid corners are as ismip6-required: "
+              f"lower right corner values at {x[0]}m and {y[0]}m, and "
+              f"upper right corner values at {x[-1]}m and {y[-1]}m")
 
     print("\n---Processing remapping file---")
     # Only do remapping steps if we have 2d files to process

--- a/landice/output_processing_li/ismip6_postprocessing/post_process_mali_to_ismip6.py
+++ b/landice/output_processing_li/ismip6_postprocessing/post_process_mali_to_ismip6.py
@@ -50,7 +50,9 @@ def main():
     parser.add_argument("--method", dest="method_remap", default="conserve",
                         required=False,
                         help="mapping method. Default='conserve'")
-
+    parser.add_argument("--res", dest="res_ismip6_grid",
+                        required=True,
+                        help="resolution of the ismip6 grid, (e.g. 8 for 8km res)")
     args = parser.parse_args()
 
     print("\n---Processing remapping file---")
@@ -68,13 +70,15 @@ def main():
             else:
                 method_remap = args.method_remap
 
-            mapping_file = f"map_{args.mali_mesh_name}_to_ismip6_8km_" \
-                           f"{method_remap}.nc"
+            mapping_file = f"map_{args.mali_mesh_name}_to_"\
+                           f"ismip6_{args.res_ismip6_grid}km_{method_remap}.nc"
 
             print(f"Creating new mapping file."
                   f"Mapping method used: {method_remap}")
+
             build_mapping_file(args.input_file_grid, mapping_file,
-                               args.ismip6_grid_file, method_remap)
+                               args.res_ismip6_grid, args.ismip6_grid_file,
+                               method_remap)
 
     print("---Processing remapping file complete---\n")
 
@@ -111,7 +115,8 @@ def main():
 
         # write out 2D state output files in the ismip6-required format
         print("Writing processed and remapped state fields to ISMIP6 file format.")
-        generate_output_2d_state_vars(processed_and_remapped_file_state, args.ismip6_grid_file,
+        generate_output_2d_state_vars(processed_and_remapped_file_state,
+                                      args.res_ismip6_grid, args.ismip6_grid_file,
                                       args.exp, output_path)
 
         os.remove(tmp_file)
@@ -152,6 +157,7 @@ def main():
 
         # write out the output files in the ismip6-required format
         generate_output_2d_flux_vars(processed_file_flux,
+                                     args.res_ismip6_grid,
                                      args.ismip6_grid_file,
                                      args.exp, output_path)
 

--- a/landice/output_processing_li/ismip6_postprocessing/post_process_mali_to_ismip6.py
+++ b/landice/output_processing_li/ismip6_postprocessing/post_process_mali_to_ismip6.py
@@ -179,7 +179,7 @@ def main():
         # write out 2D state output files in the ismip6-required format
         print("Writing processed and remapped state fields to ISMIP6 file format.")
         generate_output_2d_state_vars(processed_and_remapped_file_state,
-                                      args.res_ismip6_grid, ismip6_grid_file,
+                                      ismip6_grid_file,
                                       args.exp, output_path)
 
         os.remove(tmp_file)
@@ -220,7 +220,6 @@ def main():
 
         # write out the output files in the ismip6-required format
         generate_output_2d_flux_vars(processed_file_flux,
-                                     args.res_ismip6_grid,
                                      ismip6_grid_file,
                                      args.exp, output_path)
 

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -361,8 +361,7 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
 
 def write_netcdf_2d_flux_vars(mali_var_name, ismip6_var_name, var_std_name,
                               var_units, var_varname, remapped_mali_flux_file,
-                              res_ismip6_grid, ismip6_grid_file,
-                              exp, output_path):
+                              ismip6_grid_file, exp, output_path):
 
     """
     mali_var_name: variable name on MALI side
@@ -371,7 +370,6 @@ def write_netcdf_2d_flux_vars(mali_var_name, ismip6_var_name, var_std_name,
     var_units: variable units
     var_varname: variable variable name
     remapped_mali_flux_file: mali flux file remapped on the ISMIP6 grid
-    res_ismip6_grid: resolution of the ISMIP6 grid in kilometers
     ismip6_grid_file: original ISMIP6 file
     exp: experiment name
     output_path: output path to which the output files will be saved
@@ -451,13 +449,12 @@ def write_netcdf_2d_flux_vars(mali_var_name, ismip6_var_name, var_std_name,
     data.close()
 
 
-def generate_output_2d_flux_vars(file_remapped_mali_flux, res_ismip6_grid,
+def generate_output_2d_flux_vars(file_remapped_mali_flux,
                                  ismip6_grid_file, exp, output_path):
     """
     file_remapped_mali_flux: flux output file on mali mesh remapped
     onto the ismip6 grid
     ismip6 grid
-    res_ismip6_grid: ismip6 grid resolution in kilometers
     ismip6_grid_file: ismip6 original file
     exp: ISMIP6 experiment name
     output_path: path to which the final output files are saved
@@ -468,7 +465,7 @@ def generate_output_2d_flux_vars(file_remapped_mali_flux, res_ismip6_grid,
     write_netcdf_2d_flux_vars('sfcMassBalApplied', 'acabf',
                               'land_ice_surface_specific_mass_balance_flux',
                               'kg m-2 s-1', 'Surface mass balance flux',
-                              file_remapped_mali_flux, res_ismip6_grid,
+                              file_remapped_mali_flux,
                               ismip6_grid_file, exp, output_path)
 
     # ----------- libmassbffl ------------------
@@ -476,7 +473,7 @@ def generate_output_2d_flux_vars(file_remapped_mali_flux, res_ismip6_grid,
                               'land_ice_basal_specific_mass_balance_flux',
                               'kg m-2 s-1',
                               'Basal mass balance flux beneath floating ice',
-                              file_remapped_mali_flux, res_ismip6_grid,
+                              file_remapped_mali_flux,
                               ismip6_grid_file, exp, output_path)
 
     # ----------- libmassbfgr ------------------
@@ -484,7 +481,7 @@ def generate_output_2d_flux_vars(file_remapped_mali_flux, res_ismip6_grid,
                               'land_ice_basal_specific_mass_balance_flux',
                               'kg m-2 s-1',
                               'Basal mass balance flux beneath grounded ice',
-                              file_remapped_mali_flux, res_ismip6_grid,
+                              file_remapped_mali_flux,
                               ismip6_grid_file, exp, output_path)
 
     # ----------- dlithkdt ------------------
@@ -492,7 +489,7 @@ def generate_output_2d_flux_vars(file_remapped_mali_flux, res_ismip6_grid,
                               'tendency_of_land_ice_thickness',
                               'm s-1',
                               'Ice thickness imbalance',
-                              file_remapped_mali_flux, res_ismip6_grid,
+                              file_remapped_mali_flux,
                               ismip6_grid_file, exp, output_path)
 
     # ----------- licalvf ------------------
@@ -500,7 +497,7 @@ def generate_output_2d_flux_vars(file_remapped_mali_flux, res_ismip6_grid,
                               'land_ice_specific_mass_flux_due_to_calving',
                               'kg m-2 s-1',
                               'Calving flux',
-                              file_remapped_mali_flux, res_ismip6_grid,
+                              file_remapped_mali_flux,
                               ismip6_grid_file, exp, output_path)
 
     # ----------- lifmassbf ------------------
@@ -509,7 +506,7 @@ def generate_output_2d_flux_vars(file_remapped_mali_flux, res_ismip6_grid,
                               'land_ice_specific_mass_flux_due_to_calving_and_ice_front_melting',
                               'kg m-2 s-1',
                               'Ice front melt and calving flux',
-                              file_remapped_mali_flux, res_ismip6_grid,
+                              file_remapped_mali_flux,
                               ismip6_grid_file, exp, output_path)
 
     # ----------- ligroundf ------------------
@@ -517,5 +514,5 @@ def generate_output_2d_flux_vars(file_remapped_mali_flux, res_ismip6_grid,
                               'land_ice_specific_mass_flux_at_grounding_line',
                               'kg m-2 s-1',
                               'Grounding line flux',
-                              file_remapped_mali_flux, res_ismip6_grid,
+                              file_remapped_mali_flux,
                               ismip6_grid_file, exp, output_path)

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -378,22 +378,9 @@ def write_netcdf_2d_flux_vars(mali_var_name, ismip6_var_name, var_std_name,
     output_path: output path to which the output files will be saved
     """
 
-
     data_ismip6 = Dataset(ismip6_grid_file, 'r')
-    if 'x' and 'y' in data_ismip6.variables:
-        var_x = data_ismip6.variables['x'][:]
-        var_y = data_ismip6.variables['y'][:]
-    else:
-        nx = data_ismip6.dimensions['x'].size
-        ny = data_ismip6.dimensions['y'].size
-        dx = int(res_ismip6_grid)*1000
-        dy = dx
-        if (nx % 2) == 0:
-           var_x = dx*((np.arange(-nx/2, nx/2)) + 0.5)
-           var_y = dy*((np.arange(-ny/2, ny/2)) + 0.5)
-        else:
-           var_x = dx*((np.arange(-(nx-1)/2, (nx+1)/2)))
-           var_y = dy*((np.arange(-(ny-1)/2, (ny+1)/2)))
+    var_x = data_ismip6.variables['x'][:]
+    var_y = data_ismip6.variables['y'][:]
 
     data = Dataset(remapped_mali_flux_file, 'r')
     data.set_auto_mask(False)

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -157,6 +157,7 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
     licalvf and apply bounds checking on BMB, where some crazy values occasionally occur.
     """
 
+    debug_face_melt_flux = False
     data = xr.open_dataset(file_input, decode_cf=False) # need decode_cf=False to prevent xarray from reading daysSinceStart as a timedelta type.
     if 'units' in data.daysSinceStart.attrs:
         del data.daysSinceStart.attrs['units'] # need this line to prevent xarray from reading daysSinceStart as a timedelta type.
@@ -239,7 +240,6 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
         faceMeltingThickness = data['faceMeltingThickness'][:, :].values
         faceMeltSpeedVertAvg = faceMeltingThickness.copy() * 0.0
         # Fields for validation and debugging
-        debug_face_melt_flux = False
         if debug_face_melt_flux:
             deltat_array = np.tile(deltat,  (np.shape(faceMeltSpeed)[1],1)).transpose()
             # Cleaned field for debugging and validation
@@ -333,7 +333,7 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
                 thresholdBoundarySummedThickness[ownerIdx] += calvingThicknessFromThreshold[t,i]
                 thresholdBoundaryContributors[ownerIdx] += 1
             #print(thresholdBoundaryAssignedVolume.sum(), (calvingThicknessFromThreshold[t,:]*areaCell[:]).sum())
-            diff = np.absolute(thresholdBoundaryAssignedVolume.sum() - (calvingThicknessFromThreshold[t,:]*areaCell[:]).sum()) < 1.0
+            diff = np.absolute(thresholdBoundaryAssignedVolume.sum() - (calvingThicknessFromThreshold[t,:]*areaCell[:]).sum())
             if diff < 1.0:
                 warnings.warn(f"Difference between assigned `thresholdBoundaryAssignedVolume` value and "
                               f"`calvingThicknessFromThreshold` threshold value is less than 1: {diff} < 1.0")
@@ -352,7 +352,6 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
     data['thresholdFlux'] = thresholdFlux  # this is just written for diagnostic purposes.  It's not actually sent to ISMIP6.
     data['faceMeltAndCalvingFlux'] = faceMeltFluxArray + calvingFluxArray  # ismip6 only wants the combined fields for face-melt
     print("===done calving flux processing!===")
-    debug_face_melt_flux = False
     if debug_face_melt_flux:
         print('debug_face_melt_flux is True, so I assume you want a breakpoint' +
               ' to check fluxes. Just type continue when you want to proceed.')

--- a/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_flux_variables.py
@@ -335,7 +335,8 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
             #print(thresholdBoundaryAssignedVolume.sum(), (calvingThicknessFromThreshold[t,:]*areaCell[:]).sum())
             diff = np.absolute(thresholdBoundaryAssignedVolume.sum() - (calvingThicknessFromThreshold[t,:]*areaCell[:]).sum()) < 1.0
             if diff < 1.0:
-                warnings.warn(f"Difference between assigned value and threshold {diff} < 1.0")
+                warnings.warn(f"Difference between assigned `thresholdBoundaryAssignedVolume` value and "
+                              f"`calvingThicknessFromThreshold` threshold value is less than 1: {diff} < 1.0")
             #for i in bdyIndices:
                 #print(f"length={thresholdBoundaryLength[i]}, vol={thresholdBoundaryAssignedVolume[i]}, sumthk={thresholdBoundarySummedThickness[i]}, num={thresholdBoundaryContributors[i]}, meanthk={thresholdBoundarySummedThickness[i]/thresholdBoundaryContributors[i]}")
             # Finally calculate licalvf for each boundary cell and add to whatever was already there
@@ -351,6 +352,7 @@ def clean_flux_fields_before_time_averaging(file_input, file_mesh,
     data['thresholdFlux'] = thresholdFlux  # this is just written for diagnostic purposes.  It's not actually sent to ISMIP6.
     data['faceMeltAndCalvingFlux'] = faceMeltFluxArray + calvingFluxArray  # ismip6 only wants the combined fields for face-melt
     print("===done calving flux processing!===")
+    debug_face_melt_flux = False
     if debug_face_melt_flux:
         print('debug_face_melt_flux is True, so I assume you want a breakpoint' +
               ' to check fluxes. Just type continue when you want to proceed.')

--- a/landice/output_processing_li/ismip6_postprocessing/process_state_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_state_variables.py
@@ -76,21 +76,8 @@ def write_netcdf_2d_state_vars(mali_var_name, ismip6_var_name, var_std_name,
     """
 
     data_ismip6 = Dataset(ismip6_grid_file, 'r')
-
-    if 'x' and 'y' in data_ismip6.variables:
-        var_x = data_ismip6.variables['x'][:]
-        var_y = data_ismip6.variables['y'][:]
-    else:
-        nx = data_ismip6.dimensions['x'].size
-        ny = data_ismip6.dimensions['y'].size
-        dx = int(res_ismip6_grid)*1000
-        dy = dx
-        if (nx % 2) == 0:
-           var_x = dx*((np.arange(-nx/2, nx/2)) + 0.5)
-           var_y = dy*((np.arange(-ny/2, ny/2)) + 0.5)
-        else:
-           var_x = dx*((np.arange(-(nx-1)/2, (nx+1)/2)))
-           var_y = dy*((np.arange(-(ny-1)/2, (ny+1)/2)))
+    var_x = data_ismip6.variables['x'][:]
+    var_y = data_ismip6.variables['y'][:]
 
     data = Dataset(remapped_mali_outputfile, 'r')
     data.set_auto_mask(False)

--- a/landice/output_processing_li/ismip6_postprocessing/process_state_variables.py
+++ b/landice/output_processing_li/ismip6_postprocessing/process_state_variables.py
@@ -60,8 +60,7 @@ def process_state_vars(inputfile_state, tmp_file):
 
 def write_netcdf_2d_state_vars(mali_var_name, ismip6_var_name, var_std_name,
                                var_units, var_varname, remapped_mali_outputfile,
-                               res_ismip6_grid, ismip6_grid_file,
-                               exp, output_path):
+                               ismip6_grid_file, exp, output_path):
     """
     mali_var_name: variable name on MALI side
     ismip6_var_name: variable name required by ISMIP6
@@ -69,7 +68,6 @@ def write_netcdf_2d_state_vars(mali_var_name, ismip6_var_name, var_std_name,
     var_units: variable units
     var_varname: variable variable name
     remapped_mali_outputfile: mali state file remapped on the ISMIP6 grid
-    res_ismip6_grid: resolution of the ISMIP6 grid in kilometers
     ismip6_grid_file: original ISMIP6 file
     exp: experiment name
     output_path: output path to which the output files will be saved
@@ -147,12 +145,11 @@ def write_netcdf_2d_state_vars(mali_var_name, ismip6_var_name, var_std_name,
     dataOut.close()
 
 
-def generate_output_2d_state_vars(file_remapped_mali_state, res_ismip6_grid,
+def generate_output_2d_state_vars(file_remapped_mali_state,
                                   ismip6_grid_file, exp, output_path):
     """
     file_remapped_mali_state: output files on mali mesh remapped
     on the ismip6 grid
-    res_ismip6_grid: ismip6 grid resolution in kilometers
     ismip6_grid_file: ismip6 original file
     exp: ISMIP6 experiment name
     output_path: path to which the final output files are saved
@@ -162,25 +159,25 @@ def generate_output_2d_state_vars(file_remapped_mali_state, res_ismip6_grid,
     # ----------- lithk ------------------
     write_netcdf_2d_state_vars('thickness','lithk', 'land_ice_thickness',
                                'm', 'Ice thickness',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- orog ------------------
     write_netcdf_2d_state_vars('upperSurface','orog', 'surface_altitude', 'm',
                                'Surface elevation',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file,exp, output_path)
 
     # ----------- base ------------------
     write_netcdf_2d_state_vars('lowerSurface','base', 'base_altitude', 'm',
                                'Base elevation',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- topg ------------------
     write_netcdf_2d_state_vars('bedTopography','topg', 'bedrock_altitude', 'm',
                                'Bedrock elevation',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- hfgeoubed------------------
@@ -196,28 +193,28 @@ def generate_output_2d_state_vars(file_remapped_mali_state, res_ismip6_grid,
     write_netcdf_2d_state_vars('uReconstructX_sfc', 'xvelsurf',
                                'land_ice_surface_x_velocity',
                                'm s-1', 'Surface velocity in x',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # -----------yxvelsurf ------------------
     write_netcdf_2d_state_vars('uReconstructY_sfc', 'yvelsurf',
                                'land_ice_surface_y_velocity',
                                'm s-1', 'Surface velocity in x',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- xvelbase ------------------
     write_netcdf_2d_state_vars('uReconstructX_base', 'xvelbase',
                                'land_ice_basal_x_velocity',
                                'm s-1', 'Basal velocity in x',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- yvelbase ------------------
     write_netcdf_2d_state_vars('uReconstructY_base', 'yvelbase',
                                'land_ice_basal_y_velocity',
                                'm s-1', 'Basal velocity in y',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- zvelsurf & zvelbase ------------------
@@ -228,63 +225,63 @@ def generate_output_2d_state_vars(file_remapped_mali_state, res_ismip6_grid,
     write_netcdf_2d_state_vars('xvelmean', 'xvelmean',
                                'land_ice_vertical_mean_x_velocity',
                                'm s-1', 'Mean velocity in x',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- yvelmean ------------------
     write_netcdf_2d_state_vars('yvelmean', 'yvelmean',
                                'land_ice_vertical_mean_y_velocity',
                                'm s-1', 'Mean velocity in y',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- litemptop ------------------
     write_netcdf_2d_state_vars('surfaceTemperature', 'litemptop',
                                'temperature_at_top_of_ice_sheet_model', 'K',
                                'Surface temperature',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- litempbotgr ------------------
     write_netcdf_2d_state_vars('litempbotgr', 'litempbotgr',
                                'temperature_at_base_of_ice_sheet_model', 'K',
                                'Basal temperature beneath grounded ice sheet',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file,exp, output_path)
 
     # ----------- litempbotfl ------------------
     write_netcdf_2d_state_vars('litempbotfl', 'litempbotfl',
                                'temperature_at_base_of_ice_sheet_model', 'K',
                                'Basal temperature beneath floating ice shelf',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- strbasemag ------------------
     write_netcdf_2d_state_vars('strbasemag', 'strbasemag',
                                'land_ice_basal_drag ', 'Pa',
                                'Basal drag',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- sftgif ------------------
     write_netcdf_2d_state_vars('sftgif','sftgif',
                                'land_ice_area_fraction', '1',
                                'Land ice area fraction',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- sftgrf ------------------
     write_netcdf_2d_state_vars('sftgrf', 'sftgrf',
                                'grounded_ice_sheet_area_fraction', '1',
                                'Grounded ice sheet area fraction',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
     # ----------- sftflf ------------------
     write_netcdf_2d_state_vars('sftflf','sftflf',
                                'floating_ice_shelf_area_fraction', '1',
                                'Floating ice shelf area fraction',
-                               file_remapped_mali_state, res_ismip6_grid,
+                               file_remapped_mali_state,
                                ismip6_grid_file, exp, output_path)
 
 


### PR DESCRIPTION
This PR adds a check for the 'units' attribute in daysSinceStart because without the check for the 'units' attribute, the processing fails when processing output files that have been cleaned up for the time loop issues. The PR also 1) modifies the functions for generating ismip6 grid scripfile and writing 2d flux and state files to account for cases when `x` and `y` polar coordinate variables are missing in the ismip6 grid files, and 2) add a warning statement on differences between the assigned volume and threshold cells. 