### PR TITLE
Add new features to config parser

### DIFF
--- a/conda_package/docs/api.rst
+++ b/conda_package/docs/api.rst
@@ -116,6 +116,8 @@ Config
    MpasConfigParser.set
    MpasConfigParser.write
    MpasConfigParser.copy
+   MpasConfigParser.append
+   MpasConfigParser.prepend
    MpasConfigParser.__getitem__
 
 I/O

--- a/conda_package/mpas_tools/config.py
+++ b/conda_package/mpas_tools/config.py
@@ -415,6 +415,47 @@ class MpasConfigParser:
         config_copy._comments = dict(self._comments)
         return config_copy
 
+    def append(self, other):
+        """
+        Append a deep copy of another config parser to this one.  Config
+        options from ``other`` will take precedence over those from this config
+        parser.
+
+        Parameters
+        ----------
+        other : mpas_tools.config.MpasConfigParser
+            The other, higher priority config parser
+        """
+        other = other.copy()
+        self._configs.update(other._configs)
+        self._user_config.update(other._user_config)
+        self._comments.update(other._comments)
+
+    def prepend(self, other):
+        """
+        Prepend a deep copy of another config parser to this one.  Config
+        options from this config parser will take precedence over those from
+        ``other``.
+
+        Parameters
+        ----------
+        other : mpas_tools.config.MpasConfigParser
+            The other, higher priority config parser
+        """
+        other = other.copy()
+
+        configs = dict(other._configs)
+        configs.update(self._configs)
+        self._configs = configs
+
+        user_config = dict(other._user_config)
+        user_config.update(self._user_config)
+        self._user_config = user_config
+
+        comments = dict(other._comments)
+        comments.update(self._comments)
+        self._comments = comments
+
     def __getitem__(self, section):
         """
         Get get the config options for a given section.

--- a/conda_package/mpas_tools/config.py
+++ b/conda_package/mpas_tools/config.py
@@ -423,24 +423,6 @@ class MpasConfigParser:
             self.combine()
         return self.combined[section]
 
-    def _add(self, filename, user):
-        filename = os.path.abspath(filename)
-        config = RawConfigParser()
-        if not os.path.exists(filename):
-            raise FileNotFoundError(f'Config file does not exist: {filename}')
-        config.read(filenames=filename)
-        with open(filename) as fp:
-            comments = self._parse_comments(fp, filename, comments_before=True)
-
-        if user:
-            self._user_config[filename] = config
-        else:
-            self._configs[filename] = config
-        self._comments[filename] = comments
-        self.combined = None
-        self.combined_comments = None
-        self.sources = None
-
     def combine(self):
         """
         Combine the config files into one.  This is normally handled
@@ -462,6 +444,24 @@ class MpasConfigParser:
                         self.combined.set(section, option, value)
                         self.combined_comments[(section, option)] = \
                             self._comments[source][(section, option)]
+
+    def _add(self, filename, user):
+        filename = os.path.abspath(filename)
+        config = RawConfigParser()
+        if not os.path.exists(filename):
+            raise FileNotFoundError(f'Config file does not exist: {filename}')
+        config.read(filenames=filename)
+        with open(filename) as fp:
+            comments = self._parse_comments(fp, filename, comments_before=True)
+
+        if user:
+            self._user_config[filename] = config
+        else:
+            self._configs[filename] = config
+        self._comments[filename] = comments
+        self.combined = None
+        self.combined_comments = None
+        self.sources = None
 
     @staticmethod
     def _parse_comments(fp, filename, comments_before=True):


### PR DESCRIPTION
This merge adds 2 new features to the `MpasConfigParser`:
* Config files can be written out in "raw" format, which preserves the config options that use extended interpolation, rather than substituting them.  This is useful in situations where you want to write out a config file that can still take advantage of extended interpolation when it is read back in.  Writing out in raw format is now the default.
* Two new methods, `append()` and `prepend()` allow you to add a copy of another set of config options either before or after a given set of options.  This is useful for combining a set of specialize options with a set of common or default options, particularly if this procedure needs to happen repeatedly (e.g. for separate tasks, each with its own specialized options).