### PR TITLE
Add setuptools to dev environment

### DIFF
--- a/conda_package/dev-spec.txt
+++ b/conda_package/dev-spec.txt
@@ -28,6 +28,7 @@ xarray
 # Development
 pip
 pytest
+setuptools
 
 # Documentation
 sphinx


### PR DESCRIPTION
The lack of `setuptools` seems to be causing CI failures.