### PR TITLE
Include density correction in SL axis in globalStats

### DIFF
--- a/landice/output_processing_li/plot_globalStats.py
+++ b/landice/output_processing_li/plot_globalStats.py
@@ -14,8 +14,10 @@ import matplotlib.pyplot as plt
 import textwrap
 
 rhoi = 910.0
-rhosw = 1028.
-rhofw = 1000.
+rhosw = 1028.0
+rhofw = 1000.0
+Aocn = 3.625e14  # m^2 (Gregory et al. 2019)
+m_to_mm = 1000.0
 
 print("** Gathering information.  (Invoke with --help for more details. All arguments are optional)")
 parser = ArgumentParser(description=__doc__)
@@ -195,10 +197,10 @@ def VAF2seaLevel(vol):
     applied to the volume above flotation, when in reality, it should
     be applied for all melted ice.
     """
-    return vol / scaleVol / 3.62e14 * rhoi / rhofw * 1000.
+    return vol / scaleVol / Aocn * rhoi / rhofw * m_to_mm
 
 def seaLevel2VAF(vol):
-    return vol * scaleVol * 3.62e14 * rhofw / rhoi / 1000.
+    return vol * scaleVol * Aocn * rhofw / rhoi / m_to_mm
 
 def addSeaLevAx(axName):
     seaLevAx = axName.secondary_yaxis('right', functions=(VAF2seaLevel, seaLevel2VAF))

--- a/landice/output_processing_li/plot_globalStats.py
+++ b/landice/output_processing_li/plot_globalStats.py
@@ -15,6 +15,7 @@ import textwrap
 
 rhoi = 910.0
 rhosw = 1028.
+rhofw = 1000.
 
 print("** Gathering information.  (Invoke with --help for more details. All arguments are optional)")
 parser = ArgumentParser(description=__doc__)
@@ -188,10 +189,16 @@ ind += 1
 
 
 def VAF2seaLevel(vol):
-    return vol / scaleVol / 3.62e14 * rhoi / rhosw * 1000.
+    """
+    This function accounts for the fact that ice, when melted,
+    takes on freshwater density.  This density correction is only
+    applied to the volume above flotation, when in reality, it should
+    be applied for all melted ice.
+    """
+    return vol / scaleVol / 3.62e14 * rhoi / rhofw * 1000.
 
 def seaLevel2VAF(vol):
-    return vol * scaleVol * 3.62e14 * rhosw / rhoi / 1000.
+    return vol * scaleVol * 3.62e14 * rhofw / rhoi / 1000.
 
 def addSeaLevAx(axName):
     seaLevAx = axName.secondary_yaxis('right', functions=(VAF2seaLevel, seaLevel2VAF))


### PR DESCRIPTION
This merge adds the density correction for ice to melt into freshwater rather than seawater when plotting the secondary y-axis for sea-level equivalent in the globalStats plotting script.  It also updates to the Gregory et al. (2019) recommended ocean area value.  The first item decreases scaling of the secondary axis by about 3%.  The second increases it by about 1%.  These changes only affect the secondary axis scaling and do not affect the actual data.  Note that a full incorporation of the density change of melted ice (i.e. ice below flotation and fully floating ice) would need to occur in MALI and would not support a 1:1 relationship between Gt of VAF lost and sea-level equivalent.  This secondary axis will always be approximate for that reason.