### PR TITLE
Ensure Time dim is added to landice initial condition

### DIFF
--- a/conda_package/mpas_tools/landice/create.py
+++ b/conda_package/mpas_tools/landice/create.py
@@ -166,7 +166,14 @@ def create_from_generic_mpas_grid():  # noqa C901
     #       unlimited dimension.  Special handling is needed with the netCDF
     #       module.
     print('---- Copying dimensions from input file to output file ----')
-    for dim in filein.dimensions.keys():
+
+    create_dims = list(filein.dimensions.keys())
+
+    # We will add variables with Time as a dimension so we need it
+    if 'Time' not in create_dims:
+        create_dims.append('Time')
+
+    for dim in create_dims:
         if dim == 'nTracers':
             pass  # Do nothing - we don't want this dimension
         elif dim == 'nVertInterfaces':


### PR DESCRIPTION
MPAS meshes include an empty, unlimited `Time` dimension but the latest `NetCDF4` drops this dimension since no variable use it. The `create_from_generic_mpas_grid()` funciton in `landice.create` was taking advantage of `Time` being a dimension in the MPAS mesh but this should no longer be assumed.  This PR fixes that assumption by explicitly adding `Time` to the list of dimensions to create if it is not already in the input dataset.