### PR TITLE
Extrapolate landice variable

### DIFF
--- a/landice/mesh_tools_li/extrapolate_variable.py
+++ b/landice/mesh_tools_li/extrapolate_variable.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Script to extrapolate arbitrary variable
+Script to extrapolate arbitrary MALI variable
 
 Created on Mon Feb1 2021
 

--- a/landice/mesh_tools_li/extrapolate_variable.py
+++ b/landice/mesh_tools_li/extrapolate_variable.py
@@ -44,8 +44,16 @@ yCell = dataset.variables["xCell"][:]
 # Define region of good data to extrapolate from.  Different methods for different variables
 if var_name in ["effectivePressure", "beta", "muFriction"]:
     groundedMask = (thickness > (-1028.0 / 910.0 * bed))
-    keepCellMask = groundedMask * (varValue > 0.0)
+    keepCellMask = np.copy(groundedMask)
     extrapolation == "min"
+
+    for iCell in range(nCells):
+        for n in range(nEdgesOnCell[iCell]):
+            jCell = cellsOnCell[iCell, n] - 1
+            if (groundedMask[jCell] == 1):
+                keepCellMask[iCell] = 1
+                continue
+    keepCellMask *= (varValue > 0)  # ensure zero muFriction does not get extrapolated
 elif var_name in ["floatingBasalMassBal"]:
     floatingMask = (thickness <= (-1028.0 / 910.0 * bed))
     keepCellMask = floatingMask * (varValue != 0.0)

--- a/landice/mesh_tools_li/extrapolate_variable.py
+++ b/landice/mesh_tools_li/extrapolate_variable.py
@@ -43,6 +43,10 @@ nCells = len(dataset.dimensions['nCells'])
 if 'thickness' in dataset.variables.keys():
     thickness = dataset.variables['thickness'][0,:]
     bed = dataset.variables["bedTopography"][0,:]
+    geometry = True
+else:
+    geometry = False
+
 cellsOnCell = dataset.variables['cellsOnCell'][:]
 nEdgesOnCell = dataset.variables['nEdgesOnCell'][:]
 xCell = dataset.variables["yCell"][:]
@@ -88,8 +92,11 @@ for v in range(n_vert):
         # Get rid of invalid values
         keepCellMask *= (varValue < 1.e12)
     elif var_name in ["floatingBasalMassBal"]:
-        floatingMask = (thickness <= (-1028.0 / 910.0 * bed))
-        keepCellMask = floatingMask * (varValue != 0.0)
+        if geometry:
+            floatingMask = (thickness <= (-1028.0 / 910.0 * bed))
+            keepCellMask = floatingMask * (varValue != 0.0)
+        else:
+            keepCellMask = (varValue != 0.0)
         extrapolation == "idw"
     else:
         keepCellMask = (thickness > 0.0)

--- a/landice/mesh_tools_li/extrapolate_variable.py
+++ b/landice/mesh_tools_li/extrapolate_variable.py
@@ -79,7 +79,6 @@ for v in range(n_vert):
     if var_name in ["effectivePressure", "beta", "muFriction"]:
         groundedMask = (thickness > (-1028.0 / 910.0 * bed))
         keepCellMask = np.copy(groundedMask) * np.isfinite(varValue)
-        extrapolation == "min"
 
         for iCell in range(nCells):
             for n in range(nEdgesOnCell[iCell]):
@@ -97,7 +96,6 @@ for v in range(n_vert):
             keepCellMask = floatingMask * (varValue != 0.0)
         else:
             keepCellMask = (varValue != 0.0)
-        extrapolation == "idw"
     else:
         keepCellMask = (thickness > 0.0)
 

--- a/landice/mesh_tools_li/extrapolate_variable.py
+++ b/landice/mesh_tools_li/extrapolate_variable.py
@@ -16,12 +16,18 @@ import sys
 from datetime import datetime
 
 
-parser = OptionParser(description='Convert data from exodus file to MPAS mesh. WARNING: Change the SEACAS library dir to your own path! A simple usage example: conversion_exodus_init_to_mpasli_mesh.py -e antarctica.exo -o target.nc -a ./mpas_cellID.ascii -v beta')
+parser = OptionParser(
+    description='Extrapolate a variable into undefined regions')
 
