### PR TITLE
Add south polar stereographic projection of a sphere

### DIFF
--- a/mesh_tools/planar_grid_transformations/set_lat_lon_fields_in_planar_grid.py
+++ b/mesh_tools/planar_grid_transformations/set_lat_lon_fields_in_planar_grid.py
@@ -31,6 +31,11 @@ projections['gis-gimp'] = '+proj=stere +lat_ts=70.0 +lat_0=90 +lon_0=315.0 +k_0=
 # BEDMAP2 projection
 projections['ais-bedmap2'] = '+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0 +k_0=1.0 +x_0=0.0 +y_0=0.0 +ellps=WGS84'  # Note: BEDMAP2 elevations use EIGEN-GL04C geoid
 
+# BEDMAP2 projection of sphere. This projection must be used to adjust MALI mesh when performing 
+# coupled MALI-SeaLevelModel simulations. Otherwise, ice mass won't be conserved between the MALI planar mesh and
+# the spherical sea-level model grid during the post-processing (output analysis) step.
+projections['ais-bedmap2-sphere'] = '+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0 +k_0=1.0 +x_0=0.0 +y_0=0.0 +ellps=sphere'
+
 # Standard Lat/Long
 projections['latlon'] = '+proj=longlat +ellps=WGS84'
 # ===================================


### PR DESCRIPTION
Previously, the south polar projection onto the planar MALI mesh was done based on an ellipsoidal Earth. However, using the MALI mesh using this projection in coupled MALI and Sea Level Model simulations resulted in inconsistency in post-simulation ice mass calculation over Antarctica because the SLM grid assumes spherical global grid in its calculation. To address this issue, while not a fundamental fix in the meshing process, an interim solution was made to project the southern polar region onto the MALI planar mesh assuming a sphere so that it is consistent with the SLM; this PR adds the new projection.