### PR TITLE
Break out Vector class in its own module

### DIFF
--- a/conda_package/mpas_tools/tests/test_transects.py
+++ b/conda_package/mpas_tools/tests/test_transects.py
@@ -3,9 +3,14 @@
 import numpy as np
 
 from mpas_tools.cime.constants import constants
-from mpas_tools.transects import subdivide_great_circle, \
-    cartesian_to_great_circle_distance, subdivide_planar, \
-    lon_lat_to_cartesian, angular_distance, intersects, intersection, Vector
+from mpas_tools.transects import (
+    angular_distance,
+    cartesian_to_great_circle_distance,
+    lon_lat_to_cartesian,
+    subdivide_great_circle,
+    subdivide_planar
+)
+from mpas_tools.vector import Vector
 
 
 def test_subdivide_great_circle():
@@ -41,7 +46,7 @@ def test_angular_distance_first_second():
     ang_dist1 = angular_distance(x=x, y=y, z=z)
     first = Vector(x[0:-1], y[0:-1], z[0:-1])
     second = Vector(x[1:], y[1:], z[1:])
-    ang_dist2 = angular_distance(first=first, second=second)
+    ang_dist2 = first.angular_distance(second)
     assert np.all(ang_dist1 == ang_dist2)
 
 
@@ -50,7 +55,7 @@ def test_intersects_scalar():
     a2 = _lon_lat_to_vector(10., 10.)
     b1 = _lon_lat_to_vector(-10., 10.)
     b2 = _lon_lat_to_vector(10., -10.)
-    assert intersects(a1, a2, b1, b2)
+    assert Vector.intersects(a1, a2, b1, b2)
 
 
 def test_intersects_array():
@@ -58,7 +63,7 @@ def test_intersects_array():
     a2 = _lon_lat_to_vector(np.array([-5., 10.]), np.array([-5., 10.]))
     b1 = _lon_lat_to_vector(-10., 10.)
     b2 = _lon_lat_to_vector(10., -10.)
-    result = intersects(a1, a2, b1, b2)
+    result = Vector.intersects(a1, a2, b1, b2)
     assert np.all(result == np.array([False, True]))
 
 
@@ -69,7 +74,7 @@ def test_intersection_scalar():
     b2 = _lon_lat_to_vector(10., -10.)
     earth_radius = constants['SHR_CONST_REARTH']
     cross = _lon_lat_to_vector(0., 0.)
-    point = intersection(a1, a2, b1, b2)
+    point = Vector.intersection(a1, a2, b1, b2)
     assert np.all(np.isclose(
         [earth_radius*point.x, earth_radius*point.y, earth_radius*point.z],
         [cross.x, cross.y, cross.z]))
@@ -82,7 +87,7 @@ def test_intersection_array():
     b2 = _lon_lat_to_vector(10., -10.)
     earth_radius = constants['SHR_CONST_REARTH']
     cross = _lon_lat_to_vector(0., 0.)
