### PR TITLE
Update build_jigsaw to use a cmake toolchain

### DIFF
--- a/conda_package/mpas_tools/mesh/creation/conda-toolchain.cmake
+++ b/conda_package/mpas_tools/mesh/creation/conda-toolchain.cmake
@@ -1,0 +1,6 @@
+# Point CMake's find logic at the conda env only
+set(CMAKE_FIND_ROOT_PATH "$ENV{CONDA_PREFIX}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)  # use host tools (cmake, python) normally
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/conda_package/mpas_tools/mesh/creation/jigsaw_driver.py
+++ b/conda_package/mpas_tools/mesh/creation/jigsaw_driver.py
@@ -3,6 +3,7 @@ import os
 import platform
 import subprocess
 import time
+from importlib.resources import files as imp_res_files
 
 import numpy
 
@@ -177,18 +178,22 @@ def build_jigsaw(logger=None, clone=False, subdir='jigsaw-python', hash=None):
 
     # add build tools to deployment env, not polaris env
     jigsaw_build_deps = (
-        'cxx-compiler cmake make libnetcdf setuptools numpy scipy'
+        'cxx-compiler cmake make libnetcdf openmp setuptools numpy scipy'
+    )
+
+    conda_toolchain = (
+        imp_res_files('mpas_tools.mesh.creation') / 'conda-toolchain.cmake'
     )
     if platform.system() == 'Linux':
         jigsaw_build_deps = f'{jigsaw_build_deps} sysroot_linux-64=2.17'
-        netcdf_lib = f'{conda_env_path}/lib/libnetcdf.so'
     elif platform.system() == 'Darwin':
         jigsaw_build_deps = (
             f'{jigsaw_build_deps} macosx_deployment_target_osx-64=10.13'
         )
-        netcdf_lib = f'{conda_env_path}/lib/libnetcdf.dylib'
 
-    cmake_args = f'-DCMAKE_BUILD_TYPE=Release -DNETCDF_LIBRARY={netcdf_lib}'
+    cmake_args = (
+        f'-DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE={conda_toolchain}'
+    )
 
     print('Install dependencies\n')
     # Install dependencies


### PR DESCRIPTION
This prevents us from accidentally getting system package (e.g. on Anvil) that we don't want and doesn't require special code for finding NetCDF-C beyond what's already in CMake.

This merge also add OpenMP support to the JIGSAW build.