### PR TITLE
Ignore NaNs when checking for negative basalHeatFlux

### DIFF
--- a/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
+++ b/landice/mesh_tools_li/interpolate_to_mpasli_grid.py
@@ -774,7 +774,7 @@ for MPASfieldName in fieldInfo:
 
        # basalHeatFlux must be non-negative
        if MPASfieldName == 'basalHeatFlux':
-           assert MPASfield.min() >= 0.0, 'basalHeatFlux contains negative values! This is likely due to the ' \
+           assert np.nanmin(MPASfield) >= 0.0, 'basalHeatFlux contains negative values! This is likely due to the ' \
                                           'conventions used in the input file, rather than bad data. Ensure ' \
                                           'non-negative values before interpolating.'
            


### PR DESCRIPTION
Ignore NaNs when checking for negative basalHeatFlux by using np.nanmin() instead of just min(). This will not throw an assertion error when NaNs are present in the interpolated basalHeatFlux field. NaNs in datasets are a separate issue from sign conventions, so will be dealt with separately. This merge fixes a bug introduced in #543. 