-parser.add_option("-f", "--file", dest="nc_file", help="the mpas file to write to")
-parser.add_option("-v", "--variable", dest="var_name", help="the mpas variable(s) you want to extrapolate")
-parser.add_option("-m", "--method", dest="extrapolation", default='min', help="idw, min, or value method of extrapolation")
-parser.add_option("-s", "--set_value", dest="set_value", default=None, help="value to set variable to outside keepCellMask when using -v value")
+parser.add_option("-f", "--file", dest="nc_file",
+                  help="the mpas file to write to")
+parser.add_option("-v", "--variable", dest="var_name",
+                  help="the mpas variable(s) you want to extrapolate")
+parser.add_option("-m", "--method", dest="extrapolation", default='min',
+                  help="idw, min, or value method of extrapolation")
+parser.add_option("-s", "--set_value", dest="set_value", default=None,
+                  help=("value to set variable to outside "
+                        "keepCellMask when using -v value"))
 
 for option in parser.option_list:
     if option.default != ("NO", "DEFAULT"):
@@ -51,7 +57,8 @@ elif dataset.variables[var_name].ndim == 3:
     print(dataset.variables[var_name].dimensions[2])
     vert_dim_name = dataset.variables[var_name].dimensions[2]
     n_vert = len(dataset.dimensions[vert_dim_name])
-    print(f"This variable has a vertical dimension of {vert_dim_name} with size {n_vert}")
+    print(f"This variable has a vertical dimension "
+          f"of {vert_dim_name} with size {n_vert}")
     print("")
 else:
     print("Unexpected number of dimension in variable")
@@ -63,7 +70,8 @@ for v in range(n_vert):
     else:
         varValue = dataset.variables[var_name][0, :]
 
-    # Define region of good data to extrapolate from.  Different methods for different variables
+    # Define region of good data to extrapolate from.
+    # Different methods for different variables
     if var_name in ["effectivePressure", "beta", "muFriction"]:
         groundedMask = (thickness > (-1028.0 / 910.0 * bed))
         keepCellMask = np.copy(groundedMask) * np.isfinite(varValue)
@@ -75,8 +83,10 @@ for v in range(n_vert):
                 if (groundedMask[jCell] == 1):
                     keepCellMask[iCell] = 1
                     continue
-        keepCellMask *= (varValue > 0)  # ensure zero muFriction does not get extrapolated
-        keepCellMask *= (varValue < 1.e12)  # get rid of ridiculous values
+        # ensure zero muFriction does not get extrapolated
+        keepCellMask *= (varValue > 0)
+        # Get rid of invalid values
+        keepCellMask *= (varValue < 1.e12)
     elif var_name in ["floatingBasalMassBal"]:
         floatingMask = (thickness <= (-1028.0 / 910.0 * bed))
         keepCellMask = floatingMask * (varValue != 0.0)
@@ -84,13 +94,17 @@ for v in range(n_vert):
     else:
         keepCellMask = (thickness > 0.0)
 
-    keepCellMaskNew = np.copy(keepCellMask)  # make a copy to edit that will be used later
-    keepCellMaskOrig = np.copy(keepCellMask)  # make a copy to edit that can be edited without changing the original
+    # make a copy to edit that will be used later
+    keepCellMaskNew = np.copy(keepCellMask)
+    # make a copy to edit that can be edited without changing the original
+    keepCellMaskOrig = np.copy(keepCellMask)
 
     # recursive extrapolation steps:
     # 1) find cell A with mask = 0
-    # 2) find how many surrounding cells have nonzero mask, and their indices (this will give us the cells from upstream)
-    # 3) use the values for nonzero mask upstream cells to extrapolate the value for cell A
+    # 2) find how many surrounding cells have nonzero mask, and
+    #    their indices (this will give us the cells from upstream)
+    # 3) use the values for nonzero mask upstream
+    #    cells toextrapolate the value for cell A
     # 4) change the mask for A from 0 to 1
     # 5) Update mask
     # 6) go to step 1)
@@ -106,12 +120,14 @@ for v in range(n_vert):
 
             for iCell in searchCells:
                 neighborcellID = cellsOnCell[iCell,:nEdgesOnCell[iCell]]-1
-                neighborcellID = neighborcellID[neighborcellID>=0] # Important: ignore the phantom "neighbors" that are off the edge of the mesh (0 values in cellsOnCell)
-
-                mask_for_idx = keepCellMask[neighborcellID] # active cell mask
+                # Important: ignore the phantom "neighbors" that are
+                # off the edge of the mesh (0 values in cellsOnCell)
+                neighborcellID = neighborcellID[neighborcellID>=0]
+                # active cell mask
+                mask_for_idx = keepCellMask[neighborcellID]
                 mask_nonzero_idx, = np.nonzero(mask_for_idx)
