### PR TITLE
Move `ocean` and `visualization` conda-package scripts

### DIFF
--- a/conda_package/docs/ocean/moc.rst
+++ b/conda_package/docs/ocean/moc.rst
@@ -75,14 +75,14 @@ In this example, only the ``mesh.nc`` file is required as an input.  The
 resulting ``xarray.Dataset`` contains both the basin and southern-transect
 masks.
 
-A command-line tool ``moc_southern_boundary_extractor.py`` is also available
+A command-line tool ``moc_southern_boundary_extractor`` is also available
 for this purpose:
 
 .. code-block:: none
 
-    $ moc_southern_boundary_extractor.py --help
+    $ moc_southern_boundary_extractor --help
 
-    usage: moc_southern_boundary_extractor.py [-h] -f IN_FILE -m MESH_FILE -o
+    usage: moc_southern_boundary_extractor [-h] -f IN_FILE -m MESH_FILE -o
                                               OUT_FILE
 
     This script takes a mesh file (-m flag) and a file with MOC regions masks
@@ -91,9 +91,6 @@ for this purpose:
     boundary of each region in a file indicated with the -o flag.  The transect
     is applied only to vertices and edges, not cells, because the need for southern
     boundary transect data on cells is not foreseen.
-
-    Author: Xylar Asay-Davis
-    last modified: 5/22/2018
 
     optional arguments:
       -h, --help            show this help message and exit

--- a/conda_package/docs/visualization.rst
+++ b/conda_package/docs/visualization.rst
@@ -39,7 +39,7 @@ ParaVeiw, meaning each cell has the correct polygonal geometry and will be
 visualized with a single, constant value for a given field.  The extractor,
 which is available either through the
 :py:func:`mpas_tools.viz.paraview_extractor.extract_vtk()` function or the
-``paraview_vtk_field_extractor.py`` command-line interface, can also be used to
+``paraview_vtk_field_extractor`` command-line interface, can also be used to
 visualize data on MPAS vertices (visualized on triangles) and edges (visualized
 on quadrilaterals).
 
@@ -128,7 +128,7 @@ The same extraction could be accomplished with the command-line tool as follows:
 
 .. code-block:: none
 
-    $ paraview_vtk_field_extractor.py \
+    $ paraview_vtk_field_extractor \
          -f "analysis_members/mpaso.hist.am.timeSeriesStatsDaily.*.nc" \
          -v timeDaily_avg_activeTracers_temperature -d nVertLevels=0 \
          -m init.nc -o vtk_files --xtime=xtime_startDaily

--- a/conda_package/mpas_tools/ocean/coastline_alteration.py
+++ b/conda_package/mpas_tools/ocean/coastline_alteration.py
@@ -38,8 +38,13 @@ def main_add_critical_land_blockages():
     """
     Entry point for add_critical_land_blockages command-line tool
     """
+    description = """
+Add transects that identify critical regions where narrow strips of land block
+ocean flow.  These are, essentially, the opposite of critical passages, which
+must remain open for ocean flow.
+"""
     parser = \