-    point = intersection(a1, a2, b1, b2)
+    point = Vector.intersection(a1, a2, b1, b2)
     assert np.all(np.isclose(
         [earth_radius*point.x[0], earth_radius*point.y[0],
          earth_radius*point.z[0]],

--- a/conda_package/mpas_tools/vector.py
+++ b/conda_package/mpas_tools/vector.py
@@ -1,0 +1,234 @@
+import numpy as np
+
+
+class Vector:
+    """
+    A class for representing Cartesian vectors with ``x``, ``y`` and ``z``
+    components that are either ``float`` or ``numpy.array`` objects of
+    identical size.
+
+    Attributes
+    ----------
+    x : float or numpy.ndarray
+        The x component(s)
+
+    y : float or numpy.ndarray
+        The y component(s)
+
+    z : float or numpy.ndarray
+        The z component(s)
+    """
+    def __init__(self, x, y, z):
+        """
+        A class for representing Cartesian vectors with ``x``, ``y`` and ``z``
+        components that are either ``float`` or ``numpy.array`` objects of
+        identical size.
+
+        Parameters
+        ----------
+        x : float or numpy.ndarray
+            The x component(s)
+
+        y : float or numpy.ndarray
+            The y component(s)
+
+        z : float or numpy.ndarray
+            The z component(s)
+        """
+        self.x = x
+        self.y = y
+        self.z = z
+
+    def angular_distance(self, other):
+        """
+        Compute angular distance between points on the sphere, following:
+        https://en.wikipedia.org/wiki/Great-circle_distance
+
+        Parameters
+        ----------
+        other : mpas_tools.vector.Vector
+            The vector to compute the angular distance to
+
+        Returns
+        -------
+        angularDistance : numpy.ndarray
+            The angular distance (in radians) between segments of the transect.
+        """
+        angular_distance = np.arctan2(self.cross(other).mag(), self.dot(other))
+        return angular_distance
+
+    @staticmethod
+    def intersects(a1, a2, b1, b2):
+        """
+        Based on https://stackoverflow.com/a/26669130/7728169
+        Determine if the great circle arc from ``a1`` to ``a2`` intersects that
+        from ``b1`` to ``b2``.
+
+        Parameters
+        ----------
+        a1 : mpas_tools.vector.Vector
+            Cartesian coordinates of the end point of a great circle arc.
+            The types of the attributes ``x``, ``y``, and ``z`` must either be
+            ``numpy.arrays`` of identical size for all 4 vectors (in which case
+            intersections are found element-wise), or scalars for
+            at least one of either ``a1`` and ``a2`` or ``b1`` and ``b2``.
+
+        a2 : mpas_tools.vector.Vector
+            Cartesian coordinates of the other end point of a great circle arc.
+
+        b1 : mpas_tools.vector.Vector
+            Cartesian coordinates of an end point of a second great circle arc.
+
+        b2 : mpas_tools.vector.Vector
+            Cartesian coordinates of the other end point of the second great
+            circle arc.
+
+        Returns
+        -------
+        intersect : numpy.ndarray
+            A boolean array of the same size as ``a1`` and ``a2`` or ``b1`` and
+            ``b2``, whichever is greater, indicating if the particular pair of
+            arcs intersects
+        """
+        return np.logical_and(Vector.straddles(a1, a2, b1, b2),
+                              Vector.straddles(b1, b2, a1, a2))
+
+    @staticmethod
+    def intersection(a1, a2, b1, b2):
+        """
+        Based on https://stackoverflow.com/a/26669130/7728169
+        Find the intersection point as a unit vector between great circle arc
+        from ``a1`` to ``a2`` and from ``b1`` to ``b2``.  The arcs should have
+        already have been found to intersect by calling ``intersects()``
+
+        Parameters
+        ----------
+        a1 : mpas_tools.vector.Vector
+            Cartesian coordinates of the end point of a great circle arc.
+            The types of the attributes ``x``, ``y``, and ``z`` must either be
+            ``numpy.arrays`` of identical size for all 4 vectors (in which case
+            intersections are found element-wise), or scalars for
+            at least one of either ``a1`` and ``a2`` or ``b1`` and ``b2``.
+
+        a2 : mpas_tools.vector.Vector
+            Cartesian coordinates of the other end point of a great circle arc.
+
+        b1 : mpas_tools.vector.Vector
+            Cartesian coordinates of an end point of a second great circle arc.
+
+        b2 : mpas_tools.vector.Vector
+            Cartesian coordinates of the other end point of the second great
+            circle arc.
+
+        Returns
+        -------
+        points : mpas_tools.vector.Vector
+            An array of Cartesian points *on the unit sphere* indicating where
+            the arcs intersect
+        """
+        points = (a1.cross(a2)).cross(b1.cross(b2))
+        s = np.sign(Vector.det(a1, b1, b2))/points.mag()
+        points = Vector(s*points.x,  s*points.y, s*points.z)
+        return points
+
+    @staticmethod
+    def straddles(a1, a2, b1, b2):
+        """
+        Based on https://stackoverflow.com/a/26669130/7728169
+        Determines if the great circle segment determined by (a1, a2)
+        straddles the great circle determined by (b1, b2)
+
+        Parameters
+        ----------
+        a1: mpas_tools.vector.Vector
+            Cartesian coordinates of first end point of first great circle arc.
+            The types of the attributes ``x``, ``y``, and ``z`` must either be
+            ``numpy.arrays`` of identical size for all 4 vectors (in which case
+            intersections are found element-wise), or scalars for
+            at least one of either the ``a``s or the ``b``s.
+
+        a2 : mpas_tools.vector.Vector
+            Second end point of first great circle arc.
+
+        b1 : mpas_tools.vector.Vector
+            First end point of second great circle arc.
+
+        b2 : mpas_tools.vector.Vector
+            Second end point of second great circle arc.
+
+        Returns
+        -------
+        straddle : numpy.ndarray
+            A boolean array of the same size as the ``a``s or the ``b``s, whichever
+            is greater, indicating if the great circle segment determined by
+            (a1, a2) straddles the great circle determined by (b1, b2)
+        """
+        return Vector.det(a1, b1, b2) * Vector.det(a2, b1, b2) < 0
+
+    def dot(self, other):
+        """
+        Compute the dot product between this vector and ``other``.
+
+        Parameters
+        ----------
+        other : mpas_tools.vector.Vector
+            The other vector
+
+        Returns
+        -------
+        dot_product : numpy.ndarray
+            The dot product
+        """
+        return self.x * other.x + self.y * other.y + self.z * other.z
+
+    def cross(self, other):
+        """
+        Compute the dot product between this vector and ``other``.
+
+        Parameters
+        ----------
+        other : mpas_tools.vector.Vector
+            The other vector
+
+        Returns
+        -------
+        cross_product : mpas_tools.vector.Vector
+            The cross product
+        """
+        return Vector(self.y * other.z - self.z * other.y,
+                      self.z * other.x - self.x * other.z,
+                      self.x * other.y - self.y * other.x)
+
+    @staticmethod
+    def det(v1, v2, v3):
+        """
+        The determinant of the matrix defined by the three ``Vector`` objects
+
+        Parameters
+        ----------
+        v1 : mpas_tools.vector.Vector
+            First row of the matrix
+
+        v2 : mpas_tools.vector.Vector
+            Second row
+
+        v3 : mpas_tools.vector.Vector
+            Third row
+
+        Returns
+        -------
+        determinant : numpy.ndarray
+            The determinant of the matrix
+        """
+        return v1.dot(v2.cross(v3))
+
+    def mag(self):
+        """
+        The magnitude of the vector
+
+        Returns
+        -------
+        magnitude : numpy.ndarray
+            The magnitude of the vector
+        """
+        return np.sqrt(self.dot(self))

--- a/conda_package/mpas_tools/viz/transects.py
+++ b/conda_package/mpas_tools/viz/transects.py
@@ -4,9 +4,13 @@ import xarray
 from scipy.spatial import cKDTree
 from shapely.geometry import LineString, Point
 
-from mpas_tools.transects import Vector, lon_lat_to_cartesian, \
-    cartesian_to_lon_lat, intersects, intersection, angular_distance, \
-    subdivide_great_circle, subdivide_planar
+from mpas_tools.transects import (
+    cartesian_to_lon_lat,
+    lon_lat_to_cartesian,
+    subdivide_great_circle,
+    subdivide_planar
+)
+from mpas_tools.vector import Vector
 
 
 def make_triangle_tree(dsTris):
@@ -194,8 +198,8 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
                         yNode[n1IndicesCand],
                         zNode[n1IndicesCand])
 
-        intersect = intersects(n0Cand, n1Cand, transectv0,
-                               transectv1)
+        intersect = Vector.intersects(n0Cand, n1Cand, transectv0,
+                                      transectv1)
 
         n0Inter = Vector(n0Cand.x[intersect],
                          n0Cand.y[intersect],
@@ -208,24 +212,23 @@ def find_transect_cells_and_weights(lonTransect, latTransect, dsTris, dsMesh,
         n0IndicesInter = n0IndicesCand[intersect]
         n1IndicesInter = n1IndicesCand[intersect]
 
-        intersections = intersection(n0Inter, n1Inter, transectv0, transectv1)
+        intersections = Vector.intersection(n0Inter, n1Inter, transectv0,
+                                            transectv1)
         intersections = Vector(earth_radius*intersections.x,
                                earth_radius*intersections.y,
                                earth_radius*intersections.z)
 
-        angularDistance = angular_distance(first=transectv0,
-                                           second=intersections)
+        angularDistance = transectv0.angular_distance(intersections)
 
         dNodeLocal = dStart + earth_radius * angularDistance
 
-        dStart += earth_radius*angular_distance(first=transectv0,
-                                                second=transectv1)
+        dStart += earth_radius*transectv0.angular_distance(transectv1)
 
         node0Inter = numpy.mod(n0IndicesInter, nNodes)
         node1Inter = numpy.mod(n1IndicesInter, nNodes)
 
-        nodeWeights = (angular_distance(first=intersections, second=n1Inter) /
-                       angular_distance(first=n0Inter, second=n1Inter))
+        nodeWeights = (intersections.angular_distance(n1Inter) /
+                       n0Inter.angular_distance(n1Inter))
 
         weights = numpy.zeros((len(trisInter), nHorizWeights))
         cellIndices = numpy.zeros((len(trisInter), nHorizWeights), int)


### PR DESCRIPTION
This is useful because the `Vector` class likely might be useful outside of `transects`, where it previously resided.