### PR TITLE
Improve performance of barotropic streamfunction 

### DIFF
--- a/conda_package/docs/api.rst
+++ b/conda_package/docs/api.rst
@@ -227,6 +227,7 @@ Ocean Tools
    depth.compute_zmid
 
    compute_barotropic_streamfunction
+   shift_barotropic_streamfunction
 
 .. currentmodule:: mpas_tools.ocean.inject_bathymetry
 

--- a/conda_package/docs/ocean/streamfunction.rst
+++ b/conda_package/docs/ocean/streamfunction.rst
@@ -7,8 +7,18 @@ Computing the barotropic streamfunction
 ---------------------------------------
 
 The function :py:func:`mpas_tools.ocean.compute_barotropic_streamfunction()`
-computes the barotproic streamfunction at vertices on the MPAS-Ocean grid.
+computes the barotropic streamfunction at vertices on the MPAS-Ocean grid.
 The function takes a dataset containing an MPAS-Ocean mesh and another with
 ``normalVelocity`` and ``layerThickness`` variables (possibly with a
-``timeMonthly_avg_`` prefix).  The streamfunction is computed only over the
+``timeMonthly_avg_`` prefix). The streamfunction is computed only over the
 range of (positive-down) depths provided and at the given time index.
+
+Optionally, the Gent-McWilliams bolus velocity (``normalGMBolusVelocity``) and
+the submesoscale velocity (``normalMLEvelocity``) can be included in the
+vertically integrated velocity calculation by setting the corresponding
+arguments ``include_bolus`` and ``include_submesoscale`` to ``True``.
+
+For large meshes, performance and memory usage can be improved by specifying
+the ``horiz_chunk`` argument to control the number of edges processed at once,
+and by providing a ``tmp_dir`` argument to use a temporary directory for
+intermediate files.

--- a/conda_package/docs/ocean/streamfunction.rst
+++ b/conda_package/docs/ocean/streamfunction.rst
@@ -22,3 +22,18 @@ For large meshes, performance and memory usage can be improved by specifying
 the ``horiz_chunk`` argument to control the number of edges processed at once,
 and by providing a ``tmp_dir`` argument to use a temporary directory for
 intermediate files.
+
+Shifting the barotropic streamfunction
+--------------------------------------
+
+The function :py:func:`mpas_tools.ocean.shift_barotropic_streamfunction()`
+can be used to shift the barotropic streamfunction so that its mean value is
+zero on the boundary within a specified latitude range. This is useful for
+setting a consistent reference for the streamfunction, especially when
+comparing results across different regions or simulations.
+
+The function takes as input the barotropic streamfunction on vertices,
+a latitude range (in degrees), the ``cellsOnVertex`` and ``latVertex``
+arrays from the mesh, and optionally a logger. It returns a shifted
+streamfunction with the mean value on the boundary (within the latitude
+range) subtracted.

--- a/conda_package/mpas_tools/ocean/__init__.py
+++ b/conda_package/mpas_tools/ocean/__init__.py
@@ -1,16 +1,24 @@
 from mpas_tools.ocean.build_mesh import (
-    build_spherical_mesh,
-    build_planar_mesh,
+    build_planar_mesh as build_planar_mesh,
 )
