### PR TITLE
Remove undefined variables that cause errors when calculating masks from thickness and bedTopography

### DIFF
--- a/conda_package/mpas_tools/landice/visualization.py
+++ b/conda_package/mpas_tools/landice/visualization.py
@@ -477,7 +477,7 @@ def _calculate_masks(dataset):
     elif ( 'cellMask' not in dataset.variables.keys() and
          'thickness' in dataset.variables.keys() and
          'bedTopography' in dataset.variables.keys() ):
-        print(f'cellMask is not present in output file {run};'
+        print(f'cellMask is not present in output file;'
                ' calculating masks from ice thickness')
         valid_masks = True
         grounded_mask = (dataset.variables['thickness'][:] >
@@ -488,7 +488,7 @@ def _calculate_masks(dataset):
         initial_extent_mask = (dataset.variables['thickness'][:] > 0.)
     else:
         print('cellMask and thickness and/or bedTopography'
-              f' not present in output file {run};'
+              f' not present in output file;'
                ' Skipping mask calculation.')
         valid_masks = False
 

--- a/conda_package/mpas_tools/landice/visualization.py
+++ b/conda_package/mpas_tools/landice/visualization.py
@@ -483,6 +483,10 @@ def _calculate_masks(dataset):
         grounded_mask = (dataset.variables['thickness'][:] >
                         (-rhosw / rhoi *
                          dataset.variables['bedTopography'][:]))
+        float_mask = np.logical_and(
+                         np.logical_not(grounded_mask),
+                         dataset.variables['thickness'][:] > 1.0)
+        dynamic_mask = np.logical_or(grounded_mask, float_mask)
         # This isn't technically correct, but works for plotting
         grounding_line_mask = grounded_mask.copy()
         initial_extent_mask = (dataset.variables['thickness'][:] > 0.)


### PR DESCRIPTION
Remove undefined variable "run" in f-strings that causes and error when trying to calculate masks from thickness and bedTopography. Also add missing masks when calculating masks using thickness and bedTopography.