-
-                nonzero_id = neighborcellID[mask_nonzero_idx] # id for nonzero beta cells
+                # id for nonzero beta cells
+                nonzero_id = neighborcellID[mask_nonzero_idx]
                 nonzero_num = np.count_nonzero(mask_for_idx)
 
                 assert len(nonzero_id) == nonzero_num
@@ -130,26 +146,31 @@ for v in range(n_vert):
                     elif extrapolation == 'min':
                         varValue[iCell] = np.min(var_adj)
                     else:
-                        sys.exit("ERROR: wrong extrapolation scheme! Set option m as idw or min!")
+                        sys.exit("ERROR: wrong extrapolation scheme!"
+                                 " Set option m as idw or min!")
 
                     keepCellMaskNew[iCell] = 1
 
-            print ("{0:8d} cells left for extrapolation in total {1:8d} cells".format(nCells-np.count_nonzero(keepCellMask),  nCells))
+            print(f"{nCells-np.count_nonzero(keepCellMask)} cells left "
+                  f"for extrapolation in total {nCells} cells")
 
+    # Write updated array to file
     if has_vertical_dim == True:
-        dataset.variables[var_name][0,:,v] = varValue # Put updated array back into file.
+        dataset.variables[var_name][0,:,v] = varValue
     else:
-        dataset.variables[var_name][0,:] = varValue # Put updated array back into file.
+        dataset.variables[var_name][0,:] = varValue
+
 # === Clean-up =============
 
 # Update history attribute of netCDF file
-thiscommand = datetime.now().strftime("%a %b %d %H:%M:%S %Y") + ": " + " ".join(sys.argv[:])
-thiscommand = thiscommand+";  {} successfully extrapolated using the {} method".format(var_name, extrapolation)
+thiscommand = datetime.now().strftime("%a %b %d %H:%M:%S %Y") \
+              + ": " + " ".join(sys.argv[:])
+thiscommand = thiscommand + f";  {var_name} successfully extrapolated " + \
+              f"using the {extrapolation} method"
 if hasattr(dataset, 'history'):
    newhist = '\n'.join([thiscommand, getattr(dataset, 'history')])
 else:
    newhist = thiscommand
 setattr(dataset, 'history', newhist)
-
 
 dataset.close()

