### PR TITLE
Make some variables optional in MpasCellCuller.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
   - bash: |
       eval "$(conda shell.bash hook)"
       conda activate build
-      conda build -m "conda_package/ci/linux_python${PYTHON_VERSION}.yaml" "conda_package/recipe"
+      conda build -m "conda_package/ci/linux_64_python${PYTHON_VERSION}.____cpython.yaml" "conda_package/recipe"
     displayName: Build MPAS-Tools
 
   - bash: |
@@ -158,7 +158,7 @@ jobs:
   - bash: |
       eval "$(conda shell.bash hook)"
       conda activate build
-      conda build -m "conda_package/ci/osx_python${PYTHON_VERSION}.yaml" "conda_package/recipe"
+      conda build -m "conda_package/ci/osx_64_python${PYTHON_VERSION}.____cpython.yaml" "conda_package/recipe"
     displayName: Build MPAS-Tools
 
   - bash: |

--- a/conda_package/ci/linux_64_python3.10.____cpython.yaml
+++ b/conda_package/ci/linux_64_python3.10.____cpython.yaml
@@ -1,0 +1,33 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '12'
+hdf5:
+- 1.14.3
+libnetcdf:
+- 4.9.2
+netcdf_fortran:
+- '4.6'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda_package/ci/linux_64_python3.11.____cpython.yaml
+++ b/conda_package/ci/linux_64_python3.11.____cpython.yaml
@@ -1,0 +1,33 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '12'
+hdf5:
+- 1.14.3
+libnetcdf:
+- 4.9.2
+netcdf_fortran:
+- '4.6'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda_package/ci/linux_64_python3.12.____cpython.yaml
+++ b/conda_package/ci/linux_64_python3.12.____cpython.yaml
@@ -1,25 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libnetcdf:
 - 4.9.2
-llvm_openmp:
-- '15'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 netcdf_fortran:
 - '4.6'
 pin_run_as_build:
@@ -27,9 +25,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - cxx_compiler_version
   - fortran_compiler_version

--- a/conda_package/ci/linux_64_python3.8.____cpython.yaml
+++ b/conda_package/ci/linux_64_python3.8.____cpython.yaml
@@ -1,25 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libnetcdf:
 - 4.9.2
-llvm_openmp:
-- '15'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 netcdf_fortran:
 - '4.6'
 pin_run_as_build:
@@ -27,9 +25,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - cxx_compiler_version
   - fortran_compiler_version

--- a/conda_package/ci/linux_64_python3.9.____cpython.yaml
+++ b/conda_package/ci/linux_64_python3.9.____cpython.yaml
@@ -1,0 +1,33 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '12'
+hdf5:
+- 1.14.3
+libnetcdf:
+- 4.9.2
+netcdf_fortran:
+- '4.6'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- linux-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda_package/ci/osx_64_python3.10.____cpython.yaml
+++ b/conda_package/ci/osx_64_python3.10.____cpython.yaml
@@ -1,23 +1,25 @@
-cdt_name:
-- cos6
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libnetcdf:
 - 4.9.2
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 netcdf_fortran:
 - '4.6'
 pin_run_as_build:
@@ -25,9 +27,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - cxx_compiler_version
   - fortran_compiler_version

--- a/conda_package/ci/osx_64_python3.11.____cpython.yaml
+++ b/conda_package/ci/osx_64_python3.11.____cpython.yaml
@@ -1,23 +1,25 @@
-cdt_name:
-- cos6
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libnetcdf:
 - 4.9.2
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 netcdf_fortran:
 - '4.6'
 pin_run_as_build:
@@ -25,9 +27,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - cxx_compiler_version
   - fortran_compiler_version

--- a/conda_package/ci/osx_64_python3.12.____cpython.yaml
+++ b/conda_package/ci/osx_64_python3.12.____cpython.yaml
@@ -1,0 +1,35 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '12'
+hdf5:
+- 1.14.3
+libnetcdf:
+- 4.9.2
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+netcdf_fortran:
+- '4.6'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda_package/ci/osx_64_python3.8.____cpython.yaml
+++ b/conda_package/ci/osx_64_python3.8.____cpython.yaml
@@ -1,23 +1,25 @@
-cdt_name:
-- cos6
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libnetcdf:
 - 4.9.2
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 netcdf_fortran:
 - '4.6'
 pin_run_as_build:
