### PR TITLE
Add support for `NETCDF3_64BIT_DATA` in `write_netcdf()`

### DIFF
--- a/conda_package/dev-spec.txt
+++ b/conda_package/dev-spec.txt
@@ -12,6 +12,7 @@ hdf5
 inpoly
 libnetcdf
 matplotlib-base>=3.9.0
+nco
 netcdf4
 networkx
 numpy>=2.0,<3.0

--- a/conda_package/docs/index.rst
+++ b/conda_package/docs/index.rst
@@ -27,6 +27,8 @@ analyzing simulations, and in other MPAS-related workflows.
 
    config
 
+   io
+
    logging
 
    transects

--- a/conda_package/docs/io.rst
+++ b/conda_package/docs/io.rst
@@ -1,0 +1,28 @@
+.. _io:
+
+*********
+I/O Tools
+*********
+
+The :py:mod:`mpas_tools.io` module provides utilities for reading and writing
+NetCDF files, especially for compatibility with MPAS mesh and data conventions.
+
+write_netcdf
+============
+
+The :py:func:`mpas_tools.io.write_netcdf()` function writes an
+``xarray.Dataset`` to a NetCDF file, ensuring MPAS compatibility (e.g.,
+converting int64 to int32, handling fill values, and updating the history
+attribute). It also supports writing in various NetCDF formats, including
+conversion to ``NETCDF3_64BIT_DATA`` using ``ncks`` if needed.
+
+Example usage:
+
+.. code-block:: python
+
+    import xarray as xr
+    from mpas_tools.io import write_netcdf
+
+    # Create a simple dataset
+    ds = xr.Dataset({'foo': (('x',), [1, 2, 3])})
+    write_netcdf(ds, 'output.nc')

--- a/conda_package/mpas_tools/io.py
+++ b/conda_package/mpas_tools/io.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 from datetime import datetime
+from pathlib import Path
 
 import netCDF4
 import numpy