--- a/landice/mesh_tools_li/extrapolate_variable.py
+++ b/landice/mesh_tools_li/extrapolate_variable.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+"""
+Script to extrapolate arbitrary variable
+
+Created on Mon Feb1 2021
+
+@author: Matt Hoffman, Trevor Hillebrand
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from netCDF4 import Dataset
+from optparse import OptionParser
+import sys
+from datetime import datetime
+
+
+parser = OptionParser(description='Convert data from exodus file to MPAS mesh. WARNING: Change the SEACAS library dir to your own path! A simple usage example: conversion_exodus_init_to_mpasli_mesh.py -e antarctica.exo -o target.nc -a ./mpas_cellID.ascii -v beta')
+
+parser.add_option("-f", "--file", dest="nc_file", help="the mpas file to write to")
+parser.add_option("-v", "--variable", dest="var_name", help="the mpas variable(s) you want to extrapolate")
+parser.add_option("-m", "--method", dest="extrapolation", default='min', help="idw or min method of extrapolation")
+
+for option in parser.option_list:
+    if option.default != ("NO", "DEFAULT"):
+        option.help += (" " if option.help else "") + "[default: %default]"
+options, args = parser.parse_args()
+
+dataset = Dataset(options.nc_file, 'r+')
+var_name = options.var_name
+varValue = dataset.variables[var_name][0, :]
+extrapolation = options.extrapolation
+# Extrapolation
+nCells = len(dataset.dimensions['nCells'])
+if 'thickness' in dataset.variables.keys():
+    thickness = dataset.variables['thickness'][0,:]
+cellsOnCell = dataset.variables['cellsOnCell'][:]
+nEdgesOnCell = dataset.variables['nEdgesOnCell'][:]
+xCell = dataset.variables["yCell"][:]
+yCell = dataset.variables["xCell"][:]
+
+
+keepCellMask = np.zeros((nCells,), dtype=np.int8)
+
+# Define region of good data to extrapolate from.  Different methods for different variables
+if var_name == "beta" or var_name == "muFriction":
+    keepCellMask[varValue > 0.0] = 1
+    extrapolation == "min"
+# find the mask for grounded ice region
+else:
+    keepCellMask[thickness > 0.0] = 1
+
+keepCellMaskNew = np.copy(keepCellMask)  # make a copy to edit that will be used later
+keepCellMaskOrig = np.copy(keepCellMask)  # make a copy to edit that can be edited without changing the original
+
+
+# recursive extrapolation steps:
+# 1) find cell A with mask = 0
+# 2) find how many surrounding cells have nonzero mask, and their indices (this will give us the cells from upstream)
+# 3) use the values for nonzero mask upstream cells to extrapolate the value for cell A
+# 4) change the mask for A from 0 to 1
+# 5) Update mask
+# 6) go to step 1)
+
+print("\nStart {} extrapolation using {} method".format(var_name, extrapolation))
+while np.count_nonzero(keepCellMask) != nCells:
+
+    keepCellMask = np.copy(keepCellMaskNew)
+    searchCells = np.where(keepCellMask==0)[0]
+    varValueOld = np.copy(varValue)
+
+    for iCell in searchCells:
+        neighborcellID = cellsOnCell[iCell,:nEdgesOnCell[iCell]]-1
+        neighborcellID = neighborcellID[neighborcellID>=0] # Important: ignore the phantom "neighbors" that are off the edge of the mesh (0 values in cellsOnCell)
+
+        mask_for_idx = keepCellMask[neighborcellID] # active cell mask
+        mask_nonzero_idx, = np.nonzero(mask_for_idx)
+
+        nonzero_id = neighborcellID[mask_nonzero_idx] # id for nonzero beta cells
+        nonzero_num = np.count_nonzero(mask_for_idx)
+
+        assert len(nonzero_id) == nonzero_num
+
+        if nonzero_num > 0:
+            x_i = xCell[iCell]
+            y_i = yCell[iCell]
+            x_adj = xCell[nonzero_id]
+            y_adj = yCell[nonzero_id]
+            var_adj = varValueOld[nonzero_id]
+            if extrapolation == 'idw':
+                ds = np.sqrt((x_i-x_adj)**2+(y_i-y_adj)**2)
+                assert np.count_nonzero(ds)==len(ds)
+                var_interp = 1.0/sum(1.0/ds)*sum(1.0/ds*var_adj)
+                varValue[iCell] = var_interp
+            elif extrapolation == 'min':
+                varValue[iCell] = np.min(var_adj)
+            else:
+                sys.exit("ERROR: wrong extrapolation scheme! Set option x as idw or min!")
+
+            keepCellMaskNew[iCell] = 1
+
+    print ("{0:8d} cells left for extrapolation in total {1:8d} cells".format(nCells-np.count_nonzero(keepCellMask),  nCells))
+dataset.variables[var_name][0,:] = varValue # Put updated array back into file.
+# === Clean-up =============
+
+# Update history attribute of netCDF file
+thiscommand = datetime.now().strftime("%a %b %d %H:%M:%S %Y") + ": " + " ".join(sys.argv[:])
+thiscommand = thiscommand+";  {} successfully extrapolated using the {} method".format(var_name, extrapolation)
+if hasattr(dataset, 'history'):
+   newhist = '\n'.join([thiscommand, getattr(dataset, 'history')])
+else:
+   newhist = thiscommand
+setattr(dataset, 'history', newhist)
+
+
+dataset.close()

--- a/landice/mesh_tools_li/extrapolate_variable.py
+++ b/landice/mesh_tools_li/extrapolate_variable.py
@@ -20,7 +20,8 @@ parser = OptionParser(description='Convert data from exodus file to MPAS mesh. W
 
 parser.add_option("-f", "--file", dest="nc_file", help="the mpas file to write to")
 parser.add_option("-v", "--variable", dest="var_name", help="the mpas variable(s) you want to extrapolate")
-parser.add_option("-m", "--method", dest="extrapolation", default='min', help="idw or min method of extrapolation")
+parser.add_option("-m", "--method", dest="extrapolation", default='min', help="idw, min, or value method of extrapolation")
+parser.add_option("-s", "--set_value", dest="set_value", default=None, help="value to set variable to outside keepCellMask when using -v value")
 
 for option in parser.option_list:
     if option.default != ("NO", "DEFAULT"):
@@ -73,43 +74,46 @@ keepCellMaskOrig = np.copy(keepCellMask)  # make a copy to edit that can be edit
 # 6) go to step 1)
 
 print("\nStart {} extrapolation using {} method".format(var_name, extrapolation))
-while np.count_nonzero(keepCellMask) != nCells:
+if extrapolation == 'value':
+    varValue[np.where(np.logical_not(keepCellMask))] = float(options.set_value)
+else:
+    while np.count_nonzero(keepCellMask) != nCells:
+        keepCellMask = np.copy(keepCellMaskNew)
+        searchCells = np.where(keepCellMask==0)[0]
+        varValueOld = np.copy(varValue)
+    
+        for iCell in searchCells:
+            neighborcellID = cellsOnCell[iCell,:nEdgesOnCell[iCell]]-1
+            neighborcellID = neighborcellID[neighborcellID>=0] # Important: ignore the phantom "neighbors" that are off the edge of the mesh (0 values in cellsOnCell)
+    
+            mask_for_idx = keepCellMask[neighborcellID] # active cell mask
+            mask_nonzero_idx, = np.nonzero(mask_for_idx)
+    
+            nonzero_id = neighborcellID[mask_nonzero_idx] # id for nonzero beta cells
+            nonzero_num = np.count_nonzero(mask_for_idx)
+    
+            assert len(nonzero_id) == nonzero_num
+    
+            if nonzero_num > 0:
+                x_i = xCell[iCell]
+                y_i = yCell[iCell]
+                x_adj = xCell[nonzero_id]
+                y_adj = yCell[nonzero_id]
+                var_adj = varValueOld[nonzero_id]
+                if extrapolation == 'idw':
+                    ds = np.sqrt((x_i-x_adj)**2+(y_i-y_adj)**2)
+                    assert np.count_nonzero(ds)==len(ds)
+                    var_interp = 1.0/sum(1.0/ds)*sum(1.0/ds*var_adj)
+                    varValue[iCell] = var_interp
+                elif extrapolation == 'min':
+                    varValue[iCell] = np.min(var_adj)
+                else:
+                    sys.exit("ERROR: wrong extrapolation scheme! Set option m as idw or min!")
+    
+                keepCellMaskNew[iCell] = 1
+    
+        print ("{0:8d} cells left for extrapolation in total {1:8d} cells".format(nCells-np.count_nonzero(keepCellMask),  nCells))
 
-    keepCellMask = np.copy(keepCellMaskNew)
-    searchCells = np.where(keepCellMask==0)[0]
-    varValueOld = np.copy(varValue)
-
-    for iCell in searchCells:
-        neighborcellID = cellsOnCell[iCell,:nEdgesOnCell[iCell]]-1
-        neighborcellID = neighborcellID[neighborcellID>=0] # Important: ignore the phantom "neighbors" that are off the edge of the mesh (0 values in cellsOnCell)
-
-        mask_for_idx = keepCellMask[neighborcellID] # active cell mask
-        mask_nonzero_idx, = np.nonzero(mask_for_idx)
-
-        nonzero_id = neighborcellID[mask_nonzero_idx] # id for nonzero beta cells
-        nonzero_num = np.count_nonzero(mask_for_idx)
-
-        assert len(nonzero_id) == nonzero_num
-
-        if nonzero_num > 0:
-            x_i = xCell[iCell]
-            y_i = yCell[iCell]
-            x_adj = xCell[nonzero_id]
-            y_adj = yCell[nonzero_id]
-            var_adj = varValueOld[nonzero_id]
-            if extrapolation == 'idw':
-                ds = np.sqrt((x_i-x_adj)**2+(y_i-y_adj)**2)
-                assert np.count_nonzero(ds)==len(ds)
-                var_interp = 1.0/sum(1.0/ds)*sum(1.0/ds*var_adj)
-                varValue[iCell] = var_interp
-            elif extrapolation == 'min':
-                varValue[iCell] = np.min(var_adj)
-            else:
-                sys.exit("ERROR: wrong extrapolation scheme! Set option x as idw or min!")
-
-            keepCellMaskNew[iCell] = 1
-
-    print ("{0:8d} cells left for extrapolation in total {1:8d} cells".format(nCells-np.count_nonzero(keepCellMask),  nCells))
 dataset.variables[var_name][0,:] = varValue # Put updated array back into file.
 # === Clean-up =============
 

--- a/landice/mesh_tools_li/extrapolate_variable.py
+++ b/landice/mesh_tools_li/extrapolate_variable.py
@@ -22,7 +22,7 @@ parser = OptionParser(
 parser.add_option("-f", "--file", dest="nc_file",
                   help="the mpas file to write to")
 parser.add_option("-v", "--variable", dest="var_name",
-                  help="the mpas variable(s) you want to extrapolate")
+                  help="the MALI variable you want to extrapolate")
 parser.add_option("-m", "--method", dest="extrapolation", default='min',
                   help="idw, min, or value method of extrapolation")
 parser.add_option("-s", "--set_value", dest="set_value", default=None,


### PR DESCRIPTION
Add a script to extrapolate landice variables into regions of missing or invalid data using nearest-neighbor or inverse-distance weighted methods.