### PR TITLE
Update AIS mesh modification scripts

### DIFF
--- a/landice/mesh_tools_li/adjust_iceshelf_geometry.py
+++ b/landice/mesh_tools_li/adjust_iceshelf_geometry.py
@@ -31,7 +31,7 @@ import shutil
 
 nSmoothing = 3 # number of rounds of smoothing to apply.  3 was the best match at 8km to 30 years of thickness evolution on Ross and FRIS.  Set to 0 to disable
 
-elevationDrop = 5.0 # height in meters to drop non-grounded marine bed elevation
+elevationDrop = 20.0 # height in meters to drop non-grounded marine bed elevation
 
 # ------------------------
 

--- a/landice/mesh_tools_li/bulldoze_missing_troughs.py
+++ b/landice/mesh_tools_li/bulldoze_missing_troughs.py
@@ -117,8 +117,8 @@ def smoothTrough(WCT, p1, p2, minWCT, maxWCT):
 
 
 # Define maximum and minimum water column thickness along tough centerline
-maxWCT = 300.0
-minWCT = 50.0
+maxWCT = 400.0
+minWCT = 75.0
 
 # Specify start and end x/y coordinates for each trough to be bulldozed
 WCTnew = WCT.copy()

--- a/landice/mesh_tools_li/bulldoze_missing_troughs.py
+++ b/landice/mesh_tools_li/bulldoze_missing_troughs.py
@@ -70,9 +70,9 @@ def smoothTrough(WCT, p1, p2, minWCT, maxWCT):
     WCTnew = WCT.copy()
 
     # find representative dCell for this area
-    ind = np.nonzero( (xEdge>p1[0]) * (xEdge<p2[0]) * (yEdge>p1[1]) * (yEdge<p1[2]) )[0]
+    ind = np.nonzero( (xEdge>p1[0]) * (xEdge<p2[0]) * (yEdge>p1[1]) * (yEdge<p2[1]) )[0]
     dCell = dcEdge[ind].mean()
-    print(f"using dCell={dCell}")
+    print(f"using dCell={dCell} averaged from {len(ind)} cells")
 
     mask = (WCT<maxWCT) * (floatMask==1) * (xCell>(p1[0]-2*dCell)) * (xCell<(p2[0]+2*dCell)) * (yCell>(p1[1]-2*dCell)) * (yCell<(p2[1]+2*dCell))
     ind = np.nonzero(mask==1)[0]

--- a/landice/mesh_tools_li/bulldoze_missing_troughs.py
+++ b/landice/mesh_tools_li/bulldoze_missing_troughs.py
@@ -89,7 +89,7 @@ def smoothTrough(WCT, p1, p2, minWCT, maxWCT):
         dist2centerline = np.absolute(m1*xCell[ind2] + -1*yCell[ind2] + b1) / (m1**2 + (-1)**2)**0.5
         #dist2centerline = np.absolute( (p2[0]-p1[0]) * (p1[1] - yCell[ind2]) - (p1[0]-xCell[ind2])*(p2[1]-p1[1])) / ( (p2[0]-p1[0])**2 + (p2[1]-p1[1])**2)**0.5
         dist2centerline *= np.sign((m1*xCell[ind2]+b1) - yCell[ind2]) # make signed distance, assuming NE direction
-        print(dist2centerline)
+        #print(dist2centerline)
         width = dist2centerline.max()-dist2centerline.min()
 
         # find frac x along center line
@@ -102,7 +102,7 @@ def smoothTrough(WCT, p1, p2, minWCT, maxWCT):
         widthEndIdx = ind2[np.argmax(dist2centerline)] #idx of westmost
         widthEnd = (xCell[widthEndIdx], yCell[widthEndIdx]) # position of westmost
         widthMidpt = ((widthOrgn[0]+widthEnd[0])/2.0, (widthOrgn[1]+widthEnd[1])/2.0)
-        print(xCell[c], yCell[c], widthOrgn)
+        #print(xCell[c], yCell[c], widthOrgn)
         #dist2Orgn = ((widthOrgn[0]-xCell[c])**2 + (widthOrgn[1]-yCell[c])**2)**0.5
         #fracWidth = (dist2Orgn  / (width) - 0.5) * 2.0 # [-1,1] range
         dist2Mid = ((widthMidpt[0]-xCell[c])**2 + (widthMidpt[1]-yCell[c])**2)**0.5

--- a/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
+++ b/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
@@ -702,6 +702,7 @@ elif filetype=='mpas':
 
      fieldInfo['stiffnessFactor'] = {'InputName':'stiffnessFactor', 'scalefactor':1.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}
      fieldInfo['effectivePressure'] = {'InputName':'effectivePressure', 'scalefactor':1.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}
+     fieldInfo['iceMask'] = {'InputName':'iceMask', 'scalefactor':1.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}
 
 # Used by Trevor
 #     fieldInfo['sfcMassBalUncertainty'] = {'InputName':'smb_std_vector', 'scalefactor':910.0/(3600.0*24.0*365.0)/1000.0, 'offset':0.0, 'gridType':'cell', 'vertDim':False}

--- a/landice/mesh_tools_li/tune_ismip6_melt_deltat.py
+++ b/landice/mesh_tools_li/tune_ismip6_melt_deltat.py
@@ -39,7 +39,7 @@ gamma0 = 14500.0 # MeanAnt
 # Increments of 0.05 seems than fine enough to get a smooth function for interpolating, but use larger increments
 # when testing for faster execution.
 #dTs = np.arange(-1.5, 2.0, 0.25)  # MeanAnt - coarse spacing for rapid testing
-dTs = np.arange(-1.0 1.5, 0.05)  # MeanAnt - fine spacing for accurate calculation
+dTs = np.arange(-1.0, 1.5, 0.05)  # MeanAnt - fine spacing for accurate calculation
 #dTs = np.arange(-1.5, 0.0, 0.05)  # PIGL
 # -----------------------
 


### PR DESCRIPTION
This PR includes a number of small updates to the scripts used to modify AIS initial conditions:
* fix a bug in the bulldoze script
* reduce stdout printing in bulldoze script 
* change defaults in two adjustment scripts to match what was used for the production 4km AIS mesh
* add iceMask to the interp script for mpas-to-mpas interpolation (not directly related to the other changes, but a small quality of life addition)
* add missing comma in tune_ismip6_melt_deltat.py