### PR TITLE
Typo: Fix 'distination' to 'destination'

### DIFF
--- a/mesh_tools/grid_rotate/grid_rotate.f90
+++ b/mesh_tools/grid_rotate/grid_rotate.f90
@@ -95,7 +95,7 @@ contains
       end if
 
       if(trim(newFilename) == "") then
-         write(0,*) "Error: no distination file was specified"
+         write(0,*) "Error: no destination file was specified"
          return
       end if
 


### PR DESCRIPTION
## Changes

- Fixed typo from `distination` to `destination` in the error message.