### PR TITLE
setup: always copy subdirs ocean, landice,...

### DIFF
--- a/conda_package/setup.py
+++ b/conda_package/setup.py
@@ -34,8 +34,10 @@ version = re.search(r'{}\s*=\s*[(]([^)]*)[)]'.format('__version_info__'),
 os.chdir(here)
 
 for path in ['ocean', 'landice', 'visualization', 'mesh_tools']:
-    if not os.path.exists(path):
-        shutil.copytree('../{}'.format(path), './{}'.format(path))
+    destPath = './{}'.format(path)
+    if os.path.exists(destPath):
+        shutil.rmtree(destPath)
+    shutil.copytree('../{}'.format(path), destPath)
 
 setup(name='mpas_tools',
       version=version,


### PR DESCRIPTION
If changes are made to the scripts in these directories running `python -m pip install -e conda_package` will not update them.  This change removes the directory existence check so that they are always copied.

Thanks to @xylar for the pointer on the fix for this.

closes #549 