### PR TITLE
Add `pre-commit` for code linting

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -16,6 +16,42 @@ env:
   PATHS_IGNORE: '["**/README.md", "**/docs/**"]'
 
 jobs:
+  pre-commit-hooks:
+    name: lint with pre-commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: ${{ env.CANCEL_OTHERS }}
+          paths_ignore: ${{ env.PATHS_IGNORE }}
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Checkout Code Repository
+        uses: actions/checkout@v4
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        id: file_changes
+        uses: trilom/file-changes-action@1.2.4
+        with:
+          output: ' '
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        # Run all pre-commit hooks on all the files.
+        # Getting only staged files can be tricky in case a new PR is opened
+        # since the action is run on a branch in detached head state
+        name: Install and Run Pre-commit
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --files ${{ steps.file_changes.outputs.files}}
+
   build:
     name: test mpas_tools - python ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -1,0 +1,67 @@
+name: Pre-commit auto-update
+
+on:
+  schedule:
+    # Cron syntax:
+    # 1. Entry: Minute when the process will be started [0-60]
+    # 2. Entry: Hour when the process will be started [0-23]
+    # 3. Entry: Day of the month when the process will be started [1-28/29/30/31]
+    # 4. Entry: Month of the year when the process will be started [1-12]
+    # 5. Entry: Weekday when the process will be started [0-6] [0 is Sunday]
+    - cron: '0 8 * * 3'
+
+env:
+  UP_TO_DATE: false
+  PYTHON_VERSION: "3.10"
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Apply and commit updates
+        run: |
+          git clone https://github.com/MPAS-Dev/MPAS-Tools.git update-pre-commit-deps
+          cd update-pre-commit-deps
+          # Configure git using GitHub Actions credentials.
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git checkout -b update-pre-commit-deps
+          pre-commit autoupdate
+          git add .
+          # The second command will fail if no changes were present, so we ignore it
+          git commit -m "Update pre-commit dependencies" || ( echo "UP_TO_DATE=true" >> "$GITHUB_ENV")
+
+      - name: Push Changes
+        if: ${{ env.UP_TO_DATE == 'false' }}
+        uses: ad-m/github-push-action@master
+        with:
+          branch: update-pre-commit-deps
+          directory: update-pre-commit-deps
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          force: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Make PR and add reviewers and labels
+        if: ${{ env.UP_TO_DATE == 'false' }}
+        run: |
+          cd update-pre-commit-deps
+          gh pr create \
+          --title "Update pre-commit and its dependencies" \
+          --body "This PR was auto-generated to update pre-commit and its dependencies." \
+          --head update-pre-commit-deps \
+          --reviewer altheaden,xylar \
+          --label ci
+        env:
+          GH_TOKEN: ${{ github.token }}
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+files: "conda_package"
+default_stages: [pre-commit]
+fail_fast: true
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  # Can run individually with `flynt [file]` or `flynt [source]`
+  - repo: https://github.com/ikamensh/flynt
+    rev: '1.0.1'
+    hooks:
+      - id: flynt
+        args: ["--fail-on-change", "--verbose"]
+        require_serial: true
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.4
+    hooks:
+      # Sort the imports
+      - id: ruff
+        name: ruff-sort-imports
+        args: [--select, I, --fix]
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
+

--- a/conda_package/dev-spec.txt
+++ b/conda_package/dev-spec.txt
@@ -26,8 +26,11 @@ shapely>=2.0,<3.0
 xarray
 
 # Development
+flynt
 pip
+pre-commit
 pytest
+ruff
 setuptools
 
 # Documentation

--- a/conda_package/docs/making_changes.rst
+++ b/conda_package/docs/making_changes.rst
@@ -10,6 +10,51 @@ New python functions and modules (``.py`` files) can be added within the
 ``__init__.py`` file (which can be empty) to indicate that they are also part of
 the package.
 
+Code Styling and Linting
+========================
+``mpas_tools`` utilizes ``pre-commit`` to lint incoming code when you make a
+commit (as long as you have your environment set up correctly), and on GitHub
+whenever you make a pull request to the ``mpas_tools`` repository. Linting makes sure
+your code follows the formatting guidelines of PEP8, and cleans up additional
+things like whitespace at the end of lines.
+
+The first time you set up the ``mpas_tools_dev`` environment, you will need to set up
+``pre-commit``. This is done by running:
+
+```bash
+pre-commit install
+```
+
+You only need to do this once when you create the ``mpas_tools_dev``
+environment. If you create a new version of ``mpas_tools_dev``, then you will
+need to run it again.
+
+When you run ``git commit <filename>``, ``pre-commit`` will automatically lint
+your code before committing. Some formatting will be updated by ``pre-commit``
+automatically, in which case it will terminate the commit and inform you of the
+change. Then you can run ``git commit <filename>`` again to continue the
+linting process until your commit is successful. Some changes need to be made
+manually, such as a line being too long. When this happens, you must update the
+file to ``pre-commit``'s standards, and then attempt to re-commit the file.
+
+Internally, ``pre-commit``  uses `ruff <https://docs.astral.sh/ruff/>` to check
+PEP8 compliance, as well as sort, check and format imports,
+`flynt <https://github.com/ikamensh/flynt>` to change any format strings to
+f-strings, and `mypy <https://mypy-lang.org/>` to check for consistent variable
+types. An example error might be:
+
+```bash
+example.py:77:1: E302 expected 2 blank lines, found 1
+```
+
+For this example, we would just add an additional blank line after line 77 and
+try the commit again to make sure we've resolved the issue.
+
+You may also find it useful to use an IDE with a PEP8 style checker built in,
+such as `VS Code <https://code.visualstudio.com/>`. See
+`Formatting Python in VS Code <https://code.visualstudio.com/docs/python/formatting>`
+for some tips on checking code style in VS Code.
+
 Entry Points
 ============
 

--- a/conda_package/pyproject.toml
+++ b/conda_package/pyproject.toml
@@ -31,7 +31,7 @@ authors = [
     { name="Riley Brady" },
 ]
 description = """\
-    A set of tools for creating and manipulating meshes for the climate 
+    A set of tools for creating and manipulating meshes for the climate
     components based on the Model for Prediction Across Scales (MPAS) framework
     """
 license = { file = "LICENSE" }
@@ -83,7 +83,37 @@ dev = [
     # testing
     "pip",
     "pytest",
+    "flynt",
+    "pre-commit",
+    "ruff",
 ]
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = ["docs", "conda"]
+line-length = 79
+
+[tool.ruff.lint]
+# E501 - max line-length
+# E4 - whitespace
+# E7 - multiple-statements
+# E9 - trailing-whitespace
+# F - Enable Pyflakes
+# B - Enable flake8-bugbear
+# W - Enable pycodestyle
+# C901 - complex-structure
+# D - Enable flake8-docstrings
+select = ["E501", "E4", "E7", "E9", "F", "B", "W", "C901"]
+
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.ruff.lint.mccabe]
+# Flag errors (`C901`) whenever the complexity level exceeds 18.
+max-complexity = 18
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [build-system]
 requires = ["setuptools>=60"]


### PR DESCRIPTION
This PR adds `pre-commit` for code linting, as well as some various tools which configure `pre-commit` as we have done in related repos.