### PR TITLE
Switch from use of 'nc-config' to 'nf-config' in top-level Makefile for grid_rotate

### DIFF
--- a/mesh_tools/grid_rotate/Makefile
+++ b/mesh_tools/grid_rotate/Makefile
@@ -1,7 +1,7 @@
-FC = $(shell nc-config --fc)
+FC = $(shell nf-config --fc)
 FFLAGS = -O3
-FCINCLUDES = $(shell nc-config --fflags)
-FCLIBS = $(shell nc-config --flibs)
+FCINCLUDES = $(shell nf-config --fflags)
+FCLIBS = $(shell nf-config --flibs)
 
 all: grid_rotate
 

--- a/mesh_tools/grid_rotate/README
+++ b/mesh_tools/grid_rotate/README
@@ -3,6 +3,9 @@ latitude, longitude, and bird's eye rotations
 
 REVISION HISTORY:
 
+   22 Sept 2023 - Switch from nc-config to nf-config for detecting Fortran
+                  compiler and compilation flags
+
    10 July 2013 - Fix issue where angleEdge was overwritten in output files
                   for meshes that don't provide fEdge and fVertex fields.
 
@@ -27,10 +30,10 @@ II. BUILDING THE CODE
 
    Building requires NetCDF and a Fortran compiler.
 
-   Before building, ensure that the directory containing the 'nc-config' utility
+   Before building, ensure that the directory containing the 'nf-config' utility
    is in your $PATH; this directory is usually in bin/ subdirectory of your
-   NetCDF installation root directory. The 'nc-config' utility is part of most
-   modern NetCDF installations, and if you do not have nc-config, it will be
+   NetCDF installation root directory. The 'nf-config' utility is part of most
+   modern NetCDF installations, and if you do not have nf-config, it will be
    necessary to manually set the name of your Fortran compiler, as well as the
    library paths, in the Makefile; specifically, the following variables must be
    manually set: FC, FCINCLUDES, and FCLIBS.


### PR DESCRIPTION
This PR switches to the use of `nf-config` in the top-level `Makefile` for the grid_rotate tool.

Beginning with NetCDF-C 4.9.2, the `nc-config` program no longer provides information from `nf-config`; see
Unidata/netcdf-c@6f55c852

Now, `nf-config`, rather than `nc-config` is used to determine the Fortran compiler, include paths, and library paths to use.