### PR TITLE
Change default earth_radius_km value for the hex_projection tool to 6371.229 km

### DIFF
--- a/mesh_tools/hex_projection/namelist.projections
+++ b/mesh_tools/hex_projection/namelist.projections
@@ -2,7 +2,7 @@
   cell_spacing_km = 15.
   mesh_length_x_km =  5403.
   mesh_length_y_km =  3183.
-  earth_radius_km = 6378.14
+  earth_radius_km = 6371.229
 /
 &projection
   projection_type = "lambert_conformal"


### PR DESCRIPTION
This PR changes the default `earth_radius_km` value for the `hex_projection` tool to 6371.229 km.

MPAS-Atmosphere uses a sphere radius of 6371229.0 m, and since the `hex_projection` tool is intended primarily for use with MPAS-Atmosphere, this PR sets the default sphere radius provided in the `namelist.projections` file for the `hex_projection` tool to match that value.