### PR TITLE
Fix print in mali interpolate

### DIFF
--- a/conda_package/mpas_tools/landice/interpolate.py
+++ b/conda_package/mpas_tools/landice/interpolate.py
@@ -462,7 +462,7 @@ def interpolate_to_mpasli_grid():  # noqa: C901
             elif filetype == 'mpas':
                 print(
                     f'  Input layer {z}, layer {InputFieldName} min/max: '
-                    f'{InputField[z, :, :].min()} {InputField[z, :, :].max()}'
+                    f'{InputField[:, z].min()} {InputField[:, z].max()}'
                 )
                 # Call the appropriate routine for actually doing the
                 # interpolation


### PR DESCRIPTION
This merge applies the latest linting tools to `mpas_tools.landice.interpolate`.

Then, it fixes a print statement that was incorrectly copied over from the original script:
https://github.com/MPAS-Dev/MPAS-Tools/blob/8ee9da8852d5d38252f899b3d5631999a9a9707c/landice/mesh_tools_li/interpolate_to_mpasli_grid.py#L343