### PR TITLE
Bump cmake_minimum_required to 3.5 to make conda happy

### DIFF
--- a/mesh_tools/mesh_conversion_tools/CMakeLists.txt
+++ b/mesh_tools/mesh_conversion_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.5)
 project (mesh_conversion_tools)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")

--- a/mesh_tools/mesh_conversion_tools_netcdf_c/CMakeLists.txt
+++ b/mesh_tools/mesh_conversion_tools_netcdf_c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.5)
 project (mesh_conversion_tools)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

--- a/mesh_tools/seaice_grid_tools/CMakeLists.txt
+++ b/mesh_tools/seaice_grid_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.5)
 enable_language(Fortran)
 project (seaice_grid_tools)
 

--- a/ocean/smooth_topo/CMakeLists.txt
+++ b/ocean/smooth_topo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.5)
 enable_language(Fortran)
 project (ocean_smooth_topo)
 


### PR DESCRIPTION
I'm not able to build the conda package at the moment because `cmake_minimum_required < 3.5` in various places.  I don't think there's a strong reason that we need this minimum so I'm proposing we bump it up to what conda wants.