### PR TITLE
Use separate conda cache directories in CI

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -44,7 +44,7 @@ jobs:
           # Increase this value to reset cache if dev-spec and setup.py have not changed in the workflow
           CACHE_NUMBER: 0
         with:
-          path: ~/conda_pkgs_dir
+          path: ~/conda_pkgs_dir_py${{ matrix.python-version }}
           key:
             ${{ runner.os }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('conda_package/dev-spec.txt,conda_package/setup.py') }}

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+env:
+  PYTHON_VERSION: "3.10"
+
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
@@ -40,7 +43,7 @@ jobs:
           channels: conda-forge
           channel-priority: strict
           auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install mpas_tools


### PR DESCRIPTION
This PR updates the build workflow to use separate directories for each python version for conda caching. Issues with this seem to have been crashing CI runs lately.

I also fixed a bug in the docs workflow, where it was referring to a nonexistent python version matrix (likely a remnant of copying from the build workflow). Instead, I set this to be an environment variable called `PYTHON_VERSION` which will allow us to more easily specify and update the python version we use for the documentation without having to change it in a couple different places.