### PR TITLE
Allow external mapping file for sea-ice partitioning

### DIFF
--- a/conda_package/mpas_tools/seaice/partition.py
+++ b/conda_package/mpas_tools/seaice/partition.py
@@ -189,16 +189,26 @@ def prepare_partitions():
     """
     # parsing input
     parser = argparse.ArgumentParser(
-        description='Perform preparatory work for making seaice partitions.')
+        description="Perform preparatory work for making seaice partitions.")
 
-    parser.add_argument('-i', '--inputmesh', dest="meshFilenameSrc", required=True,
-                        help='MPAS mesh file for source regridding mesh.')
-    parser.add_argument('-p', '--presence', dest="filenameData", required=True,
-                        help='Input ice presence file for source mesh.')
-    parser.add_argument('-m', '--outputmesh', dest="meshFilenameDst", required=True,
-                        help='MPAS mesh file for destination regridding mesh.')
-    parser.add_argument('-o', '--outputDir', dest="outputDir", required=True,
-                        help='Output directory for temporary files and partition files.')
+    parser.add_argument("-i", "--inputmesh", dest="meshFilenameSrc",
+                        required=True,
+                        help="MPAS mesh file for source regridding mesh.")
+    parser.add_argument("-p", "--presence", dest="filenameData",
+                        required=True,
+                        help="Input ice presence file for source mesh.")
+    parser.add_argument("-m", "--outputmesh", dest="meshFilenameDst",
+                        required=True,
+                        help="MPAS mesh file for destination regridding mesh.")
+    parser.add_argument("-o", "--outputDir", dest="outputDir",
+                        required=True,
+                        help="Output directory for temporary files and "
+                             "partition files.")
+    parser.add_argument("-w", "--weightsFilename", dest="weightsFilename",
+                        required=False,
+                        help="A mapping file between the input and output "
+                             "MPAS meshes.  One will be generated if it is "
+                             "not supplied.")
 
     args = parser.parse_args()
 
@@ -209,11 +219,14 @@ def prepare_partitions():
     # 1) Regrid the ice presence from the input data mesh to the grid of choice
     print("Regrid to desired mesh...")
     filenameOut = args.outputDir + "/icePresent_regrid.nc"
+
     regrid_to_other_mesh(
-        args.meshFilenameSrc,
-        args.filenameData,
-        args.meshFilenameDst,
-        filenameOut)
+        meshFilenameSrc=args.meshFilenameSrc,
+        filenameData=args.filenameData,
+        meshFilenameDst=args.meshFilenameDst,
+        filenameOut=filenameOut,
+        generateWeights=(args.weightsFilename is None),
+        weightsFilename=args.weightsFilename)
 
     # 2) create icePresence variable
     print("fix_regrid_output...")

--- a/conda_package/mpas_tools/seaice/regrid.py
+++ b/conda_package/mpas_tools/seaice/regrid.py
@@ -9,7 +9,8 @@ from .mesh import make_mpas_scripfile_on_cells
 
 
 def regrid_to_other_mesh(meshFilenameSrc, filenameData,
-                         meshFilenameDst, filenameOut):
+                         meshFilenameDst, filenameOut,
+                         generateWeights=True, weightsFilename=None):
 
     # make scrip files
     print("Make scrip files...")
@@ -22,11 +23,16 @@ def regrid_to_other_mesh(meshFilenameSrc, filenameData,
     make_mpas_scripfile_on_cells(meshFilenameSrc, SCRIPFilenameSrc, titleSrc)
     make_mpas_scripfile_on_cells(meshFilenameDst, SCRIPFilenameDst, titleDst)
 
-    # generate weights file
-    print("Generate weights...")
-    weightsFilename = os.getcwd() + "/weights_tmp.nc"
-    _generate_weights_file(SCRIPFilenameSrc, SCRIPFilenameDst,
-                           weightsFilename, reuseWeights=False)
+    if weightsFilename is None:
+        weightsFilename = os.getcwd() + "/weights_tmp.nc"
+
+    if generateWeights:
+        # generate weights file
+        print("Generate weights...")
+        _generate_weights_file(SCRIPFilenameSrc, SCRIPFilenameDst,
+                               weightsFilename, reuseWeights=False)
+    else:
+        assert os.path.exists(weightsFilename)
 
     # load output mesh
     print("Load output mesh...")


### PR DESCRIPTION
This allows us to generat the mapping file externally if needed (e.g. if calling ESMF requires a parallel executable like `srun` and if we want to use MPI parallelism).

closes #497 