### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # MPAS Tools
 
-[![Build Status](https://dev.azure.com/MPAS-Dev/MPAS-Tools%20testing/_apis/build/status/MPAS-Dev.MPAS-Tools?branchName=master)](https://dev.azure.com/MPAS-Dev/MPAS-Tools%20testing/_build/latest?definitionId=4&branchName=master)
-
 This repository houses all MPAS related tools. These include compiled tools,
 and scripts with a variety of purposes. Tools should be sorted into larger
 directories based on their purpose. Under each of these directories, a tool
@@ -11,7 +9,7 @@ should live in it's own directory.
 
 The latest documentation for the conda package `mpas-tools` can be found here:
 
-[http://mpas-dev.github.io/MPAS-Tools/stable/](http://mpas-dev.github.io/MPAS-Tools/stable/)
+[http://mpas-dev.github.io/MPAS-Tools/master/](http://mpas-dev.github.io/MPAS-Tools/master/)
 
 Many tools are not in the conda package, and documentation (sometimes fairly
 limited) is available at the beginning of each script.


### PR DESCRIPTION
This merge removes the Azure Pipelines badge and points to the new location of the docs for the conda package.