### PR TITLE
Limit lon to -180 to 180 in lon-lat region masks

### DIFF
--- a/conda_package/mpas_tools/mesh/mask.py
+++ b/conda_package/mpas_tools/mesh/mask.py
@@ -522,6 +522,9 @@ def compute_lon_lat_region_masks(lon, lat, fcMask, logger=None, pool=None,
 
     dsMasks = xr.Dataset()
 
+    # make sure lon is between -180 and 180
+    lon = numpy.mod(lon + 180., 360.) - 180.
+
     Lon, Lat = numpy.meshgrid(lon, lat)
 
     shape = Lon.shape


### PR DESCRIPTION
This is needed for grids where longitude is from 0 to 360 and it is inconvenient to modify the grid before passing it to the command-line tool.