@@ -25,9 +27,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - cxx_compiler_version
   - fortran_compiler_version

--- a/conda_package/ci/osx_64_python3.9.____cpython.yaml
+++ b/conda_package/ci/osx_64_python3.9.____cpython.yaml
@@ -7,17 +7,17 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.2
+- 1.14.3
 libnetcdf:
 - 4.9.2
 llvm_openmp:
-- '15'
+- '16'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 netcdf_fortran:
@@ -27,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/mesh_tools/mesh_conversion_tools_netcdf_c/mpas_cell_culler.cpp
+++ b/mesh_tools/mesh_conversion_tools_netcdf_c/mpas_cell_culler.cpp
@@ -1232,7 +1232,7 @@ int mapAndOutputEdgeFields( const string inputFilename, const string outputFilen
     double *dcEdgeOld, *dcEdgeNew;
     double *angleEdgeOld, *angleEdgeNew;
 
-    bool hasWeightsOnEdge;
+    bool hasWeightsOnEdge, hasAngleEdge;
 
     // Need to map cellsOnEdge and verticesOnEdge
     cellsOnEdgeOld = new int[nEdges*2];
@@ -1387,7 +1387,7 @@ int mapAndOutputEdgeFields( const string inputFilename, const string outputFilen
 
             for(int j = edgeCount; j < maxEdges2New; j++){
                 edgesOnEdgeNew[edgeMap.at(iEdge)*maxEdges2New + j] = 0;
-                if(hasWeightsOnEdge) {
+                if(hasWeightsOnEdge){
                     weightsOnEdgeNew[edgeMap.at(iEdge)*maxEdges2New + j] = 0;
                 }
             }
@@ -1427,13 +1427,22 @@ int mapAndOutputEdgeFields( const string inputFilename, const string outputFilen
 
     ncutil::get_var(inputFilename, "dvEdge", dvEdgeOld);
     ncutil::get_var(inputFilename, "dcEdge", dcEdgeOld);
-    ncutil::get_var(inputFilename, "angleEdge", angleEdgeOld);
+
+    try{
+        ncutil::get_var(inputFilename, "angleEdge", angleEdgeOld);
+        hasAngleEdge = true;
+    } catch (...) {
+        // allow errors for optional vars. not found
+        hasAngleEdge = false;
+    }
 
     for(int iEdge = 0; iEdge < nEdges; iEdge++){
         if(edgeMap.at(iEdge) != -1){
             dvEdgeNew[edgeMap.at(iEdge)] = dvEdgeOld[iEdge];
             dcEdgeNew[edgeMap.at(iEdge)] = dcEdgeOld[iEdge];
-            angleEdgeNew[edgeMap.at(iEdge)] = angleEdgeOld[iEdge];
+            if(hasAngleEdge) {
+                angleEdgeNew[edgeMap.at(iEdge)] = angleEdgeOld[iEdge];
+            }
         }
     }
 
@@ -1446,7 +1455,9 @@ int mapAndOutputEdgeFields( const string inputFilename, const string outputFilen
 
     ncutil::put_var(outputFilename, "dvEdge", &dvEdgeNew[0]);
     ncutil::put_var(outputFilename, "dcEdge", &dcEdgeNew[0]);
-    ncutil::put_var(outputFilename, "angleEdge", &angleEdgeNew[0]);
+    if(hasAngleEdge) {
+        ncutil::put_var(outputFilename, "angleEdge", &angleEdgeNew[0]);
+    }
 
     delete[] dvEdgeOld;
     delete[] dvEdgeNew;


### PR DESCRIPTION
We want to be able to run the cell culler even on meshes (e.g. in MPAS-Seaice restart files) without `meshDensity`, `weightsOnEdge`, and `angleEdge` as variables.

I have made some updates to the configurations used to make local package builds and run CI so they match the package versions that conda-forge is using.  I include this here because I used it in testing these changes.