### PR TITLE
Update ci packages to match conda-forge versions

### DIFF
--- a/conda_package/ci/linux_python3.10.yaml
+++ b/conda_package/ci/linux_python3.10.yaml
@@ -1,17 +1,25 @@
+cdt_name:
+- cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '12'
 hdf5:
-- 1.12.2
+- 1.14.1
 libnetcdf:
-- 4.8.1
+- 4.9.2
+netcdf_fortran:
+- '4.6'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -20,3 +28,6 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda_package/ci/linux_python3.11.yaml
+++ b/conda_package/ci/linux_python3.11.yaml
@@ -1,17 +1,25 @@
+cdt_name:
+- cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '12'
 hdf5:
-- 1.12.2
+- 1.14.1
 libnetcdf:
-- 4.8.1
+- 4.9.2
+netcdf_fortran:
+- '4.6'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -20,3 +28,6 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda_package/ci/linux_python3.9.yaml
+++ b/conda_package/ci/linux_python3.9.yaml
@@ -1,17 +1,25 @@
+cdt_name:
+- cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '12'
 hdf5:
-- 1.12.2
+- 1.14.1
 libnetcdf:
-- 4.8.1
+- 4.9.2
+netcdf_fortran:
+- '4.6'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -20,3 +28,6 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda_package/ci/osx_python3.10.yaml
+++ b/conda_package/ci/osx_python3.10.yaml
@@ -1,17 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '12'
 hdf5:
-- 1.12.2
+- 1.14.1
 libnetcdf:
-- 4.8.1
+- 4.9.2
+llvm_openmp:
+- '15'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+netcdf_fortran:
+- '4.6'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -20,3 +30,6 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - osx-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda_package/ci/osx_python3.11.yaml
+++ b/conda_package/ci/osx_python3.11.yaml
@@ -1,17 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '12'
 hdf5:
-- 1.12.2
+- 1.14.1
 libnetcdf:
-- 4.8.1
+- 4.9.2
+llvm_openmp:
+- '15'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+netcdf_fortran:
+- '4.6'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -20,3 +30,6 @@ python:
 - 3.11.* *_cpython
 target_platform:
 - osx-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda_package/ci/osx_python3.9.yaml
+++ b/conda_package/ci/osx_python3.9.yaml
@@ -1,17 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '12'
 hdf5:
-- 1.12.2
+- 1.14.1
 libnetcdf:
-- 4.8.1
+- 4.9.2
+llvm_openmp:
+- '15'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+netcdf_fortran:
+- '4.6'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -20,3 +30,6 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - osx-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version


### PR DESCRIPTION
This is necessary for local and CI builds of `mpas_tools` to be compatible with other packages in the conda-forge ecosystem.