### PR TITLE
Fix `pre-commit` workflow and other CI updates/cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,5 @@ updates:
     reviewers:
       - "xylar"
       - "altheaden"
+      - "andrewdnolan"
 

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -26,6 +26,7 @@ on:
 env:
   CANCEL_OTHERS: false
   PATHS_IGNORE: '["**/README.md", "**/docs/**"]'
+  PYTHON_VERSION: "3.13"
 
 jobs:
   pre-commit-hooks:
@@ -36,10 +37,10 @@ jobs:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - id: file_changes
         uses: trilom/file-changes-action@1.2.4

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -73,6 +73,10 @@ jobs:
         if: ${{ env.UP_TO_DATE == 'false' }}
         run: |
           cd update-pre-commit-deps
+          # Close any existing PR and replace with most up-to-date changes
+          gh pr close update-pre-commit-deps \
+          --comment "This PR was closed to create a new, updated PR." || \
+          echo "No existing PR to close and replace."
           gh pr create \
           --title "Update pre-commit and its dependencies" \
           --body "This PR was auto-generated to update pre-commit and its dependencies." \

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -9,10 +9,13 @@ on:
     # 4. Entry: Month of the year when the process will be started [1-12]
     # 5. Entry: Weekday when the process will be started [0-6] [0 is Sunday]
     - cron: '0 8 * * 3'
+  # Allow manual triggering of the workflow
+  workflow_dispatch:
 
 env:
   UP_TO_DATE: false
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.13"
+  REVIEWERS: "altheaden,xylar,andrewdnolan"
 
 jobs:
   auto-update:
@@ -20,16 +23,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Conda Environment
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          environment-name: pre_commit_dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels:
+                - conda-forge
+          create-args: >-
+            python=${{ env.PYTHON_VERSION }}
 
-      - name: Install pre-commit
-        run: pip install pre-commit
+      - name: Install pre-commit and gh
+        run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pre_commit_dev
+          # permissions issue with gh 2.76.0
+          conda install -y pre-commit "gh !=2.76.0"
+          gh --version
 
       - name: Apply and commit updates
         run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pre_commit_dev
           git clone https://github.com/MPAS-Dev/MPAS-Tools.git update-pre-commit-deps
           cd update-pre-commit-deps
           # Configure git using GitHub Actions credentials.
@@ -60,7 +77,7 @@ jobs:
           --title "Update pre-commit and its dependencies" \
           --body "This PR was auto-generated to update pre-commit and its dependencies." \
           --head update-pre-commit-deps \
-          --reviewer altheaden,xylar \
+          --reviewer ${{ env.REVIEWERS }} \
           --label ci
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR makes a few changes and updates to CI.
1. `PYTHON_VERSION` is now defined in all workflow files for consistency
2. `REVIEWERS` variable is now used to list the reviewers instead of a magic string to make things more readable
3. `pre_commit_update_workflow.yml` has been fixed to use conda in to avoid a bug with `gh` which was causing permissions errors in workflow runs
4. `workflow_dispatch` has been added to `pre_commit_update_workflow.yml` CI workflow to allow manual triggering
5. `pre_commit_update_workflow.yml` now checks for and closes any existing update PRs before creating a new one, something that previously would have caused a failure
6. @andrewdnolan has been added to the dependabot reviewers list

@xylar Review checklist:
* [ ] Add @andrewdnolan as maintainer (if he isn't already)