### PR TITLE
Add `meshDensity` in mesh conversion if not already present

### DIFF
--- a/mesh_tools/mesh_conversion_tools_netcdf_c/mpas_mesh_converter.cpp
+++ b/mesh_tools/mesh_conversion_tools_netcdf_c/mpas_mesh_converter.cpp
@@ -476,7 +476,14 @@ int readGridInput(const string inputFilename){/*{{{*/
 
     meshDensity.clear();
     meshDensity.resize(cells.size());
-    ncutil::get_var(inputFilename, "meshDensity", &meshDensity[0]);
+    try {
+        ncutil::get_var(inputFilename, "meshDensity", &meshDensity[0]);
+    } catch (...) {
+        // should be all ones by default
+        for(int i = 0; i < nCells; i++){
+            meshDensity[i] = 1.0;
+        }
+    }
 
     xCellDistance = fabs(xCellRange[1] - xCellRange[0]);
     yCellDistance = fabs(yCellRange[1] - yCellRange[0]);


### PR DESCRIPTION
@changliao1025 discovered that the new `MpasMeshConverter.x` (the one with NetCDF-C support) doesn't correctly handle the case where `meshDensity` is not passed in.  In the older version of the tool, `meshDensity` was set to all ones if it isn't present, and I have added that here.