### PR TITLE
Fix registering colormaps

### DIFF
--- a/conda_package/dev-spec.txt
+++ b/conda_package/dev-spec.txt
@@ -12,7 +12,7 @@ inpoly
 jigsaw>=0.9.12
 jigsawpy>=0.2.1
 libnetcdf
-matplotlib-base
+matplotlib-base>=3.9.0
 netcdf4
 numpy>=2.0,<3.0
 progressbar2

--- a/conda_package/mpas_tools/viz/colormaps.py
+++ b/conda_package/mpas_tools/viz/colormaps.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as ET
 from importlib.resources import files as imp_res_files
 from matplotlib.colors import LinearSegmentedColormap
 import matplotlib.pyplot as plt
+from matplotlib import colormaps
 
 
 def register_sci_viz_colormaps():
@@ -43,5 +44,5 @@ def _read_xml_colormap(xmlFile, mapName):
 
 def _register_colormap_and_reverse(mapName, cmap):
     if mapName not in plt.colormaps():
-        plt.register_cmap(mapName, cmap)
-        plt.register_cmap('{}_r'.format(mapName), cmap.reversed())
+        colormaps.register(cmap=cmap, name=mapName)
+        colormaps.register(cmap=cmap.reversed(), name='{}_r'.format(mapName))

--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -65,7 +65,7 @@ requirements:
     - jigsawpy >=0.2.1
     - libnetcdf
     - netcdf-fortran
-    - matplotlib-base
+    - matplotlib-base >=3.9.0
     - netcdf4
     - numpy >=2.0,<3.0
     - progressbar2

--- a/conda_package/setup.py
+++ b/conda_package/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'cmocean',
     'dask',
     'inpoly',
-    'matplotlib',
+    'matplotlib >=3.9.0',
     'netcdf4',
     'numpy',
     'progressbar2',


### PR DESCRIPTION
`plt.register_cmap()` seems to have been removed in the latest `matplotlib`.