### PR TITLE
Convert masks to int type in `cull()` function

### DIFF
--- a/conda_package/mpas_tools/mesh/conversion.py
+++ b/conda_package/mpas_tools/mesh/conversion.py
@@ -1,6 +1,6 @@
 import os
 import xarray
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, mkdtemp
 import shutil
 
 import mpas_tools.io
@@ -38,26 +38,26 @@ def convert(dsIn, graphInfoFileName=None, logger=None, dir=None):
     """
     if dir is not None:
         dir = os.path.abspath(dir)
-    with TemporaryDirectory(dir=dir) as tempdir:
-        inFileName = '{}/mesh_in.nc'.format(tempdir)
-        write_netcdf(dsIn, inFileName)
 
-        outFileName = '{}/mesh_out.nc'.format(tempdir)
+    tempdir = mkdtemp(dir=dir)
+    inFileName = '{}/mesh_in.nc'.format(tempdir)
+    write_netcdf(dsIn, inFileName)
 
-        if graphInfoFileName is not None:
-            graphInfoFileName = os.path.abspath(graphInfoFileName)
+    outFileName = '{}/mesh_out.nc'.format(tempdir)
 
-        outDir = os.path.dirname(outFileName)
+    if graphInfoFileName is not None:
+        graphInfoFileName = os.path.abspath(graphInfoFileName)
 
-        check_call(['MpasMeshConverter.x', inFileName, outFileName],
-                         logger)
+    outDir = os.path.dirname(outFileName)
 
-        dsOut = xarray.open_dataset(outFileName)
-        dsOut.load()
+    check_call(['MpasMeshConverter.x', inFileName, outFileName], logger)
 
-        if graphInfoFileName is not None:
-            shutil.copyfile('{}/graph.info'.format(outDir),
-                            graphInfoFileName)
+    dsOut = xarray.open_dataset(outFileName)
+    dsOut.load()
+
+    if graphInfoFileName is not None:
+        shutil.copyfile('{}/graph.info'.format(outDir),
+                        graphInfoFileName)
 
     return dsOut
 
@@ -109,50 +109,50 @@ def cull(dsIn, dsMask=None, dsInverse=None, dsPreserve=None,
     """
     if dir is not None:
         dir = os.path.abspath(dir)
-    with TemporaryDirectory(dir=dir) as tempdir:
-        inFileName = '{}/ds_in.nc'.format(tempdir)
-        write_netcdf(dsIn, inFileName)
-        outFileName = '{}/ds_out.nc'.format(tempdir)
+    tempdir = mkdtemp(dir=dir)
+    inFileName = '{}/ds_in.nc'.format(tempdir)
+    write_netcdf(dsIn, inFileName)
+    outFileName = '{}/ds_out.nc'.format(tempdir)
 
-        args = ['MpasCellCuller.x', inFileName, outFileName]
+    args = ['MpasCellCuller.x', inFileName, outFileName]
 
-        if dsMask is not None:
-            if not isinstance(dsMask, list):
-                dsMask = [dsMask]
-            for index, ds in enumerate(dsMask):
-                fileName = '{}/mask{}.nc'.format(tempdir, index)
-                write_netcdf(ds, fileName)
-                args.extend(['-m', fileName])
+    if dsMask is not None:
+        if not isinstance(dsMask, list):
+            dsMask = [dsMask]
+        for index, ds in enumerate(dsMask):
+            fileName = '{}/mask{}.nc'.format(tempdir, index)
+            write_netcdf(ds, fileName)
+            args.extend(['-m', fileName])
 
-        if dsInverse is not None:
-            if not isinstance(dsInverse, list):
-                dsInverse = [dsInverse]
-            for index, ds in enumerate(dsInverse):
-                fileName = '{}/inverse{}.nc'.format(tempdir, index)
-                write_netcdf(ds, fileName)
-                args.extend(['-i', fileName])
+    if dsInverse is not None:
+        if not isinstance(dsInverse, list):
+            dsInverse = [dsInverse]
+        for index, ds in enumerate(dsInverse):
+            fileName = '{}/inverse{}.nc'.format(tempdir, index)
+            write_netcdf(ds, fileName)
+            args.extend(['-i', fileName])
 
-        if dsPreserve is not None:
-            if not isinstance(dsPreserve, list):
-                dsPreserve = [dsPreserve]
-            for index, ds in enumerate(dsPreserve):
-                fileName = '{}/preserve{}.nc'.format(tempdir, index)
-                write_netcdf(ds, fileName)
-                args.extend(['-p', fileName])
+    if dsPreserve is not None:
+        if not isinstance(dsPreserve, list):
+            dsPreserve = [dsPreserve]
+        for index, ds in enumerate(dsPreserve):
+            fileName = '{}/preserve{}.nc'.format(tempdir, index)
+            write_netcdf(ds, fileName)
+            args.extend(['-p', fileName])
 
-        if graphInfoFileName is not None:
-            graphInfoFileName = os.path.abspath(graphInfoFileName)
+    if graphInfoFileName is not None:
+        graphInfoFileName = os.path.abspath(graphInfoFileName)
 
-        outDir = os.path.dirname(outFileName)
+    outDir = os.path.dirname(outFileName)
 
-        check_call(args=args, logger=logger)
+    check_call(args=args, logger=logger)
 
-        dsOut = xarray.open_dataset(outFileName)
-        dsOut.load()
+    dsOut = xarray.open_dataset(outFileName)
+    dsOut.load()
 
-        if graphInfoFileName is not None:
-            shutil.copyfile('{}/culled_graph.info'.format(outDir),
-                            graphInfoFileName)
+    if graphInfoFileName is not None:
+        shutil.copyfile('{}/culled_graph.info'.format(outDir),
+                        graphInfoFileName)
 
     return dsOut
 


### PR DESCRIPTION
The new version of the cell culler requires masks in `int` (rather than `int64` or `float`) format.

This is needed because output in NETCDF4 format is producing int64, rather than int32, arrays but the cell culller is then reading a full int64 data array into memory allocated for an int32 array, thus overwriting a lot of memory allocated for other arrays with garbage.