### PR TITLE
Add dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "xylar"
+    reviewers:
+      - "xylar"
+      - "altheaden"
+


### PR DESCRIPTION
This PR adds the dependabot workflow. Dependabot checks for updates to dependencies on a weekly basis, and makes a PR when an update is available. 