### PR TITLE
Fix `SHR_CONST_OMEGA` in `cime.constants`

### DIFF
--- a/conda_package/mpas_tools/cime/constants.py
+++ b/conda_package/mpas_tools/cime/constants.py
@@ -1,8 +1,10 @@
+import numpy as np
+
+
 constants = \
     {'SHR_CONST_PI': 3.14159265358979323846,
      'SHR_CONST_CDAY': 86400.0,
      'SHR_CONST_SDAY': 86164.0,
-     'SHR_CONST_OMEGA': 2.0,
      'SHR_CONST_REARTH': 6.37122e6,
      'SHR_CONST_G': 9.80616,
      'SHR_CONST_STEBOL': 5.67e-8,
@@ -34,8 +36,8 @@ constants = \
      'SHR_CONST_OCN_REF_SAL': 34.7,
      'SHR_CONST_ICE_REF_SAL':  4.0,
      'SHR_CONST_SPVAL': 1.0e30,
-     'SHR_CONST_SPVAL_TOLMIN': 0.99,
-     'SHR_CONST_SPVAL_TOLMAX': 1.01,
+     'SHR_CONST_SPVAL_TOLMIN': 0.99 * 1.0e30,
+     'SHR_CONST_SPVAL_TOLMAX': 1.01 * 1.0e30,
      'SHR_CONST_SPVAL_AERODEP': 1.e29,
      'SHR_CONST_VSMOW_18O': 2005.2e-6,
      'SHR_CONST_VSMOW_17O': 379.e-6,
@@ -44,3 +46,5 @@ constants = \
      'SHR_CONST_VSMOW_T': 1.85e-6,
      'SHR_CONST_VSMOW_H': 0.99984426,
      'SHR_CONST_RSTD_H2ODEV': 1.0}
+
+constants['SHR_CONST_OMEGA'] = 2.0 * np.pi / constants['SHR_CONST_SDAY']

--- a/conda_package/mpas_tools/tests/test_cime_constants.py
+++ b/conda_package/mpas_tools/tests/test_cime_constants.py
@@ -13,8 +13,8 @@ def test_cime_constants(e3sm_tag='master'):
     """
 
     resp = requests.get(
-        'https://raw.githubusercontent.com/E3SM-Project/E3SM/{}/share/util/'
-        'shr_const_mod.F90'.format(e3sm_tag))
+        f'https://raw.githubusercontent.com/E3SM-Project/E3SM/{e3sm_tag}/'
+        f'share/util/shr_const_mod.F90')
 
     text = resp.text
 
@@ -28,20 +28,28 @@ def test_cime_constants(e3sm_tag='master'):
         constant, value = _parse_value(line)
         if constant is None:
             continue
-        print(line)
-        print('parsed: {} = {}'.format(constant, value))
+        print(f'line: {line}')
+        print(f'parsed: {constant} = {value}')
         if constant in constants:
-            print('verifying {}'.format(constant))
-            assert value == constants[constant]
-            found[constant] = True
+            if isinstance(value, float):
+                print('verifying {}'.format(constant))
+                assert value == constants[constant]
+            else:
+                print('skipping verification for {}'.format(constant))
 
-    allFound = True
+            found[constant] = True
+        else:
+            print('not in constants')
+
+        print('')
+
+    all_found = True
     for constant in found:
         if not found[constant]:
             print('{} was not found!'.format(constant))
-            allFound = False
+            all_found = False
 
-    assert allFound
+    assert all_found
 
 
 def _parse_value(line):
@@ -57,11 +65,7 @@ def _parse_value(line):
     if '!' in line:
         line, _ = line.split('!', 1)
 
-    if '_R8' in line:
-        line, _ = line.split('_R8')
-
-    if '_r8' in line:
-        line, _ = line.split('_r8')
+    line = line.replace('_R8', '').replace('_r8', '')
 
     try:
         value = float(line)


### PR DESCRIPTION
Update testing to do a better job at skipping expressions when verifying constants.