### PR TITLE
Change `pre-commit` hook ID to `ruff-check`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,11 @@ repos:
     rev: v0.12.0
     hooks:
       # Sort the imports
-      - id: ruff
+      - id: ruff-check
         name: ruff-sort-imports
         args: [--select, I, --fix]
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       # Run the formatter.
       - id: ruff-format


### PR DESCRIPTION
The `pre-commit` hook used to be `ruff` but it changed to `ruff-check`, resulting in a message about the legacy alias. This updates the hook to the current `ruff-check` format.