-        argparse.ArgumentParser(description=__doc__,
+        argparse.ArgumentParser(description=description,
                                 formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-f", "--input_mask_file", dest="input_mask_filename",
                         help="Mask file that includes cell and edge masks.",
@@ -109,8 +114,13 @@ def main_widen_transect_edge_masks():
     """
     Entry point for widen_transect_edge_masks command-line tool
     """
+    description = """
+Alter transects to be at least two cells wide.  This is used for critical
+passages, to avoid sea ice blockage.  Specifically, mark cells on both sides
+of each transect edge mask as a water cell.
+"""
     parser = \
-        argparse.ArgumentParser(description=__doc__,
+        argparse.ArgumentParser(description=description,
                                 formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-f", "--mask_file", dest="mask_filename",
                         help="Mask file with cell and edge transect masks.",
@@ -207,8 +217,12 @@ def main_add_land_locked_cells_to_mask():
     """
     Entry point for add_land_locked_cells_to_mask command-line tool
     """
+    description = """
+Find ocean cells that are land-locked, and alter the cell
+mask so that they are counted as land cells.
+"""
     parser = \
-        argparse.ArgumentParser(description=__doc__,
+        argparse.ArgumentParser(description=description,
                                 formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-f", "--input_mask_file", dest="input_mask_filename",
                         help="Mask file that includes cell and edge masks.",

--- a/conda_package/mpas_tools/ocean/moc.py
+++ b/conda_package/mpas_tools/ocean/moc.py
@@ -116,8 +116,16 @@ def moc_southern_boundary_extractor():
     """
     Entry point for moc_southern_boundary_extractor command-line tool
     """
+    description = """
+This script takes a mesh file (-m flag) and a file with MOC regions masks
+(-f flag) produce by the MPAS mask creator.  The script produces a copy of
+the contents of the MOC mask file, adding transects that mark the southern
+boundary of each region in a file indicated with the -o flag.  The transect
+is applied only to vertices and edges, not cells, because the need for southern
+boundary transect data on cells is not foreseen.
+"""
     parser = \
-        argparse.ArgumentParser(description=__doc__,
+        argparse.ArgumentParser(description=description,
                                 formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-f', '--in_file', dest='in_file',
                         help='Input file with MOC masks', metavar='IN_FILE',

--- a/conda_package/recipe/build.sh
+++ b/conda_package/recipe/build.sh
@@ -3,13 +3,11 @@
 set -x
 set -e
 
-cp -r ocean landice visualization mesh_tools conda_package
-
 cd conda_package
 ${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
 
 # build and install ocean topography smoothing tool
-cd ${SRC_DIR}/conda_package/ocean/smooth_topo
+cd ${SRC_DIR}/ocean/smooth_topo
 mkdir build
 cd build
 cmake \
@@ -20,7 +18,7 @@ cmake --build .
 cmake --install .
 
 # build and install sea ice partitioning tool
-cd ${SRC_DIR}/conda_package/mesh_tools/seaice_grid_tools
+cd ${SRC_DIR}/mesh_tools/seaice_grid_tools
 mkdir build
 cd build
 cmake \
@@ -31,7 +29,7 @@ cmake --build .
 cmake --install .
 
 # build and install legacy mask creator
-cd ${SRC_DIR}/conda_package/mesh_tools/mesh_conversion_tools
+cd ${SRC_DIR}/mesh_tools/mesh_conversion_tools
 mkdir build
 cd build
 cmake \
@@ -42,7 +40,7 @@ cmake --build .
 cp MpasMaskCreator.x ${PREFIX}/bin
 
 # build and install mesh conversion tools
-cd ${SRC_DIR}/conda_package/mesh_tools/mesh_conversion_tools_netcdf_c
+cd ${SRC_DIR}/mesh_tools/mesh_conversion_tools_netcdf_c
 mkdir build
 cd build
 cmake \

--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -10,30 +10,6 @@ source:
 
 build:
   number: 0
-  entry_points:
-    - planar_hex = mpas_tools.planar_hex:main
-    - translate_planar_grid = mpas_tools.translate:main
-    - merge_grids = mpas_tools.merge_grids:main
-    - split_grids = mpas_tools.split_grids:main
-    - inject_bathymetry = mpas_tools.ocean.inject_bathymetry:main
-    - inject_preserve_floodplain = mpas_tools.ocean.inject_preserve_floodplain:main
-    - mpas_to_triangle = mpas_tools.mesh.creation.mpas_to_triangle:main
-    - triangle_to_netcdf = mpas_tools.mesh.creation.triangle_to_netcdf:main
-    - jigsaw_to_netcdf = mpas_tools.mesh.creation.jigsaw_to_netcdf:main
-    - scrip_from_mpas = mpas_tools.scrip.from_mpas:main
-    - ocean_add_depth = mpas_tools.ocean.depth:main_add_depth
-    - ocean_add_zmid = mpas_tools.ocean.depth:main_add_zmid
-    - ocean_write_time_varying_zmid = mpas_tools.ocean.depth:main_write_time_varying_zmid
-    - plot_ocean_transects = mpas_tools.ocean.viz.transects:main
-    - compute_mpas_region_masks = mpas_tools.mesh.mask:entry_point_compute_mpas_region_masks
-    - compute_mpas_transect_masks = mpas_tools.mesh.mask:entry_point_compute_mpas_transect_masks
-    - compute_mpas_flood_fill_mask = mpas_tools.mesh.mask:entry_point_compute_mpas_flood_fill_mask
-    - compute_lon_lat_region_masks = mpas_tools.mesh.mask:entry_point_compute_lon_lat_region_masks
-    - compute_projection_region_masks = mpas_tools.mesh.mask:entry_point_compute_projection_grid_region_masks
-    - prepare_seaice_partitions = mpas_tools.seaice.partition:prepare_partitions
-    - create_seaice_partitions = mpas_tools.seaice.partition:create_partitions
-    - simple_seaice_partitions = mpas_tools.seaice.partition:simple_partitions
-    - sort_mesh = mpas_tools.mesh.creation.sort_mesh:main
 
 requirements:
   build:
@@ -121,14 +97,14 @@ test:
     - define_cullMask.py --help
     - interpolate_to_mpasli_grid.py --help
     - mark_domain_boundaries_dirichlet.py --help
-    - add_land_locked_cells_to_mask.py --help
-    - widen_transect_edge_masks.py --help
-    - add_critical_land_blockages_to_mask.py --help
-    - moc_southern_boundary_extractor.py --help
+    - add_critical_land_blockages_to_mask --help
+    - add_land_locked_cells_to_mask --help
+    - widen_transect_edge_masks --help
+    - moc_southern_boundary_extractor --help
     - ocean_add_depth --help
     - ocean_add_zmid --help
     - ocean_write_time_varying_zmid --help
-    - paraview_vtk_field_extractor.py -f mesh_tools/mesh_conversion_tools/test/mesh.QU.1920km.151026.nc -v latCell,lonCell --ignore_time -o vtk_test
+    - paraview_vtk_field_extractor -f mesh_tools/mesh_conversion_tools/test/mesh.QU.1920km.151026.nc -v latCell,lonCell --ignore_time -o vtk_test
     - split_grids --help
     - merge_grids --help
     - inject_bathymetry mesh_tools/mesh_conversion_tools/test/mesh.QU.1920km.151026.nc

--- a/conda_package/setup.py
+++ b/conda_package/setup.py
@@ -33,7 +33,7 @@ version = re.search(r'{}\s*=\s*[(]([^)]*)[)]'.format('__version_info__'),
 
 os.chdir(here)
 
-for path in ['ocean', 'landice', 'visualization', 'mesh_tools']:
+for path in ['landice', 'mesh_tools']:
     destPath = './{}'.format(path)
     if os.path.exists(destPath):
         shutil.rmtree(destPath)
@@ -71,12 +71,7 @@ setup(name='mpas_tools',
                'landice/mesh_tools_li/create_landice_grid_from_generic_MPAS_grid.py',
                'landice/mesh_tools_li/define_cullMask.py',
                'landice/mesh_tools_li/interpolate_to_mpasli_grid.py',
-               'landice/mesh_tools_li/mark_domain_boundaries_dirichlet.py',
-               'ocean/coastline_alteration/add_land_locked_cells_to_mask.py',
-               'ocean/coastline_alteration/widen_transect_edge_masks.py',
-               'ocean/coastline_alteration/add_critical_land_blockages_to_mask.py',
-               'ocean/moc_southern_boundary_extractor/moc_southern_boundary_extractor.py',
-               'visualization/paraview_vtk_field_extractor/paraview_vtk_field_extractor.py'],
+               'landice/mesh_tools_li/mark_domain_boundaries_dirichlet.py'],
       install_requires=install_requires,
       entry_points={'console_scripts':
                     ['planar_hex = mpas_tools.planar_hex:main',
@@ -102,4 +97,11 @@ setup(name='mpas_tools',
                      'prepare_seaice_partitions = mpas_tools.seaice.partition:prepare_partitions',
                      'create_seaice_partitions = mpas_tools.seaice.partition:create_partitions',
                      'simple_seaice_partitions = mpas_tools.seaice.partition:simple_partitions',
-                     'vector_reconstruct = mpas_tools.vector.reconstruct:main']})
+                     'vector_reconstruct = mpas_tools.vector.reconstruct:main',
+                     'add_critical_land_blockages_to_mask = mpas_tools.ocean.coastline_alteration:main_add_critical_land_blockages',
+                     'add_land_locked_cells_to_mask = mpas_tools.ocean.coastline_alteration:main_add_land_locked_cells_to_mask',
+                     'widen_transect_edge_masks = mpas_tools.ocean.coastline_alteration:main_widen_transect_edge_masks',
+                     'moc_southern_boundary_extractor = mpas_tools.ocean.moc:moc_southern_boundary_extractor',
+                     'paraview_vtk_field_extractor = mpas_tools.viz.paraview_extractor:main',
+          ]
+      })

--- a/ocean/coastline_alteration/add_critical_land_blockages_to_mask.py
+++ b/ocean/coastline_alteration/add_critical_land_blockages_to_mask.py
@@ -1,42 +1,13 @@
 #!/usr/bin/env python
 """
-Name: add_critical_land_blockages_to_mask.py
-Author: Xylar Asay-Davis
-
 Add transects that identify critical regions where narrow strips of land block
 ocean flow.  These are, essentially, the opposite of critical passages, which
 must remain open for ocean flow.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
-import xarray
-import argparse
-
-from mpas_tools.ocean.coastline_alteration import add_critical_land_blockages
-
+from mpas_tools.ocean.coastline_alteration import (
+    main_add_critical_land_blockages
+)
 
 if __name__ == '__main__':
-    parser = \
-        argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument("-f", "--input_mask_file", dest="input_mask_filename",
-                        help="Mask file that includes cell and edge masks.",
-                        metavar="INPUTMASKFILE", required=True)
-    parser.add_argument("-o", "--output_mask_file",
-                        dest="output_mask_filename",
-                        help="Mask file that includes cell and edge masks.",
-                        metavar="OUTPUTMASKFILE", required=True)
-    parser.add_argument("-b", "--blockage_file", dest="blockage_file",
-                        help="Masks for each transect identifying critical "
-                             "land blockage.", metavar="BLOCKFILE",
-                        required=True)
-    args = parser.parse_args()
-
-    dsMask = xarray.open_dataset(args.input_mask_filename)
-
-    dsBlockages = xarray.open_dataset(args.blockage_file)
-
-    dsMask = add_critical_land_blockages(dsMask, dsBlockages)
-    dsMask.to_netcdf(args.output_mask_filename)
+    main_add_critical_land_blockages()

--- a/ocean/coastline_alteration/add_land_locked_cells_to_mask.py
+++ b/ocean/coastline_alteration/add_land_locked_cells_to_mask.py
@@ -1,49 +1,12 @@
 #!/usr/bin/env python
 """
-Name: add_land_locked_cells_to_mask.py
-Author: Mark Petersen, Adrian Turner, Xylar Asay-Davis
-
 Find ocean cells that are land-locked, and alter the cell
 mask so that they are counted as land cells.
 """
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 
-import argparse
-import xarray
-
-from mpas_tools.ocean.coastline_alteration import add_land_locked_cells_to_mask
+from mpas_tools.ocean.coastline_alteration import (
+    main_add_land_locked_cells_to_mask
+)
 
 if __name__ == '__main__':
-    parser = \
-        argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument("-f", "--input_mask_file", dest="input_mask_filename",
-                        help="Mask file that includes cell and edge masks.",
-                        metavar="INPUTMASKFILE", required=True)
-    parser.add_argument("-o", "--output_mask_file",
-                        dest="output_mask_filename",
-                        help="Mask file that includes cell and edge masks.",
-                        metavar="OUTPUTMASKFILE", required=True)
-    parser.add_argument("-m", "--mesh_file", dest="mesh_filename",
-                        help="MPAS Mesh filename.", metavar="MESHFILE",
-                        required=True)
-    parser.add_argument("-l", "--latitude_threshold",
-                        dest="latitude_threshold",
-                        help="Minimum latitude, in degrees, for transect "
-                             "widening.",
-                        required=False, type=float, default=43.0)
-    parser.add_argument("-n", "--number_sweeps", dest="nSweeps",
-                        help="Maximum number of sweeps to search for "
-                             "land-locked cells.",
-                        required=False, type=int, default=10)
-    args = parser.parse_args()
-
-    dsMask = xarray.open_dataset(args.input_mask_filename)
-
-    dsMesh = xarray.open_dataset(args.mesh_filename)
-
-    dsMask = add_land_locked_cells_to_mask(dsMask, dsMesh,
-                                           args.latitude_threshold,
-                                           args.nSweeps)
-    dsMask.to_netcdf(args.output_mask_filename)
+    main_add_land_locked_cells_to_mask()

--- a/ocean/coastline_alteration/widen_transect_edge_masks.py
+++ b/ocean/coastline_alteration/widen_transect_edge_masks.py
@@ -1,47 +1,12 @@
 #!/usr/bin/env python
 """
-Name: widen_transect_edge_masks.py
-Author: Mark Petersen, Xylar Asay-Davis
-
 Alter transects to be at least two cells wide.  This is used for critical
 passages, to avoid sea ice blockage.  Specifically, mark cells on both sides
 of each transect edge mask as a water cell.
 """
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
-import argparse
-import xarray
-
-from mpas_tools.ocean.coastline_alteration import widen_transect_edge_masks
-
+from mpas_tools.ocean.coastline_alteration import (
+    main_widen_transect_edge_masks
+)
 
 if __name__ == '__main__':
-
-    parser = \
-        argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument("-f", "--mask_file", dest="mask_filename",
-                        help="Mask file with cell and edge transect masks.",
-                        metavar="MASKFILE",
-                        required=True)
-    parser.add_argument("-m", "--mesh_file", dest="mesh_filename",
-                        help="MPAS Mesh filename.", metavar="MESHFILE",
-                        required=True)
-    parser.add_argument("-o", "--out_file", dest="out_filename",
-                        help="Output mask file,different from input filename.",
-                        metavar="MASKFILE",
-                        required=True)
-    parser.add_argument("-l", "--latitude_threshold",
-                        dest="latitude_threshold",
-                        help="Minimum latitude, degrees, for transect "
-                             "widening.",
-                        required=False, type=float, default=43.0)
-    args = parser.parse_args()
-
-    dsMask = xarray.open_dataset(args.mask_filename)
-
-    dsMesh = xarray.open_dataset(args.mesh_filename)
-
-    dsMask = widen_transect_edge_masks(dsMask, dsMesh, args.latitude_threshold)
-    dsMask.to_netcdf(args.out_filename)
+    main_widen_transect_edge_masks()

--- a/ocean/moc_southern_boundary_extractor/moc_southern_boundary_extractor.py
+++ b/ocean/moc_southern_boundary_extractor/moc_southern_boundary_extractor.py
@@ -7,43 +7,11 @@ the contents of the MOC mask file, adding transects that mark the southern
 boundary of each region in a file indicated with the -o flag.  The transect
 is applied only to vertices and edges, not cells, because the need for southern
 boundary transect data on cells is not foreseen.
-
-Author: Xylar Asay-Davis
-last modified: 5/22/2018
 '''
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from mpas_tools.ocean.moc import (
+    moc_southern_boundary_extractor
+)
 
-import xarray
-import argparse
-
-from mpas_tools.io import \
-    write_netcdf
-from mpas_tools.ocean.moc import \
-    add_moc_southern_boundary_transects
-
-
-if __name__ == "__main__":
-
-    parser = \
-        argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('-f', '--in_file', dest='in_file',
-                        help='Input file with MOC masks', metavar='IN_FILE',
-                        required=True)
-    parser.add_argument('-m', '--mesh_file', dest='mesh_file',
-                        help='Input mesh file', metavar='MESH_FILE',
-                        required=True)
-    parser.add_argument('-o', '--out_file', dest='out_file',
-                        help='Output file for MOC masks and southern-boundary '
-                        'transects', metavar='OUT_FILE',
-                        required=True)
-    args = parser.parse_args()
-
-    dsMasks = xarray.open_dataset(args.in_file)
-    dsMesh = xarray.open_dataset(args.mesh_file)
-
-    dsMasksAndTransects = add_moc_southern_boundary_transects(dsMasks, dsMesh)
-
-    write_netcdf(dsMasksAndTransects, args.out_file)
+if __name__ == '__main__':
+    moc_southern_boundary_extractor()


### PR DESCRIPTION
This merge aims to move 5 scrips used primarily or exclusively by MPAS-Ocean in Compass into the `mpas_tools` package as entry points.

The motivation for this is that we are engaging in Python package modernization on all MPAS-Dev and E3SM-Project repos, and in that process we discovered that modern packaging approaches do not support standalone scripts as the old approach did.

The code from 4 of the 5 scripts has been moved into modules within `mpas_tools` (the 5th script, the paraview VTK extractor, was already a stub).  They are inside of functions, as required for entry points into a Python package, in all cases.  The original scripts are preserved as stubs that call the entry points.

The entry points cannot have the same names as the original scripts: the `.py` extention is not allowed.

A few fixes have been made to update the coastal alteration and MOC modules for better PEP8 compliance.

The documentation has been updated to reflect the new names of the command-line tools.