### PR TITLE
In CI, update docs build version to 3.13

### DIFF
--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -9,7 +9,7 @@ on:
     types: [published]
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.13"
 
 jobs:
   publish-docs:


### PR DESCRIPTION
This PR simply updates the CI docs build version from 3.10 to 3.13.