### PR TITLE
Add missing `ais-bedmap2-sphere` projection

### DIFF
--- a/conda_package/mpas_tools/landice/projections.py
+++ b/conda_package/mpas_tools/landice/projections.py
@@ -18,21 +18,33 @@ projections = dict()
 
 # This version ignores the vertical datum shift, which should be a very
 # small error for horizontal-only positions
-projections['gis-bamber'] = \
-    '+proj=stere +lat_ts=71.0 +lat_0=90 +lon_0=321.0 +k_0=1.0 ' \
+projections['gis-bamber'] = (
+    '+proj=stere +lat_ts=71.0 +lat_0=90 +lon_0=321.0 +k_0=1.0 '
     '+x_0=800000.0 +y_0=3400000.0 +ellps=WGS84'
+)
 
 # GIMP projection: This is also polar stereographic but with different
 # standard parallel and using the WGS84 ellipsoid.
-projections['gis-gimp'] = \
-    '+proj=stere +lat_ts=70.0 +lat_0=90 +lon_0=315.0 +k_0=1.0 +x_0=0.0 ' \
+projections['gis-gimp'] = (
+    '+proj=stere +lat_ts=70.0 +lat_0=90 +lon_0=315.0 +k_0=1.0 +x_0=0.0 '
     '+y_0=0.0 +ellps=WGS84'
+)
 
 # BEDMAP2 projection
 # Note: BEDMAP2 elevations use EIGEN-GL04C geoid
-projections['ais-bedmap2'] = \
-    '+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0 +k_0=1.0 +x_0=0.0 ' \
+projections['ais-bedmap2'] = (
+    '+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0 +k_0=1.0 +x_0=0.0 '
     '+y_0=0.0 +ellps=WGS84'
+)
+
+# BEDMAP2 projection of sphere. This projection must be used to adjust MALI
+# mesh when performing coupled MALI-SeaLevelModel simulations. Otherwise, ice
+# mass won't be conserved between the MALI planar mesh and the spherical
+# sea-level model grid during the post-processing (output analysis) step.
+projections['ais-bedmap2-sphere'] = (
+    '+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0 +k_0=1.0 +x_0=0.0 '
+    '+y_0=0.0 +ellps=sphere'
+)
 
 # Standard Lat/Long
 projections['latlon'] = '+proj=longlat +ellps=WGS84'


### PR DESCRIPTION
This was inadvertently removed as part of #596

Partially addresses: https://github.com/MPAS-Dev/compass/issues/901