@@ -121,8 +122,10 @@ def write_netcdf(
     convert = format == 'NETCDF3_64BIT_DATA'
 
     if convert:
-        basename, extension = os.path.splitext(fileName)
-        out_filename = f'{basename}.netcdf4{extension}'
+        out_path = Path(fileName)
+        out_filename = (
+            out_path.parent / f'_tmp_{out_path.stem}.netcdf4{out_path.suffix}'
+        )
         format = 'NETCDF4'
         if engine == 'scipy':
             # that's not going to work
@@ -151,6 +154,8 @@ def write_netcdf(
             )
         else:
             check_call(args, logger=logger)
+        # delete the temporary NETCDF4 file
+        os.remove(out_filename)
 
 
 def update_history(ds):

--- a/conda_package/mpas_tools/io.py
+++ b/conda_package/mpas_tools/io.py
@@ -34,6 +34,8 @@ def write_netcdf(
     Then, the `ncks` command is used to convert the file to the
     `NETCDF3_64BIT_DATA` format.
 
+    Note: All int64 variables are automatically converted to int32 for MPAS
+    compatibility.
 
     Parameters
     ----------
@@ -81,6 +83,13 @@ def write_netcdf(
 
     if char_dim_name is None:
         char_dim_name = default_char_dim_name
+
+    # Convert int64 variables to int32 for MPAS compatibility
+    for var in list(ds.data_vars.keys()) + list(ds.coords.keys()):
+        if ds[var].dtype == numpy.int64:
+            attrs = ds[var].attrs.copy()
+            ds[var] = ds[var].astype(numpy.int32)
+            ds[var].attrs = attrs
 
     encodingDict = {}
     variableNames = list(ds.data_vars.keys()) + list(ds.coords.keys())

--- a/conda_package/mpas_tools/mesh/mask.py
+++ b/conda_package/mpas_tools/mesh/mask.py
@@ -251,9 +251,13 @@ def entry_point_compute_mpas_region_masks():
             subdivisionThreshold=args.subdivision,
         )
 
-    write_netcdf(
-        dsMasks, args.mask_file_name, format=args.format, engine=args.engine
-    )
+        write_netcdf(
+            dsMasks,
+            args.mask_file_name,
+            format=args.format,
+            engine=args.engine,
+            logger=logger,
+        )
 
 
 def compute_mpas_transect_masks(
@@ -516,9 +520,13 @@ def entry_point_compute_mpas_transect_masks():
             addEdgeSign=args.add_edge_sign,
         )
 
-    write_netcdf(
-        dsMasks, args.mask_file_name, format=args.format, engine=args.engine
-    )
+        write_netcdf(
+            dsMasks,
+            args.mask_file_name,
+            format=args.format,
+            engine=args.engine,
+            logger=logger,
+        )
 
 
 def compute_mpas_flood_fill_mask(
@@ -641,9 +649,13 @@ def entry_point_compute_mpas_flood_fill_mask():
             dsMesh=dsMesh, fcSeed=fcSeed, logger=logger
         )
 
-    write_netcdf(
-        dsMasks, args.mask_file_name, format=args.format, engine=args.engine
-    )
+        write_netcdf(
+            dsMasks,
+            args.mask_file_name,
+            format=args.format,
+            engine=args.engine,
+            logger=logger,
+        )
 
 
 def compute_lon_lat_region_masks(
@@ -868,7 +880,11 @@ def entry_point_compute_lon_lat_region_masks():
         )
 
     write_netcdf(
-        dsMasks, args.mask_file_name, format=args.format, engine=args.engine
+        dsMasks,
+        args.mask_file_name,
+        format=args.format,
+        engine=args.engine,
+        logger=logger,
     )
 
 
@@ -1101,7 +1117,11 @@ def entry_point_compute_projection_grid_region_masks():
         )
 
     write_netcdf(
-        dsMasks, args.mask_file_name, format=args.format, engine=args.engine
+        dsMasks,
+        args.mask_file_name,
+        format=args.format,
+        engine=args.engine,
+        logger=logger,
     )
 
 

--- a/conda_package/recipe/meta.yaml
+++ b/conda_package/recipe/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - networkx
     - netcdf-fortran
     - matplotlib-base >=3.9.0
+    - nco
     - netcdf4
     - numpy >=2.0,<3.0
     - progressbar2

--- a/conda_package/tests/test_io.py
+++ b/conda_package/tests/test_io.py
@@ -1,0 +1,60 @@
+import os
+import subprocess
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from mpas_tools.io import write_netcdf
+
+from .util import get_test_data_file
+
+TEST_MESH = get_test_data_file('mesh.QU.1920km.151026.nc')
+
+
+@pytest.mark.skipif(
+    not os.path.exists(TEST_MESH), reason='Test mesh not available'
+)
+def test_write_netcdf_basic(tmp_path):
+    ds = xr.open_dataset(TEST_MESH)
+    out_file = tmp_path / 'test_basic.nc'
+    write_netcdf(ds, str(out_file))
+    ds2 = xr.open_dataset(out_file)
+    # Should have same dimensions and variables
+    assert set(ds.dims) == set(ds2.dims)
+    for var in ds.data_vars:
+        assert var in ds2.data_vars
+    ds2.close()
+
+
+@pytest.mark.skipif(
+    not os.path.exists(TEST_MESH), reason='Test mesh not available'
+)
+def test_write_netcdf_cdf5_format(tmp_path):
+    ds = xr.open_dataset(TEST_MESH)
+    out_file = tmp_path / 'test_cdf5.nc'
+    write_netcdf(ds, str(out_file), format='NETCDF3_64BIT_DATA')
+    # Use ncdump -k to check format
+    result = subprocess.run(
+        ['ncdump', '-k', str(out_file)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Should be cdf5 for NETCDF3_64BIT_DATA
+    assert result.stdout.strip() == 'cdf5'
+
+
+def test_write_netcdf_int64_conversion_and_attr(tmp_path):
+    # Create a dataset with int64 variable and an attribute
+    arr = np.array([1, 2, 3], dtype=np.int64)
+    ds = xr.Dataset({'foo': (('x',), arr)})
+    ds['foo'].attrs['myattr'] = 'testattr'
+    out_file = tmp_path / 'test_int64.nc'
+    write_netcdf(ds, str(out_file))
+    ds2 = xr.open_dataset(out_file)
+    # Should be int32, not int64
+    assert ds2['foo'].dtype == np.int32
+    # Attribute should be preserved
+    assert ds2['foo'].attrs['myattr'] == 'testattr'
+    ds2.close()


### PR DESCRIPTION
For performance, this involves first writing a `NETCDF4` file and then using `ncks` to convert it to `NETCDF3_64BIT_DATA` (CDF5) format.

This merge also:
* adds a conversion of `int64` format to `int32`, since the MPAS framework doesn't support `int64`
* adds documentation for `write_netcdf()`
* adds unit tests for `write_netcdf()`, including both CDF5 and int64 --> int32 capabilities
* adds `nco` as a dependency
* adds the logger to `write_netcdf()` calls in the mask creator (to keep output from conversion to CDF5 when it happens)