-from mpas_tools.ocean.barotropic_streamfunction import (
-    compute_barotropic_streamfunction,
+from mpas_tools.ocean.build_mesh import (
+    build_spherical_mesh as build_spherical_mesh,
 )
-from mpas_tools.ocean.inject_bathymetry import inject_bathymetry
+from mpas_tools.ocean.inject_bathymetry import (
+    inject_bathymetry as inject_bathymetry,
+)
 from mpas_tools.ocean.inject_meshDensity import (
-    inject_meshDensity_from_file,
-    inject_spherical_meshDensity,
-    inject_planar_meshDensity,
+    inject_meshDensity_from_file as inject_meshDensity_from_file,
+)
+from mpas_tools.ocean.inject_meshDensity import (
+    inject_planar_meshDensity as inject_planar_meshDensity,
+)
+from mpas_tools.ocean.inject_meshDensity import (
+    inject_spherical_meshDensity as inject_spherical_meshDensity,
 )
 from mpas_tools.ocean.inject_preserve_floodplain import (
-    inject_preserve_floodplain,
+    inject_preserve_floodplain as inject_preserve_floodplain,
+)
+from mpas_tools.ocean.streamfunction.barotropic import (
+    compute_barotropic_streamfunction as compute_barotropic_streamfunction,
 )

--- a/conda_package/mpas_tools/ocean/__init__.py
+++ b/conda_package/mpas_tools/ocean/__init__.py
@@ -22,3 +22,6 @@ from mpas_tools.ocean.inject_preserve_floodplain import (
 from mpas_tools.ocean.streamfunction.barotropic import (
     compute_barotropic_streamfunction as compute_barotropic_streamfunction,
 )
+from mpas_tools.ocean.streamfunction.barotropic import (
+    shift_barotropic_streamfunction as shift_barotropic_streamfunction,
+)

--- a/conda_package/mpas_tools/ocean/streamfunction/velocity.py
+++ b/conda_package/mpas_tools/ocean/streamfunction/velocity.py
@@ -1,0 +1,151 @@
+import numpy as np
+import xarray as xr
+
+from mpas_tools.ocean.depth import compute_zmid
+
+
+def compute_vertically_integrated_velocity(
+    ds_mesh,
+    ds,
+    logger=None,
+    min_depth=None,
+    max_depth=None,
+    prefix='timeMonthly_avg_',
+    include_bolus=False,
+    include_submesoscale=False,
+    nedges_chunk=10000,
+):
+    """
+    Compute the vertically integrated normal velocity on mesh edges.
+
+    Parameters
+    ----------
+    ds_mesh : xarray.Dataset
+        A dataset containing MPAS mesh variables
+
+    ds : xarray.Dataset
+        A dataset containing MPAS output variables ``normalVelocity`` and
+        ``layerThickness`` among others, possibly with a ``prefix``
+
+    logger : logging.Logger, optional
+        A logger for the output if not stdout
+
+    min_depth : float, optional
+        The minimum depth (positive up) to compute BSF over
+
+    max_depth : float, optional
+        The maximum depth (positive up) to compute BSF over
+
+    prefix : str, optional
+        The prefix on the ``normalVelocity`` and ``layerThickness`` variables
+
+    include_bolus : bool, optional
+        Whether to include the GM bolus velocity in the computation
+
+    include_submesoscale : bool, optional
+        Whether to include the submesoscale velocity in the computation
+
+    nedges_chunk : int, optional
+        The number of edges to chunk the dataset by. This is useful for large
+        datasets to avoid memory issues. The default is 10000. Set this to
+        ``None`` to disable chunking.
+
+    Returns
+    -------
+    vert_integ_velocity : xarray.DataArray
+        The vertically integrated velocity on the mesh edges
+    """
+    if nedges_chunk is not None:
+        ds = ds.chunk({'nEdges': nedges_chunk})
+
+    if logger:
+        logger.info('    Identifying inner edges.')
+    cells_on_edge = ds_mesh.cellsOnEdge - 1
+    inner_edges = np.logical_and(
+        cells_on_edge.isel(TWO=0) >= 0, cells_on_edge.isel(TWO=1) >= 0
+    )
+
+    # convert from boolean mask to indices
+    inner_edges = np.flatnonzero(inner_edges.values)
+
+    cell0 = cells_on_edge.isel(nEdges=inner_edges, TWO=0)
+    cell1 = cells_on_edge.isel(nEdges=inner_edges, TWO=1)
+    n_vert_levels = ds.sizes['nVertLevels']
+
+    layer_thickness = ds[f'{prefix}layerThickness']
+    max_level_cell = ds_mesh.maxLevelCell - 1
+    if 'minLevelCell' in ds_mesh:
+        min_level_cell = ds_mesh.minLevelCell - 1
+    else:
+        min_level_cell = np.zeros_like(max_level_cell)
+
+    vert_index = xr.DataArray.from_dict(
+        {'dims': ('nVertLevels',), 'data': np.arange(n_vert_levels)}
+    )
+
+    if min_depth is not None or max_depth is not None:
+        z_mid_edge = _compute_zmid_edge(
+            ds, ds_mesh, prefix, logger, cell0, cell1
+        )
+    else:
+        z_mid_edge = None
+
+    if logger:
+        logger.info('    Adding up constituents of normal velocity.')
+    normal_velocity = ds[f'{prefix}normalVelocity']
+    if include_bolus:
+        normal_velocity += ds[f'{prefix}normalGMBolusVelocity']
+    if include_submesoscale:
+        normal_velocity += ds[f'{prefix}normalMLEvelocity']
+    normal_velocity = normal_velocity.isel(nEdges=inner_edges)
+
+    thickness0 = layer_thickness.isel(nCells=cell0)
+    thickness1 = layer_thickness.isel(nCells=cell1)
+    layer_thickness_edge = 0.5 * (thickness0 + thickness1)
+
+    if logger:
+        logger.info('    Computing valid cell mask.')
+
+    valid_cells = np.logical_and(
+        vert_index >= min_level_cell, vert_index <= max_level_cell
+    ).transpose('nCells', 'nVertLevels')
+    valid_edges = np.logical_and(
+        valid_cells.isel(nCells=cell0), valid_cells.isel(nCells=cell1)
+    )
+
+    if logger:
+        logger.info('    Applying depth masks.')
+    masks = [valid_edges]
+    if min_depth is not None:
+        masks.append(z_mid_edge <= min_depth)
+    if max_depth is not None:
+        masks.append(z_mid_edge >= max_depth)
+    for mask in masks:
+        normal_velocity = normal_velocity.where(mask)
+        layer_thickness_edge = layer_thickness_edge.where(mask)
+
+    if logger:
+        logger.info('    Computing vertically integrated velocity.')
+    vert_integ_velocity = np.zeros(ds_mesh.sizes['nEdges'], dtype=float)
+    inner_vert_integ_vel = (layer_thickness_edge * normal_velocity).sum(
+        dim='nVertLevels'
+    )
+    vert_integ_velocity[inner_edges] = inner_vert_integ_vel.values
+
+    if logger:
+        logger.info('    Finalizing vertically integrated velocity.')
+    vert_integ_velocity = xr.DataArray(vert_integ_velocity, dims=('nEdges',))
+
+    return vert_integ_velocity
+
+
+def _compute_zmid_edge(ds, ds_mesh, prefix, logger, cell0, cell1):
+    layer_thickness = ds[f'{prefix}layerThickness']
+
+    if logger:
+        logger.info('    Computing z_mid and z_mid_edge.')
+    z_mid = compute_zmid(
+        ds_mesh.bottomDepth, ds_mesh.maxLevelCell, layer_thickness
+    )
+    z_mid_edge = 0.5 * (z_mid.isel(nCells=cell0) + z_mid.isel(nCells=cell1))
+    return z_mid_edge

--- a/conda_package/mpas_tools/ocean/streamfunction/vorticity.py
+++ b/conda_package/mpas_tools/ocean/streamfunction/vorticity.py
@@ -1,0 +1,107 @@
+import numpy as np
+import xarray as xr
+
+
+def compute_vertically_integrated_vorticity(
+    ds_mesh,
+    vert_integ_velocity,
+    logger=None,
+):
+    """
+    Compute the vertically integrated vorticity on MPAS vertices.
+
+    Parameters
+    ----------
+    ds_mesh : xarray.Dataset
+        A dataset containing MPAS mesh variables
+
+    vert_integ_velocity : xarray.DataArray
+        A data array containing the vertically integrated normal velocity on
+        the mesh edges.
+
+    logger : logging.Logger, optional
+        A logger for the output if not stdout
+
+    Returns
+    -------
+    vert_integ_vorticity : xarray.DataArray
+        The vertically integrated velocity on the mesh edges
+
+    edge_sign_on_vertex : xarray.DataArray
+        The sign of the edges on the vertices
+    """
+    var_list = [
+        'areaTriangle',
+        'dcEdge',
+        'edgesOnVertex',
+        'verticesOnEdge',
+        'latVertex',
+    ]
+    ds_mesh = ds_mesh[var_list].as_numpy()
+    vert_integ_velocity = vert_integ_velocity.as_numpy()
+
+    if logger:
+        logger.info('  Computing edge signs on vertices.')
+    # Compute the sign of edges on vertices to determine flow direction
+    edge_sign_on_vertex = _compute_edge_sign_on_vertex(ds_mesh)
+
+    if logger:
+        logger.info('  Computing vertically integrated vorticity.')
+    # Compute the vorticity on vertices from the integrated velocity
+    vert_integ_vorticity = _compute_vert_integ_vorticity(
+        ds_mesh, vert_integ_velocity, edge_sign_on_vertex
+    )
+
+    return vert_integ_vorticity, edge_sign_on_vertex
+
+
+def _compute_edge_sign_on_vertex(ds_mesh):
+    edges_on_vertex = ds_mesh.edgesOnVertex - 1
+    vertices_on_edge = ds_mesh.verticesOnEdge - 1
+
+    nvertices = ds_mesh.sizes['nVertices']
+    vertex_degree = ds_mesh.sizes['vertexDegree']
+
+    edge_sign_on_vertex = np.zeros((nvertices, vertex_degree), dtype=int)
+    vertices = np.arange(nvertices)
+    for iedge in range(vertex_degree):
+        eov = edges_on_vertex.isel(vertexDegree=iedge)
+        valid_edge = eov >= 0
+
+        v0_on_edge = vertices_on_edge.isel(nEdges=eov, TWO=0)
+        v1_on_edge = vertices_on_edge.isel(nEdges=eov, TWO=1)
+        valid_edge = np.logical_and(
+            eov >= 0, np.logical_and(v0_on_edge >= 0, v1_on_edge >= 0)
+        )
+
+        mask = np.logical_and(valid_edge, v0_on_edge == vertices)
+        edge_sign_on_vertex[mask, iedge] = -1
+
+        mask = np.logical_and(valid_edge, v1_on_edge == vertices)
+        edge_sign_on_vertex[mask, iedge] = 1
+
+    edge_sign_on_vertex = xr.DataArray(
+        edge_sign_on_vertex,
+        dims=('nVertices', 'vertexDegree'),
+    )
+    return edge_sign_on_vertex
+
+
+def _compute_vert_integ_vorticity(
+    ds_mesh, vert_integ_velocity, edge_sign_on_vertex
+):
+    area_vertex = ds_mesh.areaTriangle
+    dc_edge = ds_mesh.dcEdge
+    edges_on_vertex = ds_mesh.edgesOnVertex - 1
+
+    vertex_degree = ds_mesh.sizes['vertexDegree']
+
+    vert_integ_vorticity = xr.zeros_like(ds_mesh.latVertex)
+    for iedge in range(vertex_degree):
+        eov = edges_on_vertex.isel(vertexDegree=iedge)
+        edge_sign = edge_sign_on_vertex.isel(vertexDegree=iedge)
+        dc = dc_edge.isel(nEdges=eov)
+        vert_integ_vel = vert_integ_velocity.isel(nEdges=eov)
+        vert_integ_vorticity += dc / area_vertex * edge_sign * vert_integ_vel
+
+    return vert_integ_vorticity


### PR DESCRIPTION
This merge refactors the barotropic streamfunction, separating out computation of vertically integrated velocity and vorticity into their own modules.  It improves performance and memory usage for large meshes by:
* chunking along the `nEdges` dimension during computation of the vertically integrated velocity
* saving to intermediate files if a temporary directory is provided
* loading numpy array for subsequent (2D) computations