### PR TITLE
jigsaw_to_netcdf: bug fix for POINT coordinates

### DIFF
--- a/conda_package/mpas_tools/mesh/creation/jigsaw_to_netcdf.py
+++ b/conda_package/mpas_tools/mesh/creation/jigsaw_to_netcdf.py
@@ -50,7 +50,11 @@ def jigsaw_to_netcdf(msh_filename, output_name, on_sphere, sphere_radius=None):
     # Create cell variables and sphere_radius
     xCell_full = msh['POINT'][:, 0]
     yCell_full = msh['POINT'][:, 1]
-    zCell_full = msh['POINT'][:, 2]
+    zCell_full = []
+    if msh['NDIMS'] == 3:
+        zCell_full = msh['POINT'][:, 2]
+    else:
+        zCell_full = np.zeros(yCell_full.shape)
     for cells in [xCell_full, yCell_full, zCell_full]:
         assert cells.shape[0] == nCells, 'Number of anticipated nodes is' \
                                          ' not correct!'

--- a/conda_package/mpas_tools/mesh/creation/jigsaw_to_netcdf.py
+++ b/conda_package/mpas_tools/mesh/creation/jigsaw_to_netcdf.py
@@ -51,10 +51,12 @@ def jigsaw_to_netcdf(msh_filename, output_name, on_sphere, sphere_radius=None):
     xCell_full = msh['POINT'][:, 0]
     yCell_full = msh['POINT'][:, 1]
     zCell_full = []
-    if msh['NDIMS'] == 3:
+    if msh['NDIMS'] == 2:
+        zCell_full = np.zeros(yCell_full.shape)
+    elif msh['NDIMS'] == 3:
         zCell_full = msh['POINT'][:, 2]
     else:
-        zCell_full = np.zeros(yCell_full.shape)
+        raise ValueError(f'Unexpected mesh NDIMS: {msh["NDIMS"]}')
     for cells in [xCell_full, yCell_full, zCell_full]:
         assert cells.shape[0] == nCells, 'Number of anticipated nodes is' \
                                          ' not correct!'

--- a/conda_package/mpas_tools/mesh/creation/jigsaw_to_netcdf.py
+++ b/conda_package/mpas_tools/mesh/creation/jigsaw_to_netcdf.py
@@ -56,7 +56,8 @@ def jigsaw_to_netcdf(msh_filename, output_name, on_sphere, sphere_radius=None):
     elif msh['NDIMS'] == 3:
         zCell_full = msh['POINT'][:, 2]
     else:
-        raise ValueError(f'Unexpected mesh NDIMS: {msh["NDIMS"]}')
+        raise ValueError("NDIMS must be 2 or 3; input mesh has NDIMS={}"
+                         .format(msh['NDIMS']))
     for cells in [xCell_full, yCell_full, zCell_full]:
         assert cells.shape[0] == nCells, 'Number of anticipated nodes is' \
                                          ' not correct!'


### PR DESCRIPTION
This PR fixes a bug where the third column of the `POINTS` data from a Jigsaw file is read as a spatial coordinate for 2D when it should be read as an ID, or at least ignored.  The change in this PR simply ignores it for 2D meshes.  I may submit a follow up PR to extract the ID for ongoing landice work.  

The following Jigsaw wiki describes the mesh file format: https://github.com/dengwirda/jigsaw/wiki/MSH-File-Format#point-segment

Running `jigsaw_to_netcdf` and `MpasMeshConverter.x`, with Jigsaw 1.0.0, on a 2d `EUCLIDEAN-MESH` mesh ([gis_2d_pointIds.zip](https://github.com/MPAS-Dev/MPAS-Tools/files/14058459/gis_2d_pointIds.zip)) will demonstrate the bug with `master`.  Should I add this mesh to a test data set?

All the compass `mesh_gen` tests are passing with this change.  The testing setup and test output is below.  As a sanity check I've also included the output of `pip show mpas_tools` that indicates that my local mpas_tools is used within the testing environment created with `compass setup`.

## details

### compass test setup
```
(cmd)(mpasMain) cwsmith@checkers: /space/cwsmith/compassLandice/main (main)$ compass setup -w /space/cwsmith/compassLandice/mesh_gen_compass_main -f checkers.cfg -n 0 43 44 92 93 99
Setting up test cases:
  landice/antarctica/mesh_gen
  landice/greenland/mesh_gen
  landice/humboldt/mesh_gen
Downloading humboldt_1km_2020_04_20.epsg3413.icesheetonly.nc (42.5MiB)
  to /space/cwsmith/compassLandice/main/mpas-albany-landice
100% |#########################################################################################################################################################################################################################################################| Time:  0:00:02
  humboldt_1km_2020_04_20.epsg3413.icesheetonly.nc done.
  landice/kangerlussuaq/mesh_gen
Downloading greenland_8km_2020_04_20.epsg3413.nc (4.3MiB)
  to /space/cwsmith/compassLandice/main/mpas-albany-landice
100% |#########################################################################################################################################################################################################################################################| Time:  0:00:00
  greenland_8km_2020_04_20.epsg3413.nc done.
  landice/koge_bugt_s/mesh_gen
  landice/thwaites/mesh_gen
Downloading antarctica_1km_2020_10_20_ASE.nc (559.3MiB)
  to /space/cwsmith/compassLandice/main/mpas-albany-landice
100% |#########################################################################################################################################################################################################################################################| Time:  0:00:26
  antarctica_1km_2020_10_20_ASE.nc done.
target cores: 128
minimum cores: 1
```

### env sanity check
```
(ins)(mpasMain) cwsmith@checkers: /space/cwsmith/compassLandice/mesh_gen_compass_main $ pip  show mpas_tools
Name: mpas_tools
Version: 0.30.0
Summary: A set of tools for creating and manipulating meshes for the climate components based on the Model for Prediction Across Scales (MPAS) framework
Home-page: https://github.com/MPAS-Dev/MPAS-Tools
Author: MPAS-Tools Developers
Author-email: mpas-developers@googlegroups.com
License: BSD
Location: /space/cwsmith/compassLandice/MPAS-Tools/conda_package
Requires: cartopy, cmocean, dask, igraph, inpoly, matplotlib, netcdf4, numpy, progressbar2, pyamg, pyevtk, pyproj, scikit-image, scipy, shapely, xarray
Required-by: 
```

### run compass tests
```
(ins)(mpasMain) cwsmith@checkers: /space/cwsmith/compassLandice/mesh_gen_compass_main $ compass run
landice/antarctica/mesh_gen
  * step: mesh
  test execution:      SUCCESS
  test runtime:        03:12
landice/greenland/mesh_gen
  * step: mesh
  test execution:      SUCCESS
  test runtime:        03:25
landice/humboldt/mesh_gen
  * step: mesh
  test execution:      SUCCESS
  test runtime:        03:02
landice/kangerlussuaq/mesh_gen
  * step: mesh
  test execution:      SUCCESS
  test runtime:        00:11
landice/koge_bugt_s/mesh_gen
  * step: mesh
  test execution:      SUCCESS
  test runtime:        00:14
landice/thwaites/mesh_gen
  * step: mesh
  test execution:      SUCCESS
  test runtime:        01:24
Test Runtimes:
03:12 PASS landice_antarctica_mesh_gen
03:25 PASS landice_greenland_mesh_gen
03:02 PASS landice_humboldt_mesh_gen
00:11 PASS landice_kangerlussuaq_mesh_gen
00:14 PASS landice_koge_bugt_s_mesh_gen
01:24 PASS landice_thwaites_mesh_gen
Total runtime 11:29
PASS: All passed successfully!
```

 