### PR TITLE
Add `sfcMassBalUncertainty` for MALI->MALI interpolation

### DIFF
--- a/conda_package/mpas_tools/landice/interpolate.py
+++ b/conda_package/mpas_tools/landice/interpolate.py
@@ -1210,6 +1210,13 @@ def interpolate_to_mpasli_grid():  # noqa: C901
                 'gridType': 'cell',
                 'vertDim': False,
             }
+            fieldInfo['sfcMassBalUncertainty'] = {
+                'InputName': 'sfcMassBalUncertainty',
+                'scalefactor': 1.0,
+                'offset': 0.0,
+                'gridType': 'cell',
+                'vertDim': False,
+            }
             fieldInfo['floatingBasalMassBal'] = {
                 'InputName': 'floatingBasalMassBal',
                 'scalefactor': 1.0,


### PR DESCRIPTION
Add `sfcMassBalUncertainty` for MALI->MALI interpolation. This field is necessary for advanced MALI optimization methods, and often needs to be remapped between different MALI meshes, for instance from a previous E3SM simulation.