### PR TITLE
Add code to plot ocean TF within transect

### DIFF
--- a/landice/output_processing_li/plot_transect.py
+++ b/landice/output_processing_li/plot_transect.py
@@ -89,7 +89,7 @@ indices = np.where( np.logical_and(
 xCell = xCell[indices]
 yCell = yCell[indices]
 
-tri_mesh = Delaunay( np.vstack((xCell,yCell)).T )
+tri_mesh = Delaunay( np.vstack((xCell, yCell)).T )
 
 layerThicknessFractions = dataset.variables["layerThicknessFractions"][:]
 nVertLevels = dataset.dimensions['nVertLevels'].size
@@ -115,19 +115,19 @@ if (options.interp_temp or options.interp_thermal_forcing) and (len(times) > 1):
     options.interp_thermal_forcing = False
 
 li_mask_ValueDynamicIce = 2
-cellMask = dataset.variables['cellMask'][times,indices]
+cellMask = dataset.variables['cellMask'][times, indices]
 cellMask_dynamicIce = (cellMask & li_mask_ValueDynamicIce) // li_mask_ValueDynamicIce
 # only take thickness of dynamic ice
-thk = dataset.variables["thickness"][times,indices] * cellMask_dynamicIce
+thk = dataset.variables["thickness"][times, indices] * cellMask_dynamicIce
 
 plot_speed = True
 # Include speed on non-dynamic ice to avoid interpolation artifacts.
 if "surfaceSpeed" in dataset.variables.keys():
-    speed = dataset.variables["surfaceSpeed"][times,indices] * 3600. * 24. * 365.
+    speed = dataset.variables["surfaceSpeed"][times, indices] * 3600. * 24. * 365.
 elif "surfaceSpeed" not in dataset.variables.keys() and \
     all([ii in dataset.variables.keys() for ii in ['uReconstructX', 'uReconstructY']]):
-        speed = np.sqrt(dataset.variables["uReconstructX"][times,indices,0]**2. +
-                        dataset.variables["uReconstructY"][times,indices,0]**2.)
+        speed = np.sqrt(dataset.variables["uReconstructX"][times, indices, 0]**2. +
+                        dataset.variables["uReconstructY"][times, indices, 0]**2.)
         speed *= 3600. * 24. * 365.  # convert from m/s to m/yr
 else:
     print('File does not contain surfaceSpeed or uReconstructX/Y.',
@@ -135,11 +135,11 @@ else:
     plot_speed = False
 
 if options.interp_temp:
-    temperature = dataset.variables['temperature'][times,indices]
+    temperature = dataset.variables['temperature'][times, indices]
 
 if options.interp_thermal_forcing:
     # Extrapolated Ocean thermal forcing
-    thermal_forcing = dataset.variables['TFocean'][times,indices]
+    thermal_forcing = dataset.variables['TFocean'][times, indices]
     thermal_forcing[thermal_forcing == 1.0e36] = np.nan # Large invalid TF values set to NaN
     # Number of ocean layers
     nISMIP6OceanLayers = dataset.dimensions['nISMIP6OceanLayers'].size  
@@ -147,7 +147,7 @@ if options.interp_thermal_forcing:
     ismip6shelfMelt_zOcean = dataset.variables['ismip6shelfMelt_zOcean'][:]
 
     
-bedTopo = dataset.variables["bedTopography"][0,indices]
+bedTopo = dataset.variables["bedTopography"][0, indices]
 print('Reading bedTopography from the first time level only. If multiple',
       'times are needed, plot_transects.py will need to be updated.')
 
@@ -229,8 +229,8 @@ for i, time in enumerate(times):
 
         for ocean_lev in range(nISMIP6OceanLayers):
             print(f'Interpolating ocean thermal forcing for ocean level {ocean_lev}')
-            thermal_forcing_interpolant = LinearNDInterpolator(tri_mesh, thermal_forcing[i,:,ocean_lev])
-            thermal_forcing_transect[:, ocean_lev] = thermal_forcing_interpolant(np.vstack( (x_interp,y_interp) ).T)
+            thermal_forcing_interpolant = LinearNDInterpolator(tri_mesh, thermal_forcing[i, :, ocean_lev])
+            thermal_forcing_transect[:, ocean_lev] = thermal_forcing_interpolant(np.vstack( (x_interp, y_interp) ).T)
 
 thickAx.plot(distance, bed_transect, color='black')
 
@@ -242,8 +242,8 @@ if options.interp_temp:
                                     vmin=240., vmax=273.15)
 
 if options.interp_thermal_forcing:
-    thermal_forcing_plot = thickAx.pcolormesh( np.tile(distance, (nISMIP6OceanLayers+1,1)).T,
-                                               ocean_layer_interfaces[:,:], thermal_forcing_transect[1:,:],
+    thermal_forcing_plot = thickAx.pcolormesh(np.tile(distance, (nISMIP6OceanLayers+1, 1)).T,
+                                               ocean_layer_interfaces[:, :], thermal_forcing_transect[1:, :],
                                                cmap='YlOrRd', vmin=0, vmax=5.5)
     thickAx.fill_between(distance, upper_surf_nan, lower_surf_nan, color='xkcd:ice blue')
     thickAx.fill_between(distance, bed_transect, thickAx.get_ylim()[0], color='xkcd:greyish brown')

--- a/landice/output_processing_li/plot_transect.py
+++ b/landice/output_processing_li/plot_transect.py
@@ -283,7 +283,7 @@ if options.interp_temp:
 
 if options.interp_thermal_forcing:
     tf_cbar = plt.colorbar(thermal_forcing_plot)
-    tf_cbar.set_label('Thermal Forcing (C)')
+    tf_cbar.set_label(r'Thermal Forcing ($^{\circ}$C)')
 
 if (len(times) > 1):
     time_cbar = plt.colorbar(cm.ScalarMappable(cmap='plasma'), ax=thickAx)

--- a/landice/output_processing_li/plot_transect.py
+++ b/landice/output_processing_li/plot_transect.py
@@ -70,14 +70,10 @@ if '-1' in times_list:
     times_list[times_list.index('-1')] = str(dataset.dimensions['Time'].size - 1)
 
 # Cannot plot temperature or thermal forcing for more than one time index.
-if options.interp_temp and (len(times) > 1):
-    print('Cannot plot temperature for more than one time index.' +
-          ' Skipping temperature interpolation and plotting.')
+if (options.interp_temp or options.interp_thermal_forcing) and (len(times) > 1):
+    print('Cannot plot temperature or thermal forcing for more than one time index.' +
+          ' Skipping temperature or TF interpolation and plotting.')
     options.interp_temp = False
-
-if options.interp_thermal_forcing and (len(times) > 1):
-    print('Cannot plot thermal forcing for more than one time index.' +
-          ' Skipping thermal forcing interpolation and plotting.')
     options.interp_thermal_forcing = False
 
 li_mask_ValueDynamicIce = 2

--- a/landice/output_processing_li/plot_transect.py
+++ b/landice/output_processing_li/plot_transect.py
@@ -131,8 +131,8 @@ else:
     y = np.array([float(i) for i in options.y_coords.split(',')])
 
 # increase sampling to match highest mesh resolution
-total_distance, = np.cumsum( np.sqrt( np.diff(x)**2. + np.diff(y)**2. ) )
-n_samples = int(round(total_distance / np.min(dataset.variables["dcEdge"][:])))
+total_distance = np.cumsum( np.sqrt( np.diff(x)**2. + np.diff(y)**2. ) )
+n_samples = int(round(total_distance[-1] / np.min(dataset.variables["dcEdge"][:])))
 x_interp = np.interp(np.linspace(0, len(x)-1, n_samples),
                      np.linspace(0, len(x)-1, len(x)), x)
 y_interp = np.interp(np.linspace(0, len(y)-1, n_samples),
@@ -230,11 +230,11 @@ if options.interp_temp:
 if options.interp_thermal_forcing:
     thermal_forcing_plot = thickAx.pcolormesh( np.tile(distance, (nISMIP6OceanLayers+1,1)).T,
                                                ocean_layer_interfaces[:,:], thermal_forcing_transect[1:,:],
-                                               cmap='RdYlBu_r', vmin=-2, vmax=2 )
+                                               cmap='YlOrRd', vmin=0, vmax=5.5)
     thickAx.fill_between(distance, upper_surf_nan, lower_surf_nan, color='xkcd:ice blue')
     thickAx.fill_between(distance, bed_transect, thickAx.get_ylim()[0], color='xkcd:greyish brown')
     thickAx.grid(False)
-
+    thickAx.set_ylim([None, 750])
 
 speedAx.set_xlabel('Distance (km)')
 speedAx.set_ylabel('Surface\nspeed (m/yr)')


### PR DESCRIPTION
This pull request updates the existing `plot_transect.py` script to add the option of plotting ocean thermal forcing along an ice-shelf transect. 

The code plots the extrapolated `TFocean` field for a single time index along a user defined transect. Invalid (`1.0e36`) TF values are set to `np.nan` before interpolation happens for each ocean layer. Ice and bedrock are filled in with solid colors if `--thermal_forcing` option is set. 

![image](https://github.com/user-attachments/assets/e57766c6-eb04-493a-b449-315ba